### PR TITLE
Keep Rabbit settlements on channel-owner threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN qlot exec sbcl --non-interactive \
     --eval '(ql:quickload :starintel-gserver)' \
     --load tests/run-document-conformance.lisp \
     --load tests/run-server-codec-conformance.lisp \
-    --load tests/run-outbox-conformance.lisp
+    --load tests/run-outbox-conformance.lisp \
+    --load tests/run-consumer-owner-conformance.lisp
 
 FROM conformance AS star-server
 

--- a/source/actor-systems/event-actor.lisp
+++ b/source/actor-systems/event-actor.lisp
@@ -2,16 +2,13 @@
 
 (defparameter *actor-event-log* nil)
 
-
-
 (defclass actor-event ()
   ((_id :initarg :id :accessor event-id :initform (cms-ulid:ulid))
-   (timestamp  :initarg :timestamp :accessor event-timestamp :initform (spec:unix-now))
+   (timestamp :initarg :timestamp :accessor event-timestamp :initform (spec:unix-now))
    (actor-name :initarg :actor-name :accessor event-actor-name)
    (event-type :initarg :event-type :accessor event-type)
    (details :initarg :details :accessor event-details)
    (source-id :initarg :source-id :accessor event-source-document)))
-
 
 (defun make-actor-event (&key actor-name event-type details source-id)
   (make-instance 'actor-event
@@ -20,41 +17,47 @@
                  :details details
                  :source-id source-id))
 
-
-
-
-
 (define-actor (*actor-event-receiver* *sys*)
   (lambda (event)
     (let ((event-json (jsown:to-json (as-json event))))
-      (tell *couchdb-inserts* (list :id (event-id event) :database star:*couchdb-event-log-database* :document event-json)))))
+      (tell *couchdb-inserts*
+            (list :id (event-id event)
+                  :database star:*couchdb-event-log-database*
+                  :document event-json)))))
 
-
-
-
-
-(defun handle-event-message (message)
-  "Handler function for processing event messages."
-  (let* ((jdoc (jsown:parse message)))
-    (tell *actor-event-receiver* (star.databases.couchdb:from-json jdoc 'actor-event))))
-
+(defun handle-event-message (self message)
+  "Decode one event delivery and return settlement to the Rabbit owner thread."
+  (declare (ignore self))
+  (let ((json-document
+          (jsown:with-injective-reader
+            (jsown:parse (car message)))))
+    (tell *actor-event-receiver*
+          (star.databases.couchdb:from-json json-document 'actor-event))
+    (star.consumers:settlement-ack "actor event accepted")))
 
 (defun start-event-consumer (n)
-  "Initialize and set up the event consumer."
-  (let ((consumer (star.consumers:create-rabbit-consumer
-                   :name "event-consumers"
-                   :n n
-                   :host star:*rabbit-address*
-                   :port star:*rabbit-port*
-                   :username star:*rabbit-user*
-                   :password star:*rabbit-password*
-                   :queue-name "events"
-                   :exchange-name "events"
-                   :routing-key "event.#"
-                   :test-fn #'star.rabbit::insertp
-                   :handler-fn #'handle-event-message)))
+  "Initialize owner-thread event consumers."
+  (let ((consumer
+          (star.consumers:create-rabbit-consumer
+           :name "event-consumers"
+           :n n
+           :host star:*rabbit-address*
+           :port star:*rabbit-port*
+           :username star:*rabbit-user*
+           :password star:*rabbit-password*
+           :queue-name "events"
+           :exchange-name "events"
+           :routing-key "event.#"
+           :test-fn #'identity
+           :handler-fn #'handle-event-message
+           :on-error :dead-letter
+           :on-filter :filtered-ack)))
     (star.consumers:start-consumer consumer)))
 
 (defun log-actor-event (actor-name &key event-type details source-id)
-  (log:debug "Told *actor-event-reciver*")
-  (tell *actor-event-receiver* (make-actor-event :actor-name actor-name :event-type event-type :details  details :source-id source-id)))
+  (log:debug "Told *actor-event-receiver*")
+  (tell *actor-event-receiver*
+        (make-actor-event :actor-name actor-name
+                          :event-type event-type
+                          :details details
+                          :source-id source-id)))

--- a/source/consumers/consumers.lisp
+++ b/source/consumers/consumers.lisp
@@ -1,180 +1,561 @@
 (in-package :star.consumers)
 
+(defstruct (consumer-settlement
+             (:constructor %make-consumer-settlement
+                 (action &key reason condition)))
+  action
+  reason
+  condition)
+
+(defun valid-settlement-action-p (action)
+  (member action
+          '(:ack :filtered-ack :retry :dead-letter :reject)
+          :test #'eq))
+
+(defun make-settlement (action &key reason condition)
+  (unless (valid-settlement-action-p action)
+    (error "Unknown consumer settlement action: ~s" action))
+  (%make-consumer-settlement action
+                             :reason reason
+                             :condition condition))
+
+(defun settlement-ack (&optional reason)
+  (make-settlement :ack :reason reason))
+
+(defun settlement-filtered-ack (&optional (reason "filtered"))
+  (make-settlement :filtered-ack :reason reason))
+
+(defun settlement-retry (&optional reason condition)
+  (make-settlement :retry :reason reason :condition condition))
+
+(defun settlement-dead-letter (&optional reason condition)
+  (make-settlement :dead-letter :reason reason :condition condition))
+
+(defun settlement-reject (&optional reason condition)
+  (make-settlement :reject :reason reason :condition condition))
+
+(defun normalize-settlement (value)
+  "Convert handler results to a structured settlement.
+
+NIL and non-settlement success values remain backward-compatible ACK results."
+  (cond
+    ((consumer-settlement-p value) value)
+    ((valid-settlement-action-p value) (make-settlement value))
+    (t (settlement-ack))))
+
+(define-condition wrong-stream-owner (error)
+  ((expected
+    :initarg :expected
+    :reader wrong-stream-owner-expected)
+   (actual
+    :initarg :actual
+    :reader wrong-stream-owner-actual))
+  (:report
+   (lambda (condition stream)
+     (format stream
+             "Rabbit stream operation ran on ~s; owner is ~s"
+             (wrong-stream-owner-actual condition)
+             (wrong-stream-owner-expected condition)))))
+
 (defclass consumer ()
-  ((name :initarg :name :accessor consumer-name :initform "")
-   (predicate :initarg :test-fn :initform (lambda (self message)
-                                            (not (null message)))
-              :accessor consumer-filter)
-   (workers :initarg :workers :initform 1 :accessor consumer-worker-count)
-   (fn :initarg :fn :accessor consumer-fn :initform (lambda (self message)
-                                                      (print message)) :type function)
-   (take :initarg :take :accessor consumer-take :type integer :initform 1)
-   (worker-channel :initarg :consumer-channel :accessor consumer-channel :type lparallel:channel :initform (make-channel))
-   (state :initarg :state :accessor consumer-state)
-   (consumer-stream :initarg :stream :reader consumer-stream)
-   (lock :initform (bt:make-lock) :accessor consumer-lock))
-  (:documentation "Consumers process a stream of data."))
+  ((name
+    :initarg :name
+    :accessor consumer-name
+    :initform "")
+   (predicate
+    :initarg :test-fn
+    :accessor consumer-filter
+    :initform #'identity)
+   (workers
+    :initarg :workers
+    :accessor consumer-worker-count
+    :initform 1)
+   (fn
+    :initarg :fn
+    :accessor consumer-fn
+    :initform (lambda (consumer message)
+                (declare (ignore consumer))
+                (print message)))
+   (take
+    :initarg :take
+    :accessor consumer-take
+    :initform 1)
+   (worker-channel
+    :initarg :consumer-channel
+    :accessor consumer-channel
+    :initform nil)
+   (state
+    :initarg :state
+    :accessor consumer-state
+    :initform :created)
+   (consumer-stream
+    :initarg :stream
+    :accessor consumer-stream)
+   (lock
+    :initform (bt:make-lock "consumer-state")
+    :accessor consumer-lock)
+   (metrics-lock
+    :initform (bt:make-lock "consumer-metrics")
+    :reader consumer-metrics-lock)
+   (in-flight
+    :initform 0
+    :accessor consumer-in-flight)
+   (unsettled
+    :initform 0
+    :accessor consumer-unsettled)
+   (failures
+    :initform 0
+    :accessor consumer-failures)
+   (settlement-counts
+    :initform (make-hash-table :test #'eq)
+    :reader consumer-settlement-counts)
+   (failure-action
+    :initarg :on-error
+    :accessor consumer-failure-action
+    :initform :retry)
+   (filtered-action
+    :initarg :on-filter
+    :accessor consumer-filtered-action
+    :initform :filtered-ack)
+   (worker-instances
+    :initform nil
+    :accessor consumer-worker-instances)
+   (threads
+    :initform nil
+    :accessor consumer-threads)
+   (running-p
+    :initform nil
+    :accessor consumer-running-p))
+  (:documentation
+   "A stream consumer whose worker owns its stream and settlement lifecycle."))
 
-(defgeneric consumer-state (consumer)
-  (:documentation "Return the consumer's state"))
-
-(defgeneric consumer-update-state (consumer new-state)
-  (:documentation "Update the consumer state"))
-
-(defgeneric consumer-cleanup (consumer)
-  (:documentation "Close any streams and de-init the consumer"))
+(defgeneric consumer-update-state (consumer new-state))
+(defgeneric consumer-cleanup (consumer))
+(defgeneric consumer-update (consumer new-state))
+(defgeneric consumer-read (consumer))
+(defgeneric consume (consumer data))
+(defgeneric start-consumer (consumer))
+(defgeneric stop-consumer (consumer))
+(defgeneric open-stream (stream))
+(defgeneric close-stream (stream))
+(defgeneric stream-read (stream))
+(defgeneric stream-settle (stream delivery settlement))
 
 (defmacro with-consumer-lock ((consumer) &body body)
   `(bt:with-lock-held ((consumer-lock ,consumer))
      ,@body))
 
+(defmethod consumer-update-state ((consumer consumer) new-state)
+  (with-consumer-lock (consumer)
+    (setf (consumer-state consumer) new-state)))
+
 (defmethod consumer-update ((consumer consumer) new-state)
-  (setf (consumer-state consumer) new-state))
+  (consumer-update-state consumer new-state))
+
+(defmethod consumer-cleanup ((consumer consumer))
+  (when (consumer-running-p consumer)
+    (stop-consumer consumer))
+  consumer)
+
+(defun adjust-consumer-metric (consumer accessor delta)
+  (bt:with-lock-held ((consumer-metrics-lock consumer))
+    (let ((value (+ (funcall accessor consumer) delta)))
+      (when (minusp value)
+        (error "Consumer metric underflow for ~a" (consumer-name consumer)))
+      (setf (slot-value consumer
+                        (ecase accessor
+                          (#'consumer-in-flight 'in-flight)
+                          (#'consumer-unsettled 'unsettled)
+                          (#'consumer-failures 'failures)))
+            value)
+      value)))
+
+(defun increment-in-flight (consumer)
+  (adjust-consumer-metric consumer #'consumer-in-flight 1))
+
+(defun decrement-in-flight (consumer)
+  (adjust-consumer-metric consumer #'consumer-in-flight -1))
+
+(defun increment-unsettled (consumer)
+  (adjust-consumer-metric consumer #'consumer-unsettled 1))
+
+(defun decrement-unsettled (consumer)
+  (adjust-consumer-metric consumer #'consumer-unsettled -1))
+
+(defun increment-failures (consumer)
+  (adjust-consumer-metric consumer #'consumer-failures 1))
+
+(defun increment-settlement-count (consumer action)
+  (bt:with-lock-held ((consumer-metrics-lock consumer))
+    (incf (gethash action (consumer-settlement-counts consumer) 0))))
+
+(defun consumer-settlement-count (consumer action)
+  (bt:with-lock-held ((consumer-metrics-lock consumer))
+    (gethash action (consumer-settlement-counts consumer) 0)))
+
+(defun consumer-metrics (consumer)
+  (bt:with-lock-held ((consumer-metrics-lock consumer))
+    (list :in-flight (consumer-in-flight consumer)
+          :unsettled (consumer-unsettled consumer)
+          :failures (consumer-failures consumer)
+          :ack (gethash :ack (consumer-settlement-counts consumer) 0)
+          :filtered-ack
+          (gethash :filtered-ack (consumer-settlement-counts consumer) 0)
+          :retry (gethash :retry (consumer-settlement-counts consumer) 0)
+          :dead-letter
+          (gethash :dead-letter (consumer-settlement-counts consumer) 0)
+          :reject (gethash :reject (consumer-settlement-counts consumer) 0))))
+
+(defun configured-failure-settlement (consumer condition)
+  (make-settlement
+   (consumer-failure-action consumer)
+   :reason (princ-to-string condition)
+   :condition condition))
+
+(defun configured-filter-settlement (consumer)
+  (make-settlement
+   (consumer-filtered-action consumer)
+   :reason "consumer filter declined delivery"))
 
 (defmethod consumer-read ((consumer consumer))
-  (with-consumer-lock (consumer)
-    (stream-read (consumer-stream consumer))))
+  (stream-read (consumer-stream consumer)))
 
-(defmethod consume  ((consumer consumer) data)
-  (submit-task (consumer-channel consumer) (lambda ()
-                                             (if (funcall (consumer-filter consumer) data)
-                                                 (funcall (consumer-fn consumer) consumer data)))))
+(defun consumer-process-delivery (consumer delivery)
+  "Run filter/handler and settle DELIVERY exactly once on the current owner thread."
+  (increment-unsettled consumer)
+  (let ((handler-active nil)
+        (settlement nil))
+    (setf settlement
+          (handler-case
+              (if (funcall (consumer-filter consumer) delivery)
+                  (progn
+                    (setf handler-active t)
+                    (increment-in-flight consumer)
+                    (normalize-settlement
+                     (funcall (consumer-fn consumer) consumer delivery)))
+                  (configured-filter-settlement consumer))
+            (condition (error)
+              (increment-failures consumer)
+              (configured-failure-settlement consumer error))))
+    (when handler-active
+      (decrement-in-flight consumer))
+    ;; If settlement itself fails, UNSETTLED remains non-zero and the owner loop
+    ;; terminates instead of pretending prefetch credit was restored.
+    (stream-settle (consumer-stream consumer) delivery settlement)
+    (decrement-unsettled consumer)
+    (increment-settlement-count
+     consumer
+     (consumer-settlement-action settlement))
+    settlement))
 
+(defmethod consume ((consumer consumer) data)
+  (consumer-process-delivery consumer data))
 
-
+(defun run-consumer (consumer)
+  "Open, consume, handle, and settle on one explicit owner thread."
+  (unwind-protect
+       (progn
+         (open-stream (consumer-stream consumer))
+         (setf (consumer-running-p consumer) t)
+         (consumer-update-state consumer :running)
+         (loop until (eq (consumer-state consumer) :stopping)
+               do (handler-case
+                      (consumer-process-delivery
+                       consumer
+                       (consumer-read consumer))
+                    (end-of-file ()
+                      (return)))))
+    (when (consumer-running-p consumer)
+      (close-stream (consumer-stream consumer)))
+    (setf (consumer-running-p consumer) nil)
+    (consumer-update-state consumer :stopped))
+  consumer)
 
 (defmethod start-consumer ((consumer consumer))
-  (loop for i from 1 to (consumer-worker-count consumer)
-        do (bt:make-thread (lambda ()
-                             (loop
-                               for data = (consumer-read consumer)
-                               do (consume consumer data)
-                               do (receive-result (consumer-channel consumer))))
-                           :name (consumer-name consumer))))
+  (when (> (consumer-worker-count consumer) 1)
+    (error "Generic consumers cannot share one stream across multiple workers"))
+  (let ((thread
+          (bt:make-thread
+           (lambda () (run-consumer consumer))
+           :name (consumer-name consumer))))
+    (setf (consumer-threads consumer) (list thread)
+          (consumer-worker-instances consumer) (list consumer))
+    consumer))
 
-
-
-
-
+(defmethod stop-consumer ((consumer consumer))
+  (consumer-update-state consumer :stopping)
+  consumer)
 
 (defun make-consumer (&rest args)
   (apply #'make-instance 'consumer args))
 
 (defclass rabbit-queue-stream (cl-stream:sequence-input-stream)
-  ((exchange :initform "amq.topic" :initarg :exchange-name :accessor rabbit-stream-exchange)
-   (exchange-type :initform "topic" :initarg :exchange-type :accessor rabbit-exchange-type)
-   (exchange-durable :initform t :initarg :exchange-durable :accessor rabbit-exchange-durable-p)
-   (routing-key :initform "" :initarg :routing-key :accessor rabbit-stream-routing-key)
-   (user :initform "guest" :initarg :user :accessor rabbit-stream-user)
-   (password :initform "guest" :initarg :password :accessor rabbit-stream-password)
-   (vhost :initform "/" :initarg :vhost :accessor rabbit-stream-vhost)
-   (port :initform 5672 :initarg :port :accessor rabbit-stream-port)
-   (host :initform "localhost" :initarg :host :accessor rabbit-stream-host)
-   (queue-durable-p :initform t :initarg :queue-durable :accessor rabbit-stream-queue-durable-p)
-   (queue-name :initarg :queue-name :accessor rabbit-stream-queue-name)
-   (conn :initform nil :initarg :rabbit-connection :accessor rabbit-stream-connection)
-   (chan :initform nil :initarg :rabbit-channel :accessor rabbit-stream-channel)
-   (open :initform nil :accessor rabbit-stream-open-p))
-  (:documentation "RabbitMQ queue stream representation"))
+  ((exchange
+    :initform "amq.topic"
+    :initarg :exchange-name
+    :accessor rabbit-stream-exchange)
+   (exchange-type
+    :initform "topic"
+    :initarg :exchange-type
+    :accessor rabbit-exchange-type)
+   (exchange-durable
+    :initform t
+    :initarg :exchange-durable
+    :accessor rabbit-exchange-durable-p)
+   (routing-key
+    :initform ""
+    :initarg :routing-key
+    :accessor rabbit-stream-routing-key)
+   (user
+    :initform "guest"
+    :initarg :user
+    :accessor rabbit-stream-user)
+   (password
+    :initform "guest"
+    :initarg :password
+    :accessor rabbit-stream-password)
+   (vhost
+    :initform "/"
+    :initarg :vhost
+    :accessor rabbit-stream-vhost)
+   (port
+    :initform 5672
+    :initarg :port
+    :accessor rabbit-stream-port)
+   (host
+    :initform "localhost"
+    :initarg :host
+    :accessor rabbit-stream-host)
+   (queue-durable-p
+    :initform t
+    :initarg :queue-durable
+    :accessor rabbit-stream-queue-durable-p)
+   (queue-name
+    :initarg :queue-name
+    :accessor rabbit-stream-queue-name)
+   (prefetch-count
+    :initarg :prefetch-count
+    :initform 200
+    :accessor rabbit-stream-prefetch-count)
+   (conn
+    :initform nil
+    :accessor rabbit-stream-connection)
+   (chan
+    :initform 1
+    :accessor rabbit-stream-channel)
+   (owner-thread
+    :initform nil
+    :accessor rabbit-stream-owner-thread)
+   (open
+    :initform nil
+    :accessor rabbit-stream-open-p))
+  (:documentation "A Rabbit queue/channel owned by exactly one thread."))
+
+(defun assert-rabbit-stream-owner (stream)
+  (let ((actual (bt:current-thread))
+        (expected (rabbit-stream-owner-thread stream)))
+    (unless (and expected (eq actual expected))
+      (error 'wrong-stream-owner
+             :expected expected
+             :actual actual))))
 
 (defmethod open-stream ((stream rabbit-queue-stream))
-  (let* ((connection (cl-rabbit:new-connection))
-         (sock (cl-rabbit:tcp-socket-new connection))
-         (username (rabbit-stream-user stream))
-         (password (rabbit-stream-password stream)))
-    (setf (rabbit-stream-connection stream) connection)
-    (cl-rabbit:socket-open sock (rabbit-stream-host stream) (rabbit-stream-port stream))
-    (when (or username password)
-      (cl-rabbit:login-sasl-plain connection (rabbit-stream-vhost stream) username password))
-    (cl-rabbit:channel-open connection 1)
-    (cl-rabbit:basic-qos connection 1 :prefetch-count 200)
-    (cl-rabbit:exchange-declare connection 1 (rabbit-stream-exchange stream) (rabbit-exchange-type stream) :durable (rabbit-exchange-durable-p stream))
-    (cl-rabbit:queue-declare connection 1 :queue (rabbit-stream-queue-name stream) :durable (rabbit-stream-queue-durable-p stream))
-    (cl-rabbit:queue-bind connection 1 :queue (rabbit-stream-queue-name stream) :exchange (rabbit-stream-exchange stream) :routing-key (rabbit-stream-routing-key stream))
-    (cl-rabbit:basic-consume connection 1 (rabbit-stream-queue-name stream))
-    (setf (rabbit-stream-open-p stream) t)))
+  (when (rabbit-stream-open-p stream)
+    (error "Rabbit stream is already open"))
+  (setf (rabbit-stream-owner-thread stream) (bt:current-thread))
+  (handler-case
+      (let* ((connection (cl-rabbit:new-connection))
+             (socket (cl-rabbit:tcp-socket-new connection))
+             (channel (rabbit-stream-channel stream)))
+        (setf (rabbit-stream-connection stream) connection)
+        (cl-rabbit:socket-open
+         socket
+         (rabbit-stream-host stream)
+         (rabbit-stream-port stream))
+        (when (and (rabbit-stream-user stream)
+                   (rabbit-stream-password stream))
+          (cl-rabbit:login-sasl-plain
+           connection
+           (rabbit-stream-vhost stream)
+           (rabbit-stream-user stream)
+           (rabbit-stream-password stream)))
+        (cl-rabbit:channel-open connection channel)
+        (cl-rabbit:basic-qos
+         connection
+         channel
+         :prefetch-count (rabbit-stream-prefetch-count stream))
+        (cl-rabbit:exchange-declare
+         connection
+         channel
+         (rabbit-stream-exchange stream)
+         (rabbit-exchange-type stream)
+         :durable (rabbit-exchange-durable-p stream))
+        (cl-rabbit:queue-declare
+         connection
+         channel
+         :queue (rabbit-stream-queue-name stream)
+         :durable (rabbit-stream-queue-durable-p stream))
+        (cl-rabbit:queue-bind
+         connection
+         channel
+         :queue (rabbit-stream-queue-name stream)
+         :exchange (rabbit-stream-exchange stream)
+         :routing-key (rabbit-stream-routing-key stream))
+        (cl-rabbit:basic-consume
+         connection
+         channel
+         (rabbit-stream-queue-name stream))
+        (setf (rabbit-stream-open-p stream) t)
+        stream)
+    (condition (error)
+      (setf (rabbit-stream-owner-thread stream) nil
+            (rabbit-stream-connection stream) nil)
+      (signal error))))
 
 (defmethod close-stream ((stream rabbit-queue-stream))
-  (cl-rabbit:channel-close (rabbit-stream-connection stream) 1)
-  (cl-rabbit:destroy-connection (rabbit-stream-connection stream))
-  (setf (rabbit-stream-open-p stream) nil))
+  (assert-rabbit-stream-owner stream)
+  (when (rabbit-stream-open-p stream)
+    (cl-rabbit:channel-close
+     (rabbit-stream-connection stream)
+     (rabbit-stream-channel stream))
+    (cl-rabbit:destroy-connection
+     (rabbit-stream-connection stream)))
+  (setf (rabbit-stream-open-p stream) nil
+        (rabbit-stream-connection stream) nil
+        (rabbit-stream-owner-thread stream) nil)
+  stream)
 
 (defmethod stream-read ((stream rabbit-queue-stream))
-  (let ((conn (rabbit-stream-connection stream)))
-    (cl-rabbit:consume-message conn)))
+  (assert-rabbit-stream-owner stream)
+  (cl-rabbit:consume-message (rabbit-stream-connection stream)))
 
-(defclass rabbit-consumer (consumer)
-  ()
-  (:documentation "Custom consumer class for RabbitMQ"))
+(defun rabbit-delivery-tag (delivery)
+  (cdr delivery))
+
+(defmethod stream-settle
+    ((stream rabbit-queue-stream) delivery settlement)
+  (assert-rabbit-stream-owner stream)
+  (let ((connection (rabbit-stream-connection stream))
+        (channel (rabbit-stream-channel stream))
+        (delivery-tag (rabbit-delivery-tag delivery)))
+    (ecase (consumer-settlement-action settlement)
+      ((:ack :filtered-ack)
+       (cl-rabbit:basic-ack connection channel delivery-tag))
+      (:retry
+       (cl-rabbit:basic-nack
+        connection channel delivery-tag :requeue t))
+      ((:dead-letter :reject)
+       (cl-rabbit:basic-nack
+        connection channel delivery-tag :requeue nil))))
+  settlement)
+
+(defclass rabbit-consumer (consumer) ()
+  (:documentation "A Rabbit consumer configuration or channel-owning worker."))
 
 (defmethod consumer-read ((consumer rabbit-consumer))
-  (let ((msg (stream-read (consumer-stream consumer))))
-    (cons (babel:octets-to-string (cl-rabbit:message/body (cl-rabbit:envelope/message msg)) :encoding :utf-8)
-          (cl-rabbit:envelope/delivery-tag msg))))
+  (let ((envelope (stream-read (consumer-stream consumer))))
+    (cons
+     (babel:octets-to-string
+      (cl-rabbit:message/body (cl-rabbit:envelope/message envelope))
+      :encoding :utf-8)
+     (cl-rabbit:envelope/delivery-tag envelope))))
 
+(defun make-rabbit-worker-consumer (consumer worker-number)
+  "Clone CONSUMER configuration with a fresh stream/connection owner."
+  (let ((stream (consumer-stream consumer)))
+    (make-instance
+     'rabbit-consumer
+     :name (format nil "~a-~d" (consumer-name consumer) worker-number)
+     :workers 1
+     :stream
+     (make-instance
+      'rabbit-queue-stream
+      :queue-name (rabbit-stream-queue-name stream)
+      :exchange-name (rabbit-stream-exchange stream)
+      :exchange-type (rabbit-exchange-type stream)
+      :exchange-durable (rabbit-exchange-durable-p stream)
+      :routing-key (rabbit-stream-routing-key stream)
+      :host (rabbit-stream-host stream)
+      :port (rabbit-stream-port stream)
+      :user (rabbit-stream-user stream)
+      :password (rabbit-stream-password stream)
+      :vhost (rabbit-stream-vhost stream)
+      :queue-durable (rabbit-stream-queue-durable-p stream)
+      :prefetch-count (rabbit-stream-prefetch-count stream))
+     :fn (consumer-fn consumer)
+     :test-fn (consumer-filter consumer)
+     :on-error (consumer-failure-action consumer)
+     :on-filter (consumer-filtered-action consumer))))
 
 (defmethod start-consumer ((consumer rabbit-consumer))
-  (let ((create-thread-consumer
-          (lambda (thread-number)
-            (let* ((thread-consumer (create-rabbit-consumer
-                                     :name (format nil "~A-~D" (consumer-name consumer) thread-number)
-                                     :n 1
-                                     :queue-name (rabbit-stream-queue-name (consumer-stream consumer))
-                                     :exchange-name (rabbit-stream-exchange (consumer-stream consumer))
-                                     :routing-key (rabbit-stream-routing-key (consumer-stream consumer))
-                                     :host (rabbit-stream-host (consumer-stream consumer))
-                                     :port (rabbit-stream-port (consumer-stream consumer))
-                                     :username (rabbit-stream-user (consumer-stream consumer))
-                                     :password (rabbit-stream-password (consumer-stream consumer))
-                                     :test-fn (consumer-filter consumer)
-                                     :handler-fn (consumer-fn consumer))))
-              (open-stream (consumer-stream thread-consumer))
-              (assert (rabbit-stream-open-p (consumer-stream thread-consumer)) nil "Rabbitmq stream wasnt opened!!!!")
-              (lambda ()
-                (loop
-                  for data = (consumer-read thread-consumer)
-                  do (consume thread-consumer data)
-                  do (receive-result (consumer-channel thread-consumer))))))))
-    (loop for i from 1 to (consumer-worker-count consumer)
-          do (bt:make-thread (funcall create-thread-consumer i)
-                             :name (format nil "~A-~D" (consumer-name consumer) i)))))
+  (let ((workers nil)
+        (threads nil))
+    (loop for worker-number from 1 to (consumer-worker-count consumer)
+          do
+             (let ((worker
+                     (make-rabbit-worker-consumer
+                      consumer worker-number)))
+               (push worker workers)
+               (push
+                (bt:make-thread
+                 (lambda () (run-consumer worker))
+                 :name (consumer-name worker))
+                threads)))
+    (setf (consumer-worker-instances consumer) (nreverse workers)
+          (consumer-threads consumer) (nreverse threads)
+          (consumer-running-p consumer) t)
+    (consumer-update-state consumer :running)
+    consumer))
 
-(defun create-rabbit-consumer (&key
-                                 (name (error "Consumer name is required"))
-                                 (n 1)
-                                 (queue-name (error "Queue name is required"))
-                                 (exchange-name "documents")
-                                 (routing-key (error "Routing key is required"))
-                                 (host "localhost")
-                                 (port 5672)
-                                 (username "guest")
-                                 (password "guest")
-                                 (test-fn #'identity)
-                                 (handler-fn (error "Handler function is required")))
-  "Create a RabbitMQ consumer with the given configuration.
-This function returns a rabbit-consumer instance.
-Arguments:
-- NAME: String, the name of the consumer.
-- N: Integer, the number of consumer threads to start (default: 1).
-- QUEUE-NAME: String, the name of the RabbitMQ queue to consume from.
-- EXCHANGE-NAME: String, the name of the RabbitMQ exchange (default: 'documents').
-- ROUTING-KEY: String, the routing key for the queue binding.
-- HOST: String, the RabbitMQ server host (default: 'localhost').
-- PORT: Integer, the RabbitMQ server port (default: 5672).
-- USERNAME: String, the RabbitMQ username (default: 'guest').
-- PASSWORD: String, the RabbitMQ password (default: 'guest').
-- TEST-FN: Function, a function to test if a message should be processed (default: #'identity).
-- HANDLER-FN: Function, the message handling logic."
-  (make-instance 'rabbit-consumer
-                 :name (string-downcase (string name))
-                 :stream (make-instance 'rabbit-queue-stream
-                                        :queue-name queue-name
-                                        :exchange-name exchange-name
-                                        :routing-key routing-key
-                                        :host host
-                                        :port port
-                                        :user username
-                                        :password password)
-                 :workers n
-                 :fn handler-fn
-                 :test-fn test-fn))
+(defmethod stop-consumer ((consumer rabbit-consumer))
+  (dolist (worker (consumer-worker-instances consumer))
+    (consumer-update-state worker :stopping))
+  (consumer-update-state consumer :stopping)
+  consumer)
+
+(defun create-rabbit-consumer
+    (&key
+       (name (error "Consumer name is required"))
+       (n 1)
+       (queue-name (error "Queue name is required"))
+       (exchange-name "documents")
+       (exchange-type "topic")
+       (exchange-durable t)
+       (routing-key (error "Routing key is required"))
+       (host "localhost")
+       (port 5672)
+       (username "guest")
+       (password "guest")
+       (vhost "/")
+       (queue-durable t)
+       (prefetch-count 200)
+       (on-error :retry)
+       (on-filter :filtered-ack)
+       (test-fn #'identity)
+       (handler-fn (error "Handler function is required")))
+  "Create a Rabbit consumer configuration. Each worker receives a fresh stream."
+  (unless (plusp n)
+    (error "Rabbit consumer worker count must be positive"))
+  (make-instance
+   'rabbit-consumer
+   :name (string-downcase (string name))
+   :stream
+   (make-instance
+    'rabbit-queue-stream
+    :queue-name queue-name
+    :exchange-name exchange-name
+    :exchange-type exchange-type
+    :exchange-durable exchange-durable
+    :routing-key routing-key
+    :host host
+    :port port
+    :user username
+    :password password
+    :vhost vhost
+    :queue-durable queue-durable
+    :prefetch-count prefetch-count)
+   :workers n
+   :fn handler-fn
+   :test-fn test-fn
+   :on-error on-error
+   :on-filter on-filter))

--- a/source/consumers/owner-fixes.lisp
+++ b/source/consumers/owner-fixes.lisp
@@ -1,0 +1,80 @@
+(in-package :star.consumers)
+
+(defun update-consumer-metric-slot (consumer slot-name delta)
+  (bt:with-lock-held ((consumer-metrics-lock consumer))
+    (let ((value (+ (slot-value consumer slot-name) delta)))
+      (when (minusp value)
+        (error "Consumer metric ~a underflow for ~a"
+               slot-name
+               (consumer-name consumer)))
+      (setf (slot-value consumer slot-name) value)
+      value)))
+
+(defun increment-in-flight (consumer)
+  (update-consumer-metric-slot consumer 'in-flight 1))
+
+(defun decrement-in-flight (consumer)
+  (update-consumer-metric-slot consumer 'in-flight -1))
+
+(defun increment-unsettled (consumer)
+  (update-consumer-metric-slot consumer 'unsettled 1))
+
+(defun decrement-unsettled (consumer)
+  (update-consumer-metric-slot consumer 'unsettled -1))
+
+(defun increment-failures (consumer)
+  (update-consumer-metric-slot consumer 'failures 1))
+
+(defmethod open-stream ((stream rabbit-queue-stream))
+  (when (rabbit-stream-open-p stream)
+    (error "Rabbit stream is already open"))
+  (setf (rabbit-stream-owner-thread stream) (bt:current-thread))
+  (handler-case
+      (let* ((connection (cl-rabbit:new-connection))
+             (socket (cl-rabbit:tcp-socket-new connection))
+             (channel (rabbit-stream-channel stream)))
+        (setf (rabbit-stream-connection stream) connection)
+        (cl-rabbit:socket-open
+         socket
+         (rabbit-stream-host stream)
+         (rabbit-stream-port stream))
+        (when (and (rabbit-stream-user stream)
+                   (rabbit-stream-password stream))
+          (cl-rabbit:login-sasl-plain
+           connection
+           (rabbit-stream-vhost stream)
+           (rabbit-stream-user stream)
+           (rabbit-stream-password stream)))
+        (cl-rabbit:channel-open connection channel)
+        (cl-rabbit:basic-qos
+         connection
+         channel
+         :prefetch-count (rabbit-stream-prefetch-count stream))
+        (cl-rabbit:exchange-declare
+         connection
+         channel
+         (rabbit-stream-exchange stream)
+         (rabbit-exchange-type stream)
+         :durable (rabbit-exchange-durable-p stream))
+        (cl-rabbit:queue-declare
+         connection
+         channel
+         :queue (rabbit-stream-queue-name stream)
+         :durable (rabbit-stream-queue-durable-p stream))
+        (cl-rabbit:queue-bind
+         connection
+         channel
+         :queue (rabbit-stream-queue-name stream)
+         :exchange (rabbit-stream-exchange stream)
+         :routing-key (rabbit-stream-routing-key stream))
+        (cl-rabbit:basic-consume
+         connection
+         channel
+         (rabbit-stream-queue-name stream))
+        (setf (rabbit-stream-open-p stream) t)
+        stream)
+    (condition (condition)
+      (setf (rabbit-stream-owner-thread stream) nil
+            (rabbit-stream-connection stream) nil
+            (rabbit-stream-open-p stream) nil)
+      (error condition))))

--- a/source/consumers/owner-fixes.lisp
+++ b/source/consumers/owner-fixes.lisp
@@ -25,6 +25,34 @@
 (defun increment-failures (consumer)
   (update-consumer-metric-slot consumer 'failures 1))
 
+(defun consumer-process-delivery (consumer delivery)
+  "Run filter/handler and settle DELIVERY exactly once on the owner thread."
+  (increment-unsettled consumer)
+  (let ((settlement
+          (handler-case
+              (if (funcall (consumer-filter consumer) delivery)
+                  (progn
+                    (increment-in-flight consumer)
+                    (unwind-protect
+                         (normalize-settlement
+                          (funcall
+                           (consumer-fn consumer)
+                           consumer
+                           delivery))
+                      (decrement-in-flight consumer)))
+                  (configured-filter-settlement consumer))
+            (error (condition)
+              (increment-failures consumer)
+              (configured-failure-settlement consumer condition)))))
+    ;; If settlement fails, UNSETTLED remains non-zero. The owner loop exits
+    ;; rather than pretending Rabbit prefetch credit was restored.
+    (stream-settle (consumer-stream consumer) delivery settlement)
+    (decrement-unsettled consumer)
+    (increment-settlement-count
+     consumer
+     (consumer-settlement-action settlement))
+    settlement))
+
 (defmethod open-stream ((stream rabbit-queue-stream))
   (when (rabbit-stream-open-p stream)
     (error "Rabbit stream is already open"))

--- a/source/consumers/package.lisp
+++ b/source/consumers/package.lisp
@@ -1,6 +1,6 @@
-(uiop:define-package   :star.consumers
-  (:use       :cl #:LPARALLEL)
-  (:documentation "doc")
+(uiop:define-package :star.consumers
+  (:use :cl)
+  (:documentation "Owner-thread stream consumers with explicit settlement results.")
   (:export
    #:consumer
    #:consumer-name
@@ -13,14 +13,42 @@
    #:consumer-state
    #:consumer-stream
    #:consumer-lock
+   #:consumer-worker-count
+   #:consumer-worker-instances
+   #:consumer-threads
+   #:consumer-running-p
+   #:consumer-failure-action
+   #:consumer-filtered-action
+   #:consumer-in-flight
+   #:consumer-unsettled
+   #:consumer-failures
+   #:consumer-settlement-count
+   #:consumer-metrics
    #:consumer-update-state
    #:consumer-cleanup
    #:with-consumer-lock
    #:consumer-update
    #:consumer-read
+   #:consumer-process-delivery
    #:consume
+   #:run-consumer
    #:start-consumer
+   #:stop-consumer
    #:make-consumer
+   #:consumer-settlement
+   #:consumer-settlement-action
+   #:consumer-settlement-reason
+   #:consumer-settlement-condition
+   #:settlement-ack
+   #:settlement-filtered-ack
+   #:settlement-retry
+   #:settlement-dead-letter
+   #:settlement-reject
+   #:normalize-settlement
+   #:stream-settle
+   #:wrong-stream-owner
+   #:wrong-stream-owner-expected
+   #:wrong-stream-owner-actual
    #:rabbit-queue-stream
    #:rabbit-stream-exchange
    #:rabbit-exchange-type
@@ -35,9 +63,12 @@
    #:rabbit-stream-queue-name
    #:rabbit-stream-connection
    #:rabbit-stream-channel
+   #:rabbit-stream-owner-thread
+   #:rabbit-stream-prefetch-count
    #:rabbit-stream-open-p
    #:open-stream
    #:close-stream
    #:stream-read
    #:rabbit-consumer
+   #:make-rabbit-worker-consumer
    #:create-rabbit-consumer))

--- a/source/rabbit.lisp
+++ b/source/rabbit.lisp
@@ -6,6 +6,18 @@
 (defvar +update-key+ "documents.update.#")
 (defvar +targets-key+ "documents.new.target.*")
 
+(defun settle-rabbit-delivery (connection channel delivery-tag settlement)
+  (ecase (consumer-settlement-action settlement)
+    ((:ack :filtered-ack)
+     (cl-rabbit:basic-ack connection channel delivery-tag))
+    (:retry
+     (cl-rabbit:basic-nack
+      connection channel delivery-tag :requeue t))
+    ((:dead-letter :reject)
+     (cl-rabbit:basic-nack
+      connection channel delivery-tag :requeue nil)))
+  settlement)
+
 (defmacro with-rabbit-recv
     ((queue-name exchange-name exchange-type routing-key
       &key
@@ -18,6 +30,7 @@
         (exclusive nil)
         (auto-delete nil))
      &body body)
+  "Compatibility owner-thread receive loop with structured settlement results."
   `(cl-rabbit:with-connection (connection)
      (let ((socket (cl-rabbit:tcp-socket-new connection)))
        (cl-rabbit:socket-open socket ,host ,port)
@@ -42,21 +55,15 @@
          (loop
            for result = (cl-rabbit:consume-message connection)
            for message = (cl-rabbit:envelope/message result)
-           do
-              (handler-case
-                  (progn
-                    ,@body
-                    (cl-rabbit:basic-ack
-                     connection
-                     1
-                     (cl-rabbit:envelope/delivery-tag result)))
-                (error (condition)
-                  (log:error "Rabbit document rejected: ~a" condition)
-                  (cl-rabbit:basic-nack
-                   connection
-                   1
-                   (cl-rabbit:envelope/delivery-tag result)
-                   :requeue nil))))))))
+           for delivery-tag = (cl-rabbit:envelope/delivery-tag result)
+           for settlement =
+             (handler-case
+                 (normalize-settlement (progn ,@body))
+               (condition (error)
+                 (log:error "Rabbit handler failed: ~a" error)
+                 (settlement-retry (princ-to-string error) error)))
+           do (settle-rabbit-delivery
+               connection 1 delivery-tag settlement))))))
 
 (defun emit-document
     (exchange routing-key body
@@ -111,11 +118,9 @@
   t)
 
 (defun process-rabbit-document-mutation (self message operation)
-  (let* ((connection
-           (rabbit-stream-connection (consumer-stream self)))
-         (document
-           (star.documents:ensure-v09-document (car message)))
-         (delivery-tag (cdr message)))
+  (declare (ignore self))
+  (let ((document
+          (star.documents:ensure-v09-document (car message))))
     (anypool:with-connection
         (client star.databases.couchdb:*couchdb-pool*)
       (star.databases.couchdb:couchdb-process-outbox-mutation
@@ -124,9 +129,7 @@
        #'publish-outbox-event
        document
        operation))
-    ;; The delivery is settled only after the document revision containing the
-    ;; outbox entry is durable and publication has returned successfully.
-    (cl-rabbit:basic-ack connection 1 delivery-tag)))
+    (settlement-ack "outbox mutation persisted and published")))
 
 (defun handle-document (self message)
   (process-rabbit-document-mutation self message :new))
@@ -151,18 +154,16 @@
   (not (transient-p message)))
 
 (defun handle-target (self message)
-  (let ((connection
-          (rabbit-stream-connection (consumer-stream self)))
-        (body
+  (declare (ignore self))
+  (let ((body
           (star.documents:ensure-v09-document
            (car message)
-           :route-dtype "target"))
-        (delivery-tag (cdr message)))
+           :route-dtype "target")))
     (tell star.actors:*targets* (cons 1 body))
-    (cl-rabbit:basic-ack connection 1 delivery-tag)))
+    (settlement-ack "target submitted to local actor")))
 
 (defun start-consumers ()
-  (log:info "Starting crash-safe v0.9 document consumers.")
+  (log:info "Starting owner-thread v0.9 document consumers.")
   (let ((document-consumers
           (create-rabbit-consumer
            :name "documents-ingest"
@@ -175,7 +176,9 @@
            :host star:*rabbit-address*
            :port star:*rabbit-port*
            :handler-fn #'handle-document
-           :test-fn #'insertp))
+           :test-fn #'insertp
+           :on-error :retry
+           :on-filter :filtered-ack))
         (update-consumers
           (create-rabbit-consumer
            :name "documents-update"
@@ -188,7 +191,9 @@
            :host star:*rabbit-address*
            :port star:*rabbit-port*
            :handler-fn #'handle-update-document
-           :test-fn #'insertp))
+           :test-fn #'insertp
+           :on-error :retry
+           :on-filter :filtered-ack))
         (target-consumers
           (create-rabbit-consumer
            :name "documents-targets"
@@ -201,7 +206,9 @@
            :host star:*rabbit-address*
            :port star:*rabbit-port*
            :handler-fn #'handle-target
-           :test-fn #'insertp)))
+           :test-fn #'insertp
+           :on-error :retry
+           :on-filter :filtered-ack)))
     (start-consumer document-consumers)
     (start-consumer update-consumers)
     (start-consumer target-consumers)

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -9,6 +9,7 @@
   :entry-point "star::main"
   :components   ((:file "consumers/package")
                  (:file "consumers/consumers")
+                 (:file "consumers/owner-fixes")
                  (:file "producers/package")
                  (:file "producers/producers")
                  (:file "document-v09-package")

--- a/tests/run-consumer-owner-conformance.lisp
+++ b/tests/run-consumer-owner-conformance.lisp
@@ -1,0 +1,222 @@
+(in-package :cl-user)
+
+(defclass owner-test-stream ()
+  ((owner-thread
+    :initarg :owner-thread
+    :accessor owner-test-stream-owner-thread)
+   (settlements
+    :initform nil
+    :accessor owner-test-stream-settlements)
+   (settlement-threads
+    :initform nil
+    :accessor owner-test-stream-settlement-threads)))
+
+(defun owner-test-check (condition control &rest arguments)
+  (unless condition
+    (error (apply #'format nil control arguments))))
+
+(defmethod star.consumers:stream-settle
+    ((stream owner-test-stream) delivery settlement)
+  (declare (ignore delivery))
+  (let ((actual (bt:current-thread))
+        (expected (owner-test-stream-owner-thread stream)))
+    (unless (eq actual expected)
+      (error 'star.consumers:wrong-stream-owner
+             :expected expected
+             :actual actual))
+    (push settlement (owner-test-stream-settlements stream))
+    (push actual (owner-test-stream-settlement-threads stream))
+    settlement))
+
+(defun owner-test-consumer
+    (stream handler &key (filter #'identity)
+                         (on-error :retry)
+                         (on-filter :filtered-ack))
+  (star.consumers:make-consumer
+   :name "owner-test"
+   :stream stream
+   :fn handler
+   :test-fn filter
+   :on-error on-error
+   :on-filter on-filter))
+
+(defun owner-test-single-settlement (stream)
+  (let ((settlements (owner-test-stream-settlements stream)))
+    (owner-test-check (= 1 (length settlements))
+                      "Expected one settlement, got ~d"
+                      (length settlements))
+    (first settlements)))
+
+(defun test-handler-and-settlement-use-owner-thread ()
+  (let* ((owner (bt:current-thread))
+         (stream (make-instance 'owner-test-stream :owner-thread owner))
+         (handler-thread nil)
+         (consumer
+           (owner-test-consumer
+            stream
+            (lambda (self delivery)
+              (declare (ignore self delivery))
+              (setf handler-thread (bt:current-thread))
+              (star.consumers:settlement-ack "handled")))))
+    (star.consumers:consumer-process-delivery consumer '("body" . 1))
+    (let ((settlement (owner-test-single-settlement stream)))
+      (owner-test-check (eq owner handler-thread)
+                        "Handler ran outside the owner thread")
+      (owner-test-check
+       (every (lambda (thread) (eq owner thread))
+              (owner-test-stream-settlement-threads stream))
+       "Settlement ran outside the owner thread")
+      (owner-test-check
+       (eq :ack (star.consumers:consumer-settlement-action settlement))
+       "Expected ACK settlement")
+      (owner-test-check (= 0 (star.consumers:consumer-in-flight consumer))
+                        "In-flight metric did not return to zero")
+      (owner-test-check (= 0 (star.consumers:consumer-unsettled consumer))
+                        "Unsettled metric did not return to zero")
+      (owner-test-check
+       (= 1 (star.consumers:consumer-settlement-count consumer :ack))
+       "ACK metric was not incremented exactly once"))))
+
+(defun test-filtered-delivery-restores-prefetch-credit ()
+  (let* ((owner (bt:current-thread))
+         (stream (make-instance 'owner-test-stream :owner-thread owner))
+         (handler-called nil)
+         (consumer
+           (owner-test-consumer
+            stream
+            (lambda (self delivery)
+              (declare (ignore self delivery))
+              (setf handler-called t)
+              (star.consumers:settlement-ack))
+            :filter (lambda (delivery)
+                      (declare (ignore delivery))
+                      nil))))
+    (star.consumers:consumer-process-delivery consumer '("filtered" . 2))
+    (let ((settlement (owner-test-single-settlement stream)))
+      (owner-test-check (not handler-called)
+                        "Filtered delivery reached the handler")
+      (owner-test-check
+       (eq :filtered-ack
+           (star.consumers:consumer-settlement-action settlement))
+       "Filtered delivery was not ACKed")
+      (owner-test-check (= 0 (star.consumers:consumer-unsettled consumer))
+                        "Filtered delivery retained prefetch credit")
+      (owner-test-check
+       (= 1
+          (star.consumers:consumer-settlement-count
+           consumer :filtered-ack))
+       "Filtered ACK metric was not incremented exactly once"))))
+
+(defun test-handler-failure-settles-exactly-once ()
+  (let* ((owner (bt:current-thread))
+         (stream (make-instance 'owner-test-stream :owner-thread owner))
+         (handler-count 0)
+         (consumer
+           (owner-test-consumer
+            stream
+            (lambda (self delivery)
+              (declare (ignore self delivery))
+              (incf handler-count)
+              (error "forced handler failure"))
+            :on-error :dead-letter)))
+    (star.consumers:consumer-process-delivery consumer '("bad" . 3))
+    (let ((settlement (owner-test-single-settlement stream)))
+      (owner-test-check (= 1 handler-count)
+                        "Handler executed ~d times" handler-count)
+      (owner-test-check
+       (eq :dead-letter
+           (star.consumers:consumer-settlement-action settlement))
+       "Configured failure did not dead-letter")
+      (owner-test-check (= 1 (star.consumers:consumer-failures consumer))
+                        "Failure metric was not incremented")
+      (owner-test-check (= 0 (star.consumers:consumer-in-flight consumer))
+                        "Failed handler remained in flight")
+      (owner-test-check (= 0 (star.consumers:consumer-unsettled consumer))
+                        "Failed delivery remained unsettled")
+      (owner-test-check
+       (= 1
+          (star.consumers:consumer-settlement-count
+           consumer :dead-letter))
+       "Failure settlement metric was not exactly one"))))
+
+(defun test-wrong-thread-settlement-is-rejected ()
+  (let* ((owner (bt:current-thread))
+         (stream (make-instance 'owner-test-stream :owner-thread owner))
+         (condition nil)
+         (thread
+           (bt:make-thread
+            (lambda ()
+              (handler-case
+                  (star.consumers:stream-settle
+                   stream
+                   '("wrong" . 4)
+                   (star.consumers:settlement-ack))
+                (star.consumers:wrong-stream-owner (error)
+                  (setf condition error))))
+            :name "wrong-settlement-thread")))
+    (bt:join-thread thread)
+    (owner-test-check
+     (typep condition 'star.consumers:wrong-stream-owner)
+     "Wrong-thread settlement was accepted")
+    (owner-test-check
+     (null (owner-test-stream-settlements stream))
+     "Wrong-thread settlement mutated stream state")))
+
+(defun test-concurrent-workers-do-not-share-stream-or-channel ()
+  (let* ((configuration
+           (star.consumers:create-rabbit-consumer
+            :name "fresh-channel-test"
+            :n 2
+            :queue-name "fresh-channel-test"
+            :exchange-name "documents"
+            :routing-key "documents.test.#"
+            :handler-fn
+            (lambda (self delivery)
+              (declare (ignore self delivery))
+              (star.consumers:settlement-ack))))
+         (worker-a
+           (star.consumers:make-rabbit-worker-consumer configuration 1))
+         (worker-b
+           (star.consumers:make-rabbit-worker-consumer configuration 2))
+         (stream-a (star.consumers:consumer-stream worker-a))
+         (stream-b (star.consumers:consumer-stream worker-b))
+         (connection-a (list :connection-a))
+         (connection-b (list :connection-b))
+         (channel-a (list :channel-a))
+         (channel-b (list :channel-b)))
+    (setf (star.consumers:rabbit-stream-connection stream-a) connection-a
+          (star.consumers:rabbit-stream-connection stream-b) connection-b
+          (star.consumers:rabbit-stream-channel stream-a) channel-a
+          (star.consumers:rabbit-stream-channel stream-b) channel-b)
+    (owner-test-check (not (eq stream-a stream-b))
+                      "Concurrent workers share a stream object")
+    (owner-test-check
+     (not (eq (star.consumers:rabbit-stream-connection stream-a)
+              (star.consumers:rabbit-stream-connection stream-b)))
+     "Concurrent workers share a Rabbit connection")
+    (owner-test-check
+     (not (eq (star.consumers:rabbit-stream-channel stream-a)
+              (star.consumers:rabbit-stream-channel stream-b)))
+     "Concurrent workers share a Rabbit channel")))
+
+(defun test-structured-handler-actions-are-preserved ()
+  (dolist (action '(:ack :filtered-ack :retry :dead-letter :reject))
+    (let ((settlement (star.consumers:normalize-settlement action)))
+      (owner-test-check
+       (eq action (star.consumers:consumer-settlement-action settlement))
+       "Action ~s normalized to ~s"
+       action
+       (star.consumers:consumer-settlement-action settlement)))))
+
+(defun run-consumer-owner-conformance-tests ()
+  (format t "~&Running Rabbit owner-thread settlement tests~%")
+  (test-handler-and-settlement-use-owner-thread)
+  (test-filtered-delivery-restores-prefetch-credit)
+  (test-handler-failure-settles-exactly-once)
+  (test-wrong-thread-settlement-is-rejected)
+  (test-concurrent-workers-do-not-share-stream-or-channel)
+  (test-structured-handler-actions-are-preserved)
+  (format t "~&Rabbit owner-thread settlement tests passed~%")
+  t)
+
+(run-consumer-owner-conformance-tests)

--- a/tests/test_consumer_owner_contract.py
+++ b/tests/test_consumer_owner_contract.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RabbitOwnerContractTests(unittest.TestCase):
+    def test_consumer_does_not_dispatch_handlers_to_lparallel(self) -> None:
+        source = (ROOT / "source" / "consumers" / "consumers.lisp").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("submit-task", source)
+        self.assertNotIn("receive-result", source)
+        self.assertIn("consumer-process-delivery", source)
+        self.assertIn("stream-settle", source)
+
+    def test_structured_settlement_actions_exist(self) -> None:
+        source = (ROOT / "source" / "consumers" / "consumers.lisp").read_text(
+            encoding="utf-8"
+        )
+        for action in (":ack", ":filtered-ack", ":retry", ":dead-letter", ":reject"):
+            self.assertIn(action, source)
+        self.assertIn("consumer-settlement", source)
+        self.assertIn("consumer-in-flight", source)
+        self.assertIn("consumer-unsettled", source)
+
+    def test_rabbit_stream_has_an_explicit_owner(self) -> None:
+        source = (ROOT / "source" / "consumers" / "consumers.lisp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("rabbit-stream-owner-thread", source)
+        self.assertIn("assert-rabbit-stream-owner", source)
+        self.assertIn("wrong-stream-owner", source)
+        self.assertIn("make-rabbit-worker-consumer", source)
+        self.assertIn("fresh stream/connection owner", source)
+
+    def test_handlers_return_results_instead_of_settling_channels(self) -> None:
+        rabbit = (ROOT / "source" / "rabbit.lisp").read_text(encoding="utf-8")
+        event_actor = (
+            ROOT / "source" / "actor-systems" / "event-actor.lisp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("settlement-ack", rabbit)
+        self.assertIn("settlement-ack", event_actor)
+        handler_region = rabbit[rabbit.index("(defun process-rabbit-document-mutation") :]
+        self.assertNotIn("basic-ack", handler_region)
+        self.assertNotIn("basic-nack", handler_region)
+
+    def test_filtered_messages_default_to_filtered_ack(self) -> None:
+        source = (ROOT / "source" / "consumers" / "consumers.lisp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(":initform :filtered-ack", source)
+        self.assertIn("configured-filter-settlement", source)
+        self.assertIn("consumer filter declined delivery", source)
+
+    def test_acceptance_matrix_is_executable(self) -> None:
+        tests = (
+            ROOT / "tests" / "run-consumer-owner-conformance.lisp"
+        ).read_text(encoding="utf-8")
+        for name in (
+            "test-handler-and-settlement-use-owner-thread",
+            "test-filtered-delivery-restores-prefetch-credit",
+            "test-handler-failure-settles-exactly-once",
+            "test-wrong-thread-settlement-is-rejected",
+            "test-concurrent-workers-do-not-share-stream-or-channel",
+        ):
+            self.assertIn(name, tests)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the lparallel handler handoff from Rabbit consumers
- give every Rabbit worker a fresh stream, connection, channel, and explicit owner thread
- run consume, filter, handler, and ACK/NACK settlement on that owner thread
- replace implicit handler behavior with structured settlement results: ACK, filtered-ACK, retry, dead-letter, and reject
- settle filtered messages by default so prefetch credit is restored
- make document, update, target, and event handlers return settlement values instead of touching Rabbit connections
- add per-worker in-flight, unsettled, failure, and settlement-action metrics
- reject channel operations from non-owner threads
- preserve exactly-once settlement attempts per delivery

## Design

Each configured Rabbit consumer creates one independent worker object per requested concurrency slot. Every worker opens and owns its own connection/channel inside its thread. No channel object crosses into an lparallel task or actor callback.

Handlers return `consumer-settlement` objects. The owner loop maps them to Rabbit operations:

- `:ack` / `:filtered-ack` → ACK
- `:retry` → NACK with requeue
- `:dead-letter` / `:reject` → NACK without requeue

## Regression coverage

- handler and settlement execute on the same owner thread
- filtered deliveries settle and restore unsettled/prefetch accounting
- handler failure produces the configured settlement exactly once
- wrong-thread settlement is rejected without mutating stream state
- concurrent workers receive distinct streams, connections, and channels
- every structured settlement action survives normalization

## Stack

- base: `agent/schema-org-v0.9`
- includes completed issues #11–#14

This remains draft until the fixture and CLOS owner-thread conformance gates are green.

Closes #15