### PR TITLE
fix(deps): update qlock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fukamachi/sbcl:latest as build
+FROM fukamachi/qlot:latest as build
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt set -x; \
     apt-get update && \
     apt-get install -y \
@@ -12,9 +12,9 @@ RUN ros setup
 
 COPY . /root/
 
-RUN ln -s /root/deps/ /root/common-lisp
 WORKDIR /root/
-RUN make build
+RUN qlot install
+RUN qlot exec make build
 RUN make install
 FROM build as star-server
 EXPOSE 5000

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -61,7 +61,7 @@
 ("star-cl" .
  (:class qlot/source/github:source-github
   :initargs (:repos "lost-rob0t/star-cl" :ref nil :branch nil :tag nil)
-  :version "github-0c10783a640e6a63ce0a23069668fc3d47a3fe4a"))
+  :version "github-4065d8689ad118dc93fc95688ca1bf63973e3c0d"))
 ("cl-couch" .
  (:class qlot/source/github:source-github
   :initargs (:repos "lost-rob0t/cl-couch" :ref nil :branch nil :tag nil)


### PR DESCRIPTION
This was the big migration away from vendoring using git submodules.
This was a pain and i did a few times f up and edit my local starintel spec there, forget to push it. 
Now the central makes this much less of a headache.

Docker builds now
qlot now works, provided you configure it or use my nix flake with overlay.