### PR TITLE
fix(docker): extra_hosts fixes the host not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ FROM build as star-server
 
 VOLUME /config
 EXPOSE 5000
+EXPOSE 4009 # NOTE Debug port do not expose in production.
 RUN echo '#!/bin/sh\n\
 set -e\n\
 # Check if /config/init.lisp exists; if not, use /root/init.lisp\n\

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -1,14 +1,13 @@
 version: '3.8'
-
+# This is the compose to be used for hacking on gserver
+# No state is set just restart to get to a blank state
 services:
   couchdb:
     container_name: "couchdb"
     hostname: couchdb
+    volumes: !reset []
     image: ibmcom/couchdb3
-    volumes:
-      - couchdb:/opt/couchdb/data
     environment:
-      #NOTE CHANGE ME
       COUCHDB_USER: admin
       COUCHDB_PASSWORD: password
     ports:
@@ -21,28 +20,26 @@ services:
     hostname: rabbitmq
     container_name: "rabbitmq"
     environment:
-      #NOTE CHANGEME
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest
+    volumes: !reset []
     ports:
       - "5672:5672"
       - "15672:15672"
-    volumes:
-      - rabbitmq:/var/lib/rabbitmq
     networks:
       - star
+
   star-server:
     hostname: star-server
     container_name: "star-server"
     restart: always
     build: .
     volumes:
-      # You can copy example_configs to ./config in order to configure star-server
       - ./config:/config
     environment:
       BUILD_MODE: DEV
     ports:
-      # port 4009 is a debugging port and you MUST disable it during prod use
+      - "4009:4009"
       - "5000:5000"
     networks:
       - star
@@ -53,12 +50,7 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
 
-
-
 networks:
   star:
     name: star
   default:
-volumes:
-    couchdb:
-    rabbitmq:

--- a/docker-compose.override.prod.yml
+++ b/docker-compose.override.prod.yml
@@ -1,12 +1,14 @@
 version: '3.8'
-
+# This is an example production compose file
+# instead of using a named volume this bind mounds the state for couchdb and rabbitmq to a dir
+# TODO Nginx rev proxy
 services:
   couchdb:
     container_name: "couchdb"
     hostname: couchdb
     image: ibmcom/couchdb3
     volumes:
-      - couchdb:/opt/couchdb/data
+      - ./state/couchdb:/opt/couchdb/data
     environment:
       #NOTE CHANGE ME
       COUCHDB_USER: admin
@@ -28,7 +30,7 @@ services:
       - "5672:5672"
       - "15672:15672"
     volumes:
-      - rabbitmq:/var/lib/rabbitmq
+      - ./state/rabbitmq:/var/lib/rabbitmq
     networks:
       - star
   star-server:
@@ -39,8 +41,6 @@ services:
     volumes:
       # You can copy example_configs to ./config in order to configure star-server
       - ./config:/config
-    environment:
-      BUILD_MODE: DEV
     ports:
       # port 4009 is a debugging port and you MUST disable it during prod use
       - "5000:5000"

--- a/example_configs/init.lisp
+++ b/example_configs/init.lisp
@@ -1,14 +1,21 @@
 ;; Example config
 (in-package :star)
-(format t "Starting starintel....")
-(setq *rabbit-address* "rabbitmq")
-(setq *couchdb-host* "couchdb")
-(setq *couchdb-default-database* "starintel")
+(format t "Starting starintel....~%")
+(log:info "RabbitMQ Service: ~a~%" (setf *rabbit-address* "rabbitmq"))
+(log:info "Couchdb Service: ~a~%" (setf *couchdb-host* "couchdb"))
+(log:info "Listening On ~a : ~a~%" (setf *http-scheme* "http") (setf *http-api-address* "0.0.0.0"))
+
 ;; You can invoke sylnk like so
 ;; (start-debugger)
 ;; Set log config path to logs
-(log:config :daily "logs/gserver.log"
+;; here it defaults to the /config/logs/star-server.log
+;; Just uncomment this if you want to not use docker the docker volumne
+;; TODO Make a docker vol for logs, instead of writing to the config dir SECURITY risk
+;; (log:config :daily "./logs/gserver.log"
+;;             :file2
+;;             :sane)
+(log:config :daily "/config/logs/gserver.log"
             :file2
             :sane)
 
-;;
+


### PR DESCRIPTION
uses host-gateway to make sure the rabbitmq and couchdb containers can be found
Remove slynk port from default compose file, its in dev override now
Should you want to enable in prod just make sure you dont expose that port. use ssh port forwarding to access if you need to debug with slynk.
