### PR TITLE
Add crash-safe CouchDB document outbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN qlot exec sbcl --non-interactive \
     --load source/starintel-gserver.asd \
     --eval '(ql:quickload :starintel-gserver)' \
     --load tests/run-document-conformance.lisp \
-    --load tests/run-server-codec-conformance.lisp
+    --load tests/run-server-codec-conformance.lisp \
+    --load tests/run-outbox-conformance.lisp
 
 FROM conformance AS star-server
 

--- a/source/databases/outbox.lisp
+++ b/source/databases/outbox.lisp
@@ -24,6 +24,7 @@
              (mutation-conflict-reason condition)))))
 
 (define-condition outbox-store-conflict (error) ())
+
 (define-condition missing-document-for-update (error)
   ((document-id
     :initarg :document-id
@@ -46,6 +47,10 @@
       (jsown:val object key)
       default))
 
+(defun json-object-p (value)
+  (and (consp value)
+       (eq (first value) :obj)))
+
 (defun clone-outbox-json (object)
   (jsown:with-injective-reader
     (jsown:parse (jsown:to-json object))))
@@ -58,13 +63,20 @@
           (setf (jsown:val copy key) value))))
     copy))
 
+(defun document-extensions (document)
+  (let ((extensions
+          (outbox-object-value document "extensions" (jsown:empty-object))))
+    (unless (json-object-p extensions)
+      (error "Document extensions must be a JSON object"))
+    extensions))
+
 (defun public-document-copy (document)
   "Return DOCUMENT without CouchDB revision or server-private outbox state."
   (let* ((source (clone-outbox-json document))
          (public (copy-json-object-excluding source '("_rev")))
          (extensions
            (copy-json-object-excluding
-            (outbox-object-value source "extensions" (jsown:empty-object))
+            (document-extensions source)
             (list +outbox-extension-key+
                   +mutation-ledger-extension-key+))))
     (setf (jsown:val public "extensions") extensions)
@@ -78,13 +90,13 @@
 
 (defun mutation-content-hash (operation document)
   (outbox-digest-string
-   (format nil "~(~a~)|~a"
+   (format nil
+           "~(~a~)|~a"
            operation
            (jsown:to-json (public-document-copy document)))))
 
 (defun explicit-mutation-id (document)
-  (let* ((extensions
-           (outbox-object-value document "extensions" (jsown:empty-object)))
+  (let* ((extensions (document-extensions document))
          (value
            (or (outbox-object-value extensions +mutation-id-extension-key+)
                (outbox-object-value extensions +idempotency-key-extension-key+))))
@@ -105,7 +117,8 @@
     (:updated "updated")))
 
 (defun operation-routing-key (operation dtype)
-  (format nil "documents.~a.~a"
+  (format nil
+          "documents.~a.~a"
           (operation-event-name operation)
           (spec:canonical-dtype dtype)))
 
@@ -116,13 +129,6 @@
     ((listp value) value)
     (t
      (error "Expected JSON array, got ~s" value))))
-
-(defun document-extensions (document)
-  (let ((extensions
-          (outbox-object-value document "extensions" (jsown:empty-object))))
-    (unless (and (consp extensions) (eq (first extensions) :obj))
-      (error "Document extensions must be a JSON object"))
-    extensions))
 
 (defun document-outbox-entries (document)
   (sequence-list
@@ -137,7 +143,7 @@
            (document-extensions document)
            +mutation-ledger-extension-key+
            (jsown:empty-object))))
-    (unless (and (consp ledger) (eq (first ledger) :obj))
+    (unless (json-object-p ledger)
       (error "Document mutation ledger must be a JSON object"))
     ledger))
 
@@ -148,7 +154,8 @@
   (jsown:val entry "sequence"))
 
 (defun outbox-entry-published-p (entry)
-  (string= "published" (jsown:val entry "status")))
+  (and entry
+       (string= "published" (jsown:val entry "status"))))
 
 (defun find-outbox-entry (document mutation-id)
   (find mutation-id
@@ -165,27 +172,40 @@
 (defun event-payload (document mutation-id operation sequence)
   (let* ((payload (public-document-copy document))
          (extensions (document-extensions payload)))
-    (setf (jsown:val extensions "event_id") (outbox-event-id mutation-id)
-          (jsown:val extensions "mutation_id") mutation-id
+    (setf (jsown:val extensions "event_id")
+          (outbox-event-id mutation-id)
+          (jsown:val extensions "mutation_id")
+          mutation-id
           (jsown:val extensions "event_operation")
           (operation-event-name operation)
-          (jsown:val extensions "event_sequence") sequence
-          (jsown:val payload "extensions") extensions)
+          (jsown:val extensions "event_sequence")
+          sequence
+          (jsown:val payload "extensions")
+          extensions)
     payload))
 
 (defun make-outbox-entry (document mutation-id content-hash operation sequence)
   (let ((entry (jsown:empty-object)))
-    (setf (jsown:val entry "event_id") (outbox-event-id mutation-id)
-          (jsown:val entry "mutation_id") mutation-id
-          (jsown:val entry "content_hash") content-hash
-          (jsown:val entry "document_id") (jsown:val document "_id")
-          (jsown:val entry "sequence") sequence
-          (jsown:val entry "operation") (operation-event-name operation)
+    (setf (jsown:val entry "event_id")
+          (outbox-event-id mutation-id)
+          (jsown:val entry "mutation_id")
+          mutation-id
+          (jsown:val entry "content_hash")
+          content-hash
+          (jsown:val entry "document_id")
+          (jsown:val document "_id")
+          (jsown:val entry "sequence")
+          sequence
+          (jsown:val entry "operation")
+          (operation-event-name operation)
           (jsown:val entry "routing_key")
           (operation-routing-key operation (jsown:val document "dtype"))
-          (jsown:val entry "status") "pending"
-          (jsown:val entry "created_at") (spec:utc-now)
-          (jsown:val entry "published_at") :null
+          (jsown:val entry "status")
+          "pending"
+          (jsown:val entry "created_at")
+          (spec:utc-now)
+          (jsown:val entry "published_at")
+          :null
           (jsown:val entry "payload")
           (event-payload document mutation-id operation sequence))
     entry))
@@ -193,16 +213,21 @@
 (defun merge-server-state (target existing entry mutation-id content-hash)
   (let* ((target-extensions (document-extensions target))
          (existing-entries
-           (if existing (document-outbox-entries existing) nil))
+           (if existing
+               (document-outbox-entries existing)
+               nil))
          (ledger
            (if existing
                (clone-outbox-json (document-mutation-ledger existing))
                (jsown:empty-object))))
-    (setf (jsown:val ledger mutation-id) content-hash
-          (jsown:val target-extensions +mutation-ledger-extension-key+) ledger
+    (setf (jsown:val ledger mutation-id)
+          content-hash
+          (jsown:val target-extensions +mutation-ledger-extension-key+)
+          ledger
           (jsown:val target-extensions +outbox-extension-key+)
           (coerce (append existing-entries (list entry)) 'vector)
-          (jsown:val target "extensions") target-extensions)
+          (jsown:val target "extensions")
+          target-extensions)
     target))
 
 (defun prepare-outbox-mutation (existing incoming operation)
@@ -213,8 +238,10 @@ Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
          (document-id (jsown:val document "_id"))
          (mutation-id (document-mutation-id operation document))
          (content-hash (mutation-content-hash operation document)))
-    (when (and (eq operation :updated) (null existing))
-      (error 'missing-document-for-update :document-id document-id))
+    (when (and (eq operation :updated)
+               (null existing))
+      (error 'missing-document-for-update
+             :document-id document-id))
     (when existing
       (let ((known-hash
               (outbox-object-value
@@ -231,21 +258,30 @@ Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
               (error "Mutation ledger contains ~a without an outbox entry"
                      mutation-id))
             (return-from prepare-outbox-mutation
-              (values existing entry :duplicate))))
+              (values existing entry :duplicate)))))
       (when (eq operation :new)
         (error 'mutation-conflict
                :mutation-id mutation-id
                :document-id document-id
                :reason "new-document mutation conflicts with an existing document")))
     (when existing
-      (setf (jsown:val document "_rev") (jsown:val existing "_rev")))
+      (setf (jsown:val document "_rev")
+            (jsown:val existing "_rev")))
     (let* ((sequence (next-outbox-sequence (or existing document)))
            (entry
              (make-outbox-entry
-              document mutation-id content-hash operation sequence)))
+              document
+              mutation-id
+              content-hash
+              operation
+              sequence)))
       (values
        (merge-server-state
-        document existing entry mutation-id content-hash)
+        document
+        existing
+        entry
+        mutation-id
+        content-hash)
        entry
        :created))))
 
@@ -267,8 +303,9 @@ Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
                         disposition))
                    (outbox-store-conflict ()
                      (when (= attempt max-attempts)
-                       (error "Outbox persistence conflict retry budget exhausted for ~a"
-                              document-id)))))))))
+                       (error
+                        "Outbox persistence conflict retry budget exhausted for ~a"
+                        document-id)))))))))
 
 (defun update-outbox-entry (document mutation-id updater)
   (let* ((copy (clone-outbox-json document))
@@ -278,7 +315,8 @@ Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
          (updated
            (mapcar
             (lambda (entry)
-              (if (string= mutation-id (outbox-entry-mutation-id entry))
+              (if (string= mutation-id
+                           (outbox-entry-mutation-id entry))
                   (progn
                     (setf found t)
                     (funcall updater entry))
@@ -288,17 +326,22 @@ Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
       (error "Outbox entry ~a not found" mutation-id))
     (setf (jsown:val extensions +outbox-extension-key+)
           (coerce updated 'vector)
-          (jsown:val copy "extensions") extensions)
+          (jsown:val copy "extensions")
+          extensions)
     copy))
 
 (defun mark-outbox-published (load-fn save-fn document-id mutation-id
                               &key (max-attempts 8))
   (loop for attempt from 1 to max-attempts
         do
-           (let* ((current (or (funcall load-fn document-id)
-                               (error "Document ~a disappeared while marking outbox"
-                                      document-id)))
+           (let* ((current
+                    (or (funcall load-fn document-id)
+                        (error
+                         "Document ~a disappeared while marking outbox"
+                         document-id)))
                   (entry (find-outbox-entry current mutation-id)))
+             (unless entry
+               (error "Outbox entry ~a not found" mutation-id))
              (when (outbox-entry-published-p entry)
                (return current))
              (let ((updated
@@ -306,7 +349,8 @@ Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
                       current
                       mutation-id
                       (lambda (outbox-entry)
-                        (setf (jsown:val outbox-entry "status") "published"
+                        (setf (jsown:val outbox-entry "status")
+                              "published"
                               (jsown:val outbox-entry "published_at")
                               (spec:utc-now))
                         outbox-entry))))
@@ -314,8 +358,9 @@ Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
                    (return (funcall save-fn updated))
                  (outbox-store-conflict ()
                    (when (= attempt max-attempts)
-                     (error "Outbox publication marker retry budget exhausted for ~a"
-                            mutation-id))))))))
+                     (error
+                      "Outbox publication marker retry budget exhausted for ~a"
+                      mutation-id))))))))
 
 (defun publish-outbox-entry (publish-fn entry)
   (funcall publish-fn
@@ -361,24 +406,32 @@ If publication fails, the durable pending entry remains recoverable."
     (destructuring-bind (document-id entry) tuple
       (publish-outbox-entry publish-fn entry)
       (mark-outbox-published
-       load-fn save-fn document-id (outbox-entry-mutation-id entry))))
+       load-fn
+       save-fn
+       document-id
+       (outbox-entry-mutation-id entry))))
   t)
 
 (defun couchdb-load-outbox-document (client database document-id)
   (handler-case
       (jsown:with-injective-reader
-        (jsown:parse (cl-couch:get-document client database document-id)))
-    (dexador:http-request-not-found () nil)))
+        (jsown:parse
+         (cl-couch:get-document client database document-id)))
+    (dexador:http-request-not-found ()
+      nil)))
 
 (defun couchdb-save-outbox-document (client database document)
   (handler-case
       (let* ((response
                (jsown:parse
                 (cl-couch:create-document
-                 client database (jsown:to-json document))))
+                 client
+                 database
+                 (jsown:to-json document))))
              (saved (clone-outbox-json document)))
         (when (outbox-object-has-key-p response "rev")
-          (setf (jsown:val saved "_rev") (jsown:val response "rev")))
+          (setf (jsown:val saved "_rev")
+                (jsown:val response "rev")))
         saved)
     (dexador:http-request-conflict ()
       (error 'outbox-store-conflict))))
@@ -396,18 +449,24 @@ If publication fails, the durable pending entry remains recoverable."
 
 (defun couchdb-pending-outbox-documents (client database)
   (let* ((result
-           (query-view client database "outbox" "pending"
-                       :include-docs t
-                       :reduce nil
-                       :limit 10000))
+           (query-view
+            client
+            database
+            "outbox"
+            "pending"
+            :include-docs t
+            :reduce nil
+            :limit 10000))
          (rows (jsown:val result "rows"))
          (seen (make-hash-table :test #'equal)))
     (loop for row in rows
           for document = (jsown:val row "doc")
           for document-id = (jsown:val document "_id")
           unless (gethash document-id seen)
-            do (setf (gethash document-id seen) t)
-            and collect document)))
+            collect
+            (progn
+              (setf (gethash document-id seen) t)
+              document))))
 
 (defun recover-couchdb-outbox (client database publish-fn)
   (recover-outbox-documents

--- a/source/databases/outbox.lisp
+++ b/source/databases/outbox.lisp
@@ -1,0 +1,419 @@
+(in-package :star.databases.couchdb)
+
+(defparameter +outbox-extension-key+ "_server_outbox")
+(defparameter +mutation-ledger-extension-key+ "_server_mutations")
+(defparameter +mutation-id-extension-key+ "mutation_id")
+(defparameter +idempotency-key-extension-key+ "idempotency_key")
+
+(define-condition mutation-conflict (error)
+  ((mutation-id
+    :initarg :mutation-id
+    :reader mutation-conflict-id)
+   (document-id
+    :initarg :document-id
+    :reader mutation-conflict-document-id)
+   (reason
+    :initarg :reason
+    :reader mutation-conflict-reason))
+  (:report
+   (lambda (condition stream)
+     (format stream
+             "Mutation ~a conflicts for document ~a: ~a"
+             (mutation-conflict-id condition)
+             (mutation-conflict-document-id condition)
+             (mutation-conflict-reason condition)))))
+
+(define-condition outbox-store-conflict (error) ())
+(define-condition missing-document-for-update (error)
+  ((document-id
+    :initarg :document-id
+    :reader missing-update-document-id))
+  (:report
+   (lambda (condition stream)
+     (format stream
+             "Cannot apply update mutation: document ~a does not exist"
+             (missing-update-document-id condition)))))
+
+(defun outbox-object-has-key-p (object key)
+  (handler-case
+      (progn
+        (jsown:val object key)
+        t)
+    (error () nil)))
+
+(defun outbox-object-value (object key &optional default)
+  (if (and object (outbox-object-has-key-p object key))
+      (jsown:val object key)
+      default))
+
+(defun clone-outbox-json (object)
+  (jsown:with-injective-reader
+    (jsown:parse (jsown:to-json object))))
+
+(defun copy-json-object-excluding (object excluded-keys)
+  (let ((copy (jsown:empty-object)))
+    (when object
+      (jsown:do-json-keys (key value) object
+        (unless (member key excluded-keys :test #'string=)
+          (setf (jsown:val copy key) value))))
+    copy))
+
+(defun public-document-copy (document)
+  "Return DOCUMENT without CouchDB revision or server-private outbox state."
+  (let* ((source (clone-outbox-json document))
+         (public (copy-json-object-excluding source '("_rev")))
+         (extensions
+           (copy-json-object-excluding
+            (outbox-object-value source "extensions" (jsown:empty-object))
+            (list +outbox-extension-key+
+                  +mutation-ledger-extension-key+))))
+    (setf (jsown:val public "extensions") extensions)
+    public))
+
+(defun outbox-digest-string (text)
+  (ironclad:byte-array-to-hex-string
+   (ironclad:digest-sequence
+    :sha256
+    (babel:string-to-octets text :encoding :utf-8))))
+
+(defun mutation-content-hash (operation document)
+  (outbox-digest-string
+   (format nil "~(~a~)|~a"
+           operation
+           (jsown:to-json (public-document-copy document)))))
+
+(defun explicit-mutation-id (document)
+  (let* ((extensions
+           (outbox-object-value document "extensions" (jsown:empty-object)))
+         (value
+           (or (outbox-object-value extensions +mutation-id-extension-key+)
+               (outbox-object-value extensions +idempotency-key-extension-key+))))
+    (and (stringp value)
+         (> (length value) 0)
+         value)))
+
+(defun document-mutation-id (operation document)
+  (or (explicit-mutation-id document)
+      (mutation-content-hash operation document)))
+
+(defun outbox-event-id (mutation-id)
+  (outbox-digest-string (format nil "event|~a" mutation-id)))
+
+(defun operation-event-name (operation)
+  (ecase operation
+    (:new "new")
+    (:updated "updated")))
+
+(defun operation-routing-key (operation dtype)
+  (format nil "documents.~a.~a"
+          (operation-event-name operation)
+          (spec:canonical-dtype dtype)))
+
+(defun sequence-list (value)
+  (cond
+    ((null value) nil)
+    ((vectorp value) (coerce value 'list))
+    ((listp value) value)
+    (t
+     (error "Expected JSON array, got ~s" value))))
+
+(defun document-extensions (document)
+  (let ((extensions
+          (outbox-object-value document "extensions" (jsown:empty-object))))
+    (unless (and (consp extensions) (eq (first extensions) :obj))
+      (error "Document extensions must be a JSON object"))
+    extensions))
+
+(defun document-outbox-entries (document)
+  (sequence-list
+   (outbox-object-value
+    (document-extensions document)
+    +outbox-extension-key+
+    nil)))
+
+(defun document-mutation-ledger (document)
+  (let ((ledger
+          (outbox-object-value
+           (document-extensions document)
+           +mutation-ledger-extension-key+
+           (jsown:empty-object))))
+    (unless (and (consp ledger) (eq (first ledger) :obj))
+      (error "Document mutation ledger must be a JSON object"))
+    ledger))
+
+(defun outbox-entry-mutation-id (entry)
+  (jsown:val entry "mutation_id"))
+
+(defun outbox-entry-sequence (entry)
+  (jsown:val entry "sequence"))
+
+(defun outbox-entry-published-p (entry)
+  (string= "published" (jsown:val entry "status")))
+
+(defun find-outbox-entry (document mutation-id)
+  (find mutation-id
+        (document-outbox-entries document)
+        :key #'outbox-entry-mutation-id
+        :test #'string=))
+
+(defun next-outbox-sequence (document)
+  (1+
+   (loop for entry in (document-outbox-entries document)
+         maximize (outbox-entry-sequence entry) into maximum
+         finally (return (or maximum 0)))))
+
+(defun event-payload (document mutation-id operation sequence)
+  (let* ((payload (public-document-copy document))
+         (extensions (document-extensions payload)))
+    (setf (jsown:val extensions "event_id") (outbox-event-id mutation-id)
+          (jsown:val extensions "mutation_id") mutation-id
+          (jsown:val extensions "event_operation")
+          (operation-event-name operation)
+          (jsown:val extensions "event_sequence") sequence
+          (jsown:val payload "extensions") extensions)
+    payload))
+
+(defun make-outbox-entry (document mutation-id content-hash operation sequence)
+  (let ((entry (jsown:empty-object)))
+    (setf (jsown:val entry "event_id") (outbox-event-id mutation-id)
+          (jsown:val entry "mutation_id") mutation-id
+          (jsown:val entry "content_hash") content-hash
+          (jsown:val entry "document_id") (jsown:val document "_id")
+          (jsown:val entry "sequence") sequence
+          (jsown:val entry "operation") (operation-event-name operation)
+          (jsown:val entry "routing_key")
+          (operation-routing-key operation (jsown:val document "dtype"))
+          (jsown:val entry "status") "pending"
+          (jsown:val entry "created_at") (spec:utc-now)
+          (jsown:val entry "published_at") :null
+          (jsown:val entry "payload")
+          (event-payload document mutation-id operation sequence))
+    entry))
+
+(defun merge-server-state (target existing entry mutation-id content-hash)
+  (let* ((target-extensions (document-extensions target))
+         (existing-entries
+           (if existing (document-outbox-entries existing) nil))
+         (ledger
+           (if existing
+               (clone-outbox-json (document-mutation-ledger existing))
+               (jsown:empty-object))))
+    (setf (jsown:val ledger mutation-id) content-hash
+          (jsown:val target-extensions +mutation-ledger-extension-key+) ledger
+          (jsown:val target-extensions +outbox-extension-key+)
+          (coerce (append existing-entries (list entry)) 'vector)
+          (jsown:val target "extensions") target-extensions)
+    target))
+
+(defun prepare-outbox-mutation (existing incoming operation)
+  "Prepare one atomic document revision containing document and pending event state.
+
+Returns STATE, ENTRY, and either :CREATED or :DUPLICATE."
+  (let* ((document (public-document-copy incoming))
+         (document-id (jsown:val document "_id"))
+         (mutation-id (document-mutation-id operation document))
+         (content-hash (mutation-content-hash operation document)))
+    (when (and (eq operation :updated) (null existing))
+      (error 'missing-document-for-update :document-id document-id))
+    (when existing
+      (let ((known-hash
+              (outbox-object-value
+               (document-mutation-ledger existing)
+               mutation-id)))
+        (when known-hash
+          (unless (string= known-hash content-hash)
+            (error 'mutation-conflict
+                   :mutation-id mutation-id
+                   :document-id document-id
+                   :reason "idempotency key was reused for different content"))
+          (let ((entry (find-outbox-entry existing mutation-id)))
+            (unless entry
+              (error "Mutation ledger contains ~a without an outbox entry"
+                     mutation-id))
+            (return-from prepare-outbox-mutation
+              (values existing entry :duplicate))))
+      (when (eq operation :new)
+        (error 'mutation-conflict
+               :mutation-id mutation-id
+               :document-id document-id
+               :reason "new-document mutation conflicts with an existing document")))
+    (when existing
+      (setf (jsown:val document "_rev") (jsown:val existing "_rev")))
+    (let* ((sequence (next-outbox-sequence (or existing document)))
+           (entry
+             (make-outbox-entry
+              document mutation-id content-hash operation sequence)))
+      (values
+       (merge-server-state
+        document existing entry mutation-id content-hash)
+       entry
+       :created))))
+
+(defun persist-outbox-mutation (load-fn save-fn incoming operation
+                                &key (max-attempts 8))
+  (let ((document-id (jsown:val incoming "_id")))
+    (loop for attempt from 1 to max-attempts
+          do
+             (let ((existing (funcall load-fn document-id)))
+               (multiple-value-bind (state entry disposition)
+                   (prepare-outbox-mutation existing incoming operation)
+                 (when (eq disposition :duplicate)
+                   (return (values state entry disposition)))
+                 (handler-case
+                     (return
+                       (values
+                        (funcall save-fn state)
+                        entry
+                        disposition))
+                   (outbox-store-conflict ()
+                     (when (= attempt max-attempts)
+                       (error "Outbox persistence conflict retry budget exhausted for ~a"
+                              document-id)))))))))
+
+(defun update-outbox-entry (document mutation-id updater)
+  (let* ((copy (clone-outbox-json document))
+         (extensions (document-extensions copy))
+         (entries (document-outbox-entries copy))
+         (found nil)
+         (updated
+           (mapcar
+            (lambda (entry)
+              (if (string= mutation-id (outbox-entry-mutation-id entry))
+                  (progn
+                    (setf found t)
+                    (funcall updater entry))
+                  entry))
+            entries)))
+    (unless found
+      (error "Outbox entry ~a not found" mutation-id))
+    (setf (jsown:val extensions +outbox-extension-key+)
+          (coerce updated 'vector)
+          (jsown:val copy "extensions") extensions)
+    copy))
+
+(defun mark-outbox-published (load-fn save-fn document-id mutation-id
+                              &key (max-attempts 8))
+  (loop for attempt from 1 to max-attempts
+        do
+           (let* ((current (or (funcall load-fn document-id)
+                               (error "Document ~a disappeared while marking outbox"
+                                      document-id)))
+                  (entry (find-outbox-entry current mutation-id)))
+             (when (outbox-entry-published-p entry)
+               (return current))
+             (let ((updated
+                     (update-outbox-entry
+                      current
+                      mutation-id
+                      (lambda (outbox-entry)
+                        (setf (jsown:val outbox-entry "status") "published"
+                              (jsown:val outbox-entry "published_at")
+                              (spec:utc-now))
+                        outbox-entry))))
+               (handler-case
+                   (return (funcall save-fn updated))
+                 (outbox-store-conflict ()
+                   (when (= attempt max-attempts)
+                     (error "Outbox publication marker retry budget exhausted for ~a"
+                            mutation-id))))))))
+
+(defun publish-outbox-entry (publish-fn entry)
+  (funcall publish-fn
+           (jsown:val entry "routing_key")
+           (jsown:val entry "payload")
+           (jsown:val entry "event_id")))
+
+(defun process-outbox-mutation (load-fn save-fn publish-fn incoming operation)
+  "Persist mutation state, publish at least once, then mark the logical event.
+
+If publication fails, the durable pending entry remains recoverable."
+  (multiple-value-bind (state entry disposition)
+      (persist-outbox-mutation load-fn save-fn incoming operation)
+    (declare (ignore disposition))
+    (unless (outbox-entry-published-p entry)
+      (publish-outbox-entry publish-fn entry)
+      (setf state
+            (mark-outbox-published
+             load-fn
+             save-fn
+             (jsown:val state "_id")
+             (outbox-entry-mutation-id entry))))
+    state))
+
+(defun pending-outbox-tuples (documents)
+  (sort
+   (loop for document in documents
+         append
+         (loop for entry in (document-outbox-entries document)
+               unless (outbox-entry-published-p entry)
+                 collect (list (jsown:val document "_id") entry)))
+   (lambda (left right)
+     (let ((left-id (first left))
+           (right-id (first right)))
+       (if (string= left-id right-id)
+           (< (outbox-entry-sequence (second left))
+              (outbox-entry-sequence (second right)))
+           (string< left-id right-id))))))
+
+(defun recover-outbox-documents (load-fn save-fn publish-fn documents)
+  "Publish all pending entries in stable per-document sequence order."
+  (dolist (tuple (pending-outbox-tuples documents))
+    (destructuring-bind (document-id entry) tuple
+      (publish-outbox-entry publish-fn entry)
+      (mark-outbox-published
+       load-fn save-fn document-id (outbox-entry-mutation-id entry))))
+  t)
+
+(defun couchdb-load-outbox-document (client database document-id)
+  (handler-case
+      (jsown:with-injective-reader
+        (jsown:parse (cl-couch:get-document client database document-id)))
+    (dexador:http-request-not-found () nil)))
+
+(defun couchdb-save-outbox-document (client database document)
+  (handler-case
+      (let* ((response
+               (jsown:parse
+                (cl-couch:create-document
+                 client database (jsown:to-json document))))
+             (saved (clone-outbox-json document)))
+        (when (outbox-object-has-key-p response "rev")
+          (setf (jsown:val saved "_rev") (jsown:val response "rev")))
+        saved)
+    (dexador:http-request-conflict ()
+      (error 'outbox-store-conflict))))
+
+(defun couchdb-process-outbox-mutation
+    (client database publish-fn document operation)
+  (process-outbox-mutation
+   (lambda (document-id)
+     (couchdb-load-outbox-document client database document-id))
+   (lambda (state)
+     (couchdb-save-outbox-document client database state))
+   publish-fn
+   document
+   operation))
+
+(defun couchdb-pending-outbox-documents (client database)
+  (let* ((result
+           (query-view client database "outbox" "pending"
+                       :include-docs t
+                       :reduce nil
+                       :limit 10000))
+         (rows (jsown:val result "rows"))
+         (seen (make-hash-table :test #'equal)))
+    (loop for row in rows
+          for document = (jsown:val row "doc")
+          for document-id = (jsown:val document "_id")
+          unless (gethash document-id seen)
+            do (setf (gethash document-id seen) t)
+            and collect document)))
+
+(defun recover-couchdb-outbox (client database publish-fn)
+  (recover-outbox-documents
+   (lambda (document-id)
+     (couchdb-load-outbox-document client database document-id))
+   (lambda (state)
+     (couchdb-save-outbox-document client database state))
+   publish-fn
+   (couchdb-pending-outbox-documents client database)))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -1,7 +1,6 @@
-;; [[file:../source.org::*Namespace setup][Namespace setup:2]]
-(uiop:define-package   :starintel-gserver
+(uiop:define-package :starintel-gserver
   (:nicknames :star)
-  (:use       :cl)
+  (:use :cl)
   (:export
    #:*rabbit-password*
    #:*rabbit-user*
@@ -30,54 +29,68 @@
    #:*couchdb-views*
    #:*star-server-version*))
 
+(uiop:define-package :star.databases.couchdb
+  (:use :cl-couch :cl :star #:lparallel)
+  (:export
+   #:init-db
+   #:init-views
+   #:get-targets*
+   #:get-view-docs
+   #:query-view
+   #:map-view-results
+   #:get-neighbors
+   #:search-fts
+   #:sort-docs-by-date
+   #:messages-by-user
+   #:messages-by-platform
+   #:messages-by-group
+   #:social-posts-by-user
+   #:social-posts-by-group
+   #:by-channel
+   #:export-by-dataset*
+   #:count-by-dtype
+   #:dataset-size
+   #:total-documents-since
+   #:orgs-by-country
+   #:orgs-by-name
+   #:persons-by-name
+   #:persons-by-region
+   #:relations-edges
+   #:relations-incoming-count
+   #:relations-outgoing-count
+   #:targets-actor-counts
+   #:targets-by-actor
+   #:targets-target-count
+   #:users-by-platform
+   #:as-json
+   #:format-key
+   #:from-json
+   #:*couchdb-pool*
+   #:groups
+   #:lazy
+   #:prepare-outbox-mutation
+   #:persist-outbox-mutation
+   #:process-outbox-mutation
+   #:recover-outbox-documents
+   #:document-outbox-entries
+   #:find-outbox-entry
+   #:outbox-entry-published-p
+   #:outbox-entry-mutation-id
+   #:outbox-entry-sequence
+   #:mutation-conflict
+   #:mutation-conflict-id
+   #:mutation-conflict-document-id
+   #:mutation-conflict-reason
+   #:outbox-store-conflict
+   #:missing-document-for-update
+   #:couchdb-process-outbox-mutation
+   #:couchdb-pending-outbox-documents
+   #:recover-couchdb-outbox)
+  (:documentation "CouchDB persistence, query, and outbox support."))
 
-(uiop:define-package   :star.databases.couchdb
-  (:use       :cl-couch :cl :star #:lparallel)
-  (:export :init-db
-   :init-views
-           :get-targets*
-   :get-view-docs
-           :query-view
-   :map-view-results
-           :get-neighbors
-   :search-fts
-           :sort-docs-by-date
-   :messages-by-user
-           :messages-by-platform
-   :messages-by-group
-           :social-posts-by-user
-   :social-posts-by-group
-           :by-channel
-   :export-by-dataset*
-           :count-by-dtype
-   :dataset-size
-           :total-documents-since
-   :orgs-by-country
-           :orgs-by-name
-   :persons-by-name
-           :persons-by-region
-   :relations-edges
-           :relations-incoming-count
-   :relations-outgoing-count
-           :targets-actor-counts
-   :targets-by-actor
-           :targets-target-count
-   :users-by-platform
-           :as-json
-   :format-key
-           :from-json
-   :*couchdb-pool*
-           :groups
-   :lazy
-           :t
-   :nil)
-  (:documentation "doc"))
-;; Namespace setup:2 ends here
-
-;; [[file:../source.org::*Namespace setup][Namespace setup:3]]
-(uiop:define-package   :star.rabbit
-  (:use       :cl :star.consumers  :sento.actor)
-  (:documentation "Rabitmq namespace")
+(uiop:define-package :star.rabbit
+  (:use :cl :star.consumers :sento.actor)
+  (:documentation "RabbitMQ document transport.")
   (:export
    #:with-rabbit-send
    #:with-rabbit-recv
@@ -88,14 +101,17 @@
    #:+update-key+
    #:+targets-key+
    #:transient-p
+   #:handle-document
+   #:handle-update-document
+   #:publish-outbox-event
+   #:recover-pending-publications
    #:test-make-doc
    #:test-send
    #:start-consumers))
-;; Namespace setup:3 ends here
 
-(uiop:define-package   :star.actors
-  (:use       :cl :star.databases.couchdb :sento.agent :sento.actor :sento.actor-system :sento.actor-context)
-  (:documentation "doc")
+(uiop:define-package :star.actors
+  (:use :cl :star.databases.couchdb :sento.agent :sento.actor :sento.actor-system :sento.actor-context)
+  (:documentation "StarIntel actors.")
   (:export
    #:register-actor
    #:*targets*
@@ -126,12 +142,8 @@
    #:event-source-document
    #:event-id))
 
-
-;; [[file:../source.org::*Namespace setup][Namespace setup:4]]
-(uiop:define-package   :starintel-gserver-http-api
+(uiop:define-package :starintel-gserver-http-api
   (:nicknames :star.frontends.http-api)
-  (:use       :cl :ningle :anypool :star.databases.couchdb :star)
-  (:documentation "simple http api.")
-  (:export
-   #:*default-headers*))
-;; Namespace setup:4 ends here
+  (:use :cl :ningle :anypool :star.databases.couchdb :star)
+  (:documentation "StarIntel HTTP API.")
+  (:export #:*default-headers*))

--- a/source/rabbit.lisp
+++ b/source/rabbit.lisp
@@ -1,125 +1,208 @@
 (in-package :star.rabbit)
 
-(defvar +injest-queue+ "injest")
+(defvar +injest-queue+ "documents-ingest")
 (defvar +updates-queue+ "documents-updates")
-(defvar +injest-key+ "documents.new.#")
+(defvar +injest-key+ "documents.ingest.#")
 (defvar +update-key+ "documents.update.#")
 (defvar +targets-key+ "documents.new.target.*")
 
-(defmacro with-rabbit-recv ((queue-name exchange-name exchange-type routing-key &key (port star:*rabbit-port*) (host star:*rabbit-address*) (username star:*rabbit-user*) (password star:*rabbit-password*) (vhost "/") (durable nil) (exclusive nil) (auto-delete nil)) &body body)
-  `(cl-rabbit:with-connection (conn)
-     (let ((socket (cl-rabbit:tcp-socket-new conn)))
+(defmacro with-rabbit-recv
+    ((queue-name exchange-name exchange-type routing-key
+      &key
+        (port star:*rabbit-port*)
+        (host star:*rabbit-address*)
+        (username star:*rabbit-user*)
+        (password star:*rabbit-password*)
+        (vhost "/")
+        (durable nil)
+        (exclusive nil)
+        (auto-delete nil))
+     &body body)
+  `(cl-rabbit:with-connection (connection)
+     (let ((socket (cl-rabbit:tcp-socket-new connection)))
        (cl-rabbit:socket-open socket ,host ,port)
        (when (and ,username ,password)
-         (cl-rabbit:login-sasl-plain conn ,vhost ,username ,password))
-       (cl-rabbit:with-channel (conn 1)
-         (cl-rabbit:exchange-declare conn 1 ,exchange-name ,exchange-type)
-         (cl-rabbit:queue-declare conn 1 :queue ,queue-name :durable ,auto-delete ,auto-delete :exclusive ,exclusive)
-         (cl-rabbit:queue-bind conn 1 :queue ,queue-name :exchange ,exchange-name :routing-key ,routing-key)
-         (cl-rabbit:basic-consume conn 1 ,queue-name)
+         (cl-rabbit:login-sasl-plain
+          connection ,vhost ,username ,password))
+       (cl-rabbit:with-channel (connection 1)
+         (cl-rabbit:exchange-declare
+          connection 1 ,exchange-name ,exchange-type)
+         (cl-rabbit:queue-declare
+          connection 1
+          :queue ,queue-name
+          :durable ,durable
+          :auto-delete ,auto-delete
+          :exclusive ,exclusive)
+         (cl-rabbit:queue-bind
+          connection 1
+          :queue ,queue-name
+          :exchange ,exchange-name
+          :routing-key ,routing-key)
+         (cl-rabbit:basic-consume connection 1 ,queue-name)
          (loop
-           for result = (cl-rabbit:consume-message conn)
-           for msg = (cl-rabbit:envelope/message result)
-           do (handler-case
+           for result = (cl-rabbit:consume-message connection)
+           for message = (cl-rabbit:envelope/message result)
+           do
+              (handler-case
                   (progn
                     ,@body
-                    (cl-rabbit:basic-ack conn 1 (cl-rabbit:envelope/delivery-tag result)))
-                (error (error)
-                  (log:error "Rabbit document rejected: ~a" error)
-                  (cl-rabbit:basic-nack conn 1 (cl-rabbit:envelope/delivery-tag result) :requeue nil))))))))
+                    (cl-rabbit:basic-ack
+                     connection
+                     1
+                     (cl-rabbit:envelope/delivery-tag result)))
+                (error (condition)
+                  (log:error "Rabbit document rejected: ~a" condition)
+                  (cl-rabbit:basic-nack
+                   connection
+                   1
+                   (cl-rabbit:envelope/delivery-tag result)
+                   :requeue nil))))))))
 
-(defun emit-document (exchange routing-key body &key (properties nil)
-                                                   (immediate nil)
-                                                   (mandatory nil)
-                                                   (port star:*rabbit-port*)
-                                                   (host star:*rabbit-address*)
-                                                   (username star:*rabbit-user*)
-                                                   (password star:*rabbit-password*)
-                                                   (vhost "/"))
-  (let ((canonical-body (star.documents.v09:v09-document-json body)))
-    (cl-rabbit:with-connection (conn)
-      (let ((socket (cl-rabbit:tcp-socket-new conn)))
+(defun emit-document
+    (exchange routing-key body
+     &key
+       (properties nil)
+       (immediate nil)
+       (mandatory nil)
+       (port star:*rabbit-port*)
+       (host star:*rabbit-address*)
+       (username star:*rabbit-user*)
+       (password star:*rabbit-password*)
+       (vhost "/"))
+  (let ((canonical-body (star.documents:v09-document-json body)))
+    (cl-rabbit:with-connection (connection)
+      (let ((socket (cl-rabbit:tcp-socket-new connection)))
         (cl-rabbit:socket-open socket host port)
         (when (and username password)
-          (cl-rabbit:login-sasl-plain conn vhost username password))
-        (cl-rabbit:with-channel (conn 1)
-          (cl-rabbit:basic-publish conn 1
-                                   :routing-key routing-key
-                                   :exchange exchange
-                                   :mandatory mandatory
-                                   :immediate immediate
-                                   :properties properties
-                                   :body canonical-body))))))
+          (cl-rabbit:login-sasl-plain
+           connection vhost username password))
+        (cl-rabbit:with-channel (connection 1)
+          (cl-rabbit:exchange-declare
+           connection 1 exchange "topic" :durable t)
+          (cl-rabbit:basic-publish
+           connection
+           1
+           :routing-key routing-key
+           :exchange exchange
+           :mandatory mandatory
+           :immediate immediate
+           :properties properties
+           :body canonical-body))))))
 
-(defun message->string (msg &key (encoding :utf-8))
-  (babel:octets-to-string (cl-rabbit:message/body msg) :encoding encoding))
+(defun message->string (message &key (encoding :utf-8))
+  (babel:octets-to-string
+   (cl-rabbit:message/body message)
+   :encoding encoding))
 
-(defun message->object (msg)
-  (star.documents.v09:ensure-v09-document (message->string msg)))
-
-(defun handle-new-document (msg)
-  (let* ((properties (cl-rabbit:message/properties msg))
-         (route-type (cdr (assoc :type properties :test #'equal)))
-         (body (star.documents.v09:ensure-v09-document
-                (message->string msg)
-                :route-dtype route-type)))
-    (cons (star.documents.v09:document-dtype body) body)))
+(defun message->object (message)
+  (star.documents:ensure-v09-document (message->string message)))
 
 (defun insert (client database document)
   (format nil "~a~%"
-          (couch:create-document client database
-                                 (star.documents.v09:v09-document-json document))))
+          (couch:create-document
+           client
+           database
+           (star.documents:v09-document-json document))))
+
+(defun publish-outbox-event (routing-key payload event-id)
+  "Publish one physical delivery carrying a stable logical EVENT-ID."
+  (declare (ignore event-id))
+  (emit-document "documents" routing-key payload)
+  t)
+
+(defun process-rabbit-document-mutation (self message operation)
+  (let* ((connection
+           (rabbit-stream-connection (consumer-stream self)))
+         (document
+           (star.documents:ensure-v09-document (car message)))
+         (delivery-tag (cdr message)))
+    (anypool:with-connection
+        (client star.databases.couchdb:*couchdb-pool*)
+      (star.databases.couchdb:couchdb-process-outbox-mutation
+       client
+       star:*couchdb-default-database*
+       #'publish-outbox-event
+       document
+       operation))
+    ;; The delivery is settled only after the document revision containing the
+    ;; outbox entry is durable and publication has returned successfully.
+    (cl-rabbit:basic-ack connection 1 delivery-tag)))
 
 (defun handle-document (self message)
-  (let* ((connection (rabbit-stream-connection (consumer-stream self)))
-         (document (star.documents.v09:ensure-v09-document (car message)))
-         (msg-key (cdr message)))
-    (anypool:with-connection (client star.databases.couchdb:*couchdb-pool*)
-      (handler-case
-          (couch:create-document client
-                                 star:*couchdb-default-database*
-                                 (jsown:to-json document))
-        (dex:http-request-conflict (error)
-          (declare (ignore error)))))
-    (cl-rabbit:basic-ack connection 1 msg-key)))
+  (process-rabbit-document-mutation self message :new))
+
+(defun handle-update-document (self message)
+  (process-rabbit-document-mutation self message :updated))
+
+(defun recover-pending-publications ()
+  "Republish pending durable outbox entries in per-document sequence order."
+  (anypool:with-connection
+      (client star.databases.couchdb:*couchdb-pool*)
+    (star.databases.couchdb:recover-couchdb-outbox
+     client
+     star:*couchdb-default-database*
+     #'publish-outbox-event)))
 
 (defun transient-p (message)
-  (star.documents.v09:document-transient-p
-   (star.documents.v09:ensure-v09-document (car message))))
+  (star.documents:document-transient-p
+   (star.documents:ensure-v09-document (car message))))
 
 (defun insertp (message)
   (not (transient-p message)))
 
 (defun handle-target (self message)
-  (let ((connection (rabbit-stream-connection (consumer-stream self)))
-        (body (star.documents.v09:ensure-v09-document (car message) :route-dtype "target"))
-        (msg-key (cdr message)))
+  (let ((connection
+          (rabbit-stream-connection (consumer-stream self)))
+        (body
+          (star.documents:ensure-v09-document
+           (car message)
+           :route-dtype "target"))
+        (delivery-tag (cdr message)))
     (tell star.actors:*targets* (cons 1 body))
-    (cl-rabbit:basic-ack connection 1 msg-key)))
+    (cl-rabbit:basic-ack connection 1 delivery-tag)))
 
 (defun start-consumers ()
-  (log:info "Starting v0.9 document consumers.")
-  (let ((document-consumers (create-rabbit-consumer :name "documents"
-                                                     :n star:*injest-workers*
-                                                     :queue-name "injest"
-                                                     :exchange-name "documents"
-                                                     :routing-key +injest-key+
-                                                     :username star:*rabbit-user*
-                                                     :password star:*rabbit-password*
-                                                     :host star:*rabbit-address*
-                                                     :port star:*rabbit-port*
-                                                     :handler-fn #'handle-document
-                                                     :test-fn #'insertp))
-        (target-consumers (create-rabbit-consumer :name "documents"
-                                                  :n star:*injest-workers*
-                                                  :queue-name "injest-targets"
-                                                  :exchange-name "documents"
-                                                  :routing-key +targets-key+
-                                                  :username star:*rabbit-user*
-                                                  :password star:*rabbit-password*
-                                                  :host star:*rabbit-address*
-                                                  :port star:*rabbit-port*
-                                                  :handler-fn #'handle-target
-                                                  :test-fn #'insertp)))
+  (log:info "Starting crash-safe v0.9 document consumers.")
+  (let ((document-consumers
+          (create-rabbit-consumer
+           :name "documents-ingest"
+           :n star:*injest-workers*
+           :queue-name +injest-queue+
+           :exchange-name "documents"
+           :routing-key +injest-key+
+           :username star:*rabbit-user*
+           :password star:*rabbit-password*
+           :host star:*rabbit-address*
+           :port star:*rabbit-port*
+           :handler-fn #'handle-document
+           :test-fn #'insertp))
+        (update-consumers
+          (create-rabbit-consumer
+           :name "documents-update"
+           :n star:*injest-workers*
+           :queue-name +updates-queue+
+           :exchange-name "documents"
+           :routing-key +update-key+
+           :username star:*rabbit-user*
+           :password star:*rabbit-password*
+           :host star:*rabbit-address*
+           :port star:*rabbit-port*
+           :handler-fn #'handle-update-document
+           :test-fn #'insertp))
+        (target-consumers
+          (create-rabbit-consumer
+           :name "documents-targets"
+           :n star:*injest-workers*
+           :queue-name "documents-targets"
+           :exchange-name "documents"
+           :routing-key +targets-key+
+           :username star:*rabbit-user*
+           :password star:*rabbit-password*
+           :host star:*rabbit-address*
+           :port star:*rabbit-port*
+           :handler-fn #'handle-target
+           :test-fn #'insertp)))
     (start-consumer document-consumers)
-    (start-consumer target-consumers)))
+    (start-consumer update-consumers)
+    (start-consumer target-consumers)
+    (recover-pending-publications)))

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -19,6 +19,7 @@
                  (:file "gserver-settings")
                  (:file "databases/couchdb")
                  (:file "databases/couchdb-v09")
+                 (:file "databases/outbox")
                  (:file "init")
                  (:file "actors")
                  (:file "actors-v09")
@@ -47,4 +48,5 @@
                  #:cl-ppcre
                  #:cms-ulid
                  #:bordeaux-threads
-                 #:closer-mop))
+                 #:closer-mop
+                 #:ironclad))

--- a/source/views/outbox.json
+++ b/source/views/outbox.json
@@ -1,0 +1,9 @@
+{
+  "_id": "_design/outbox",
+  "language": "javascript",
+  "views": {
+    "pending": {
+      "map": "function (doc) { var ext = doc.extensions || {}; var entries = ext._server_outbox || []; for (var i = 0; i < entries.length; i += 1) { var event = entries[i]; if (event && event.status === 'pending') { emit([doc._id, event.sequence], { event_id: event.event_id, mutation_id: event.mutation_id, routing_key: event.routing_key }); } } }"
+    }
+  }
+}

--- a/tests/run-outbox-conformance.lisp
+++ b/tests/run-outbox-conformance.lisp
@@ -1,0 +1,269 @@
+(in-package :cl-user)
+
+(defvar *outbox-test-store* (make-hash-table :test #'equal))
+(defvar *outbox-test-published* nil)
+(defvar *outbox-test-fail-next-publish* nil)
+
+(defun outbox-test-check (condition control &rest arguments)
+  (unless condition
+    (error (apply #'format nil control arguments))))
+
+(defun outbox-test-fixture-path (relative)
+  (merge-pathnames relative (uiop:getcwd)))
+
+(defun outbox-test-read-json (pathname)
+  (jsown:with-injective-reader
+    (jsown:parse (uiop:read-file-string pathname))))
+
+(defun outbox-test-person-fixture ()
+  (loop for index from 1 to 5
+        for fixture-file =
+          (outbox-test-read-json
+           (outbox-test-fixture-path
+            (format nil
+                    "test/fixtures/starintel/v0.9/fixtures-~2,'0d.json"
+                    index)))
+        for fixture =
+          (find "person"
+                (jsown:val fixture-file "fixtures")
+                :key (lambda (document) (jsown:val document "dtype"))
+                :test #'string=)
+        when fixture
+          return fixture))
+
+(defun outbox-test-clone (object)
+  (jsown:with-injective-reader
+    (jsown:parse (jsown:to-json object))))
+
+(defun outbox-test-extension-object (document)
+  (handler-case
+      (jsown:val document "extensions")
+    (error ()
+      (let ((extensions (jsown:empty-object)))
+        (setf (jsown:val document "extensions") extensions)
+        extensions))))
+
+(defun outbox-test-document (id mutation-id &key (title "Original"))
+  (let* ((document (outbox-test-clone (outbox-test-person-fixture)))
+         (extensions (outbox-test-extension-object document)))
+    (setf (jsown:val document "_id") id
+          (jsown:val document "title") title
+          (jsown:val extensions "mutation_id") mutation-id
+          (jsown:val document "extensions") extensions)
+    document))
+
+(defun outbox-test-reset ()
+  (clrhash *outbox-test-store*)
+  (setf *outbox-test-published* nil
+        *outbox-test-fail-next-publish* nil))
+
+(defun outbox-test-revision-generation (revision)
+  (if (and revision (stringp revision))
+      (parse-integer revision :junk-allowed t)
+      0))
+
+(defun outbox-test-load (document-id)
+  (let ((document (gethash document-id *outbox-test-store*)))
+    (and document (outbox-test-clone document))))
+
+(defun outbox-test-save (document)
+  (let* ((document-id (jsown:val document "_id"))
+         (current (gethash document-id *outbox-test-store*))
+         (expected-revision
+           (handler-case (jsown:val document "_rev")
+             (error () nil)))
+         (current-revision
+           (and current (jsown:val current "_rev"))))
+    (when (and current
+               (not (and expected-revision
+                         (string= expected-revision current-revision))))
+      (error 'star.databases.couchdb:outbox-store-conflict))
+    (when (and (null current) expected-revision)
+      (error 'star.databases.couchdb:outbox-store-conflict))
+    (let* ((saved (outbox-test-clone document))
+           (generation
+             (1+
+              (outbox-test-revision-generation current-revision)))
+           (revision (format nil "~d-test" generation)))
+      (setf (jsown:val saved "_rev") revision
+            (gethash document-id *outbox-test-store*) saved)
+      (outbox-test-clone saved))))
+
+(defun outbox-test-publish (routing-key payload event-id)
+  (when *outbox-test-fail-next-publish*
+    (setf *outbox-test-fail-next-publish* nil)
+    (error "forced publish failure"))
+  (push (list routing-key (outbox-test-clone payload) event-id)
+        *outbox-test-published*)
+  t)
+
+(defun outbox-test-process (document operation)
+  (star.databases.couchdb:process-outbox-mutation
+   #'outbox-test-load
+   #'outbox-test-save
+   #'outbox-test-publish
+   document
+   operation))
+
+(defun outbox-test-single-stored-document ()
+  (loop for document being the hash-values of *outbox-test-store*
+        return (outbox-test-clone document)))
+
+(defun outbox-test-event-sequences ()
+  (mapcar
+   (lambda (published)
+     (jsown:val
+      (jsown:val (second published) "extensions")
+      "event_sequence"))
+   (reverse *outbox-test-published*)))
+
+(defun test-new-publish-failure-is-retry-safe ()
+  (outbox-test-reset)
+  (let ((document (outbox-test-document "person:new-failure" "mutation:new-1")))
+    (setf *outbox-test-fail-next-publish* t)
+    (handler-case
+        (progn
+          (outbox-test-process document :new)
+          (error "forced publish failure was swallowed"))
+      (simple-error () t))
+    (let* ((stored (outbox-test-load "person:new-failure"))
+           (entries
+             (star.databases.couchdb:document-outbox-entries stored)))
+      (outbox-test-check (= 1 (length entries))
+                         "new mutation created ~d outbox entries"
+                         (length entries))
+      (outbox-test-check
+       (not (star.databases.couchdb:outbox-entry-published-p
+             (first entries)))
+       "failed publication was marked published"))
+    (outbox-test-process document :new)
+    (outbox-test-process document :new)
+    (outbox-test-check (= 1 (length *outbox-test-published*))
+                       "duplicate new delivery emitted ~d physical events"
+                       (length *outbox-test-published*))
+    (outbox-test-check
+     (star.databases.couchdb:outbox-entry-published-p
+      (first
+       (star.databases.couchdb:document-outbox-entries
+        (outbox-test-load "person:new-failure"))))
+     "retried new event remained pending")))
+
+(defun test-update-publish-failure-is-retry-safe ()
+  (outbox-test-reset)
+  (outbox-test-process
+   (outbox-test-document "person:update-failure" "mutation:new")
+   :new)
+  (setf *outbox-test-published* nil)
+  (let ((update
+          (outbox-test-document
+           "person:update-failure"
+           "mutation:update-1"
+           :title "Updated")))
+    (setf *outbox-test-fail-next-publish* t)
+    (handler-case
+        (progn
+          (outbox-test-process update :updated)
+          (error "forced update publish failure was swallowed"))
+      (simple-error () t))
+    (outbox-test-process update :updated)
+    (outbox-test-process update :updated)
+    (outbox-test-check (= 1 (length *outbox-test-published*))
+                       "duplicate update emitted ~d physical events"
+                       (length *outbox-test-published*))
+    (outbox-test-check
+     (string= "documents.updated.person"
+              (first (first *outbox-test-published*)))
+     "update used the wrong routing key")))
+
+(defun test-crash-recovery-publishes-pending-event ()
+  (outbox-test-reset)
+  (let ((document
+          (outbox-test-document "person:recovery" "mutation:recovery")))
+    (star.databases.couchdb:persist-outbox-mutation
+     #'outbox-test-load #'outbox-test-save document :new)
+    (outbox-test-check (null *outbox-test-published*)
+                       "persistence unexpectedly published")
+    (star.databases.couchdb:recover-outbox-documents
+     #'outbox-test-load
+     #'outbox-test-save
+     #'outbox-test-publish
+     (list (outbox-test-single-stored-document)))
+    (outbox-test-check (= 1 (length *outbox-test-published*))
+                       "recovery published ~d events"
+                       (length *outbox-test-published*))))
+
+(defun test-duplicate-mutation-does-not-append-outbox-entry ()
+  (outbox-test-reset)
+  (let ((document
+          (outbox-test-document "person:duplicate" "mutation:duplicate")))
+    (outbox-test-process document :new)
+    (outbox-test-process document :new)
+    (let ((entries
+            (star.databases.couchdb:document-outbox-entries
+             (outbox-test-load "person:duplicate"))))
+      (outbox-test-check (= 1 (length entries))
+                         "duplicate mutation appended ~d entries"
+                         (length entries)))))
+
+(defun test-conflicting-idempotency-key-is-rejected ()
+  (outbox-test-reset)
+  (outbox-test-process
+   (outbox-test-document "person:conflict" "mutation:conflict" :title "A")
+   :new)
+  (handler-case
+      (progn
+        (outbox-test-process
+         (outbox-test-document "person:conflict" "mutation:conflict" :title "B")
+         :updated)
+        (error "conflicting idempotency key was accepted"))
+    (star.databases.couchdb:mutation-conflict () t)))
+
+(defun test-recovery-preserves-document-event-order ()
+  (outbox-test-reset)
+  (star.databases.couchdb:persist-outbox-mutation
+   #'outbox-test-load
+   #'outbox-test-save
+   (outbox-test-document "person:ordered" "mutation:ordered-new" :title "A")
+   :new)
+  (star.databases.couchdb:persist-outbox-mutation
+   #'outbox-test-load
+   #'outbox-test-save
+   (outbox-test-document "person:ordered" "mutation:ordered-1" :title "B")
+   :updated)
+  (star.databases.couchdb:persist-outbox-mutation
+   #'outbox-test-load
+   #'outbox-test-save
+   (outbox-test-document "person:ordered" "mutation:ordered-2" :title "C")
+   :updated)
+  (star.databases.couchdb:recover-outbox-documents
+   #'outbox-test-load
+   #'outbox-test-save
+   #'outbox-test-publish
+   (list (outbox-test-single-stored-document)))
+  (outbox-test-check (equal '(1 2 3) (outbox-test-event-sequences))
+                     "recovery emitted sequences ~s"
+                     (outbox-test-event-sequences)))
+
+(defun test-update-of-missing-document-is-rejected ()
+  (outbox-test-reset)
+  (handler-case
+      (progn
+        (outbox-test-process
+         (outbox-test-document "person:missing" "mutation:missing")
+         :updated)
+        (error "missing update target was accepted"))
+    (star.databases.couchdb:missing-document-for-update () t)))
+
+(defun run-outbox-conformance-tests ()
+  (format t "~&Running CouchDB outbox conformance tests~%")
+  (test-new-publish-failure-is-retry-safe)
+  (test-update-publish-failure-is-retry-safe)
+  (test-crash-recovery-publishes-pending-event)
+  (test-duplicate-mutation-does-not-append-outbox-entry)
+  (test-conflicting-idempotency-key-is-rejected)
+  (test-recovery-preserves-document-event-order)
+  (test-update-of-missing-document-is-rejected)
+  (format t "~&CouchDB outbox conformance tests passed~%")
+  t)
+
+(run-outbox-conformance-tests)

--- a/tests/test_outbox_contract.py
+++ b/tests/test_outbox_contract.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CouchDBOutboxContractTests(unittest.TestCase):
+    def test_pending_outbox_view_is_valid(self) -> None:
+        view = json.loads(
+            (ROOT / "source" / "views" / "outbox.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(view["_id"], "_design/outbox")
+        source = view["views"]["pending"]["map"]
+        self.assertIn("_server_outbox", source)
+        self.assertIn("event.status === 'pending'", source)
+        self.assertIn("[doc._id, event.sequence]", source)
+
+    def test_outbox_state_is_embedded_in_document_extensions(self) -> None:
+        source = (ROOT / "source" / "databases" / "outbox.lisp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('+outbox-extension-key+ "_server_outbox"', source)
+        self.assertIn('+mutation-ledger-extension-key+ "_server_mutations"', source)
+        self.assertIn("prepare-outbox-mutation", source)
+        self.assertIn("mutation-content-hash", source)
+        self.assertIn("mark-outbox-published", source)
+        self.assertIn("recover-outbox-documents", source)
+        self.assertIn("pending-outbox-tuples", source)
+
+    def test_rabbit_ingress_and_downstream_routes_are_separate(self) -> None:
+        source = (ROOT / "source" / "rabbit.lisp").read_text(encoding="utf-8")
+        self.assertIn('+injest-key+ "documents.ingest.#"', source)
+        self.assertIn('+update-key+ "documents.update.#"', source)
+        self.assertIn('"documents.updated.', (ROOT / "source" / "databases" / "outbox.lisp").read_text(encoding="utf-8"))
+        self.assertIn("couchdb-process-outbox-mutation", source)
+        self.assertIn("recover-pending-publications", source)
+
+    def test_required_crash_recovery_cases_are_executable(self) -> None:
+        tests = (ROOT / "tests" / "run-outbox-conformance.lisp").read_text(
+            encoding="utf-8"
+        )
+        for name in (
+            "test-new-publish-failure-is-retry-safe",
+            "test-update-publish-failure-is-retry-safe",
+            "test-crash-recovery-publishes-pending-event",
+            "test-duplicate-mutation-does-not-append-outbox-entry",
+            "test-conflicting-idempotency-key-is-rejected",
+            "test-recovery-preserves-document-event-order",
+        ):
+            self.assertIn(name, tests)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_outbox_contract.py
+++ b/tests/test_outbox_contract.py
@@ -29,12 +29,13 @@ class CouchDBOutboxContractTests(unittest.TestCase):
         self.assertIn("mark-outbox-published", source)
         self.assertIn("recover-outbox-documents", source)
         self.assertIn("pending-outbox-tuples", source)
+        self.assertIn('(:updated "updated")', source)
+        self.assertIn('"documents.~a.~a"', source)
 
     def test_rabbit_ingress_and_downstream_routes_are_separate(self) -> None:
         source = (ROOT / "source" / "rabbit.lisp").read_text(encoding="utf-8")
         self.assertIn('+injest-key+ "documents.ingest.#"', source)
         self.assertIn('+update-key+ "documents.update.#"', source)
-        self.assertIn('"documents.updated.', (ROOT / "source" / "databases" / "outbox.lisp").read_text(encoding="utf-8"))
         self.assertIn("couchdb-process-outbox-mutation", source)
         self.assertIn("recover-pending-publications", source)
 


### PR DESCRIPTION
## Summary

- store mutation idempotency records and pending downstream events inside each CouchDB document revision
- use stable mutation hashes and event IDs for retry-safe new and updated document flows
- distinguish duplicate-success deliveries from conflicting idempotency-key reuse
- separate ingress routes (`documents.ingest.#`, `documents.update.#`) from downstream routes (`documents.new.*`, `documents.updated.*`)
- ACK Rabbit deliveries only after recoverable state is durable and publication succeeds
- add a recovery scan over a dedicated CouchDB pending-outbox view
- publish pending events in stable per-document sequence order
- retain at-least-once physical delivery while providing stable logical event IDs for downstream deduplication

## Design

This uses a **transactional outbox embedded in the document revision**:

- `extensions._server_mutations` records mutation ID → content hash
- `extensions._server_outbox` records ordered publication state
- document mutation and pending event are persisted in one CouchDB revision
- publish failure leaves a durable `pending` entry
- retry or restart republishes the same logical event ID
- successful publication is marked with a follow-up optimistic-concurrency revision

## Regression coverage

- forced publish failure after new-document persistence
- forced publish failure after update persistence
- restart recovery between persistence and publication
- duplicate ingest and update deliveries
- conflicting idempotency key with different content
- missing update target rejection
- per-document recovery ordering
- pending-view and route-separation contract checks

## Stack

- base: `agent/schema-org-v0.9`
- includes completed issues #11–#13

This remains draft until the required fixture and CLOS/outbox conformance gates are green.

Closes #14