### PR TITLE
Add bounded Rabbit retries and durable quarantine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN qlot exec sbcl --non-interactive \
     --load tests/run-document-conformance.lisp \
     --load tests/run-server-codec-conformance.lisp \
     --load tests/run-outbox-conformance.lisp \
-    --load tests/run-consumer-owner-conformance.lisp
+    --load tests/run-consumer-owner-conformance.lisp \
+    --load tests/run-retry-quarantine-conformance.lisp
 
 FROM conformance AS star-server
 

--- a/source/actor-systems/event-actor.lisp
+++ b/source/actor-systems/event-actor.lisp
@@ -25,18 +25,27 @@
                   :database star:*couchdb-event-log-database*
                   :document event-json)))))
 
+(defun decode-actor-event-delivery (message)
+  (handler-case
+      (let ((json-document
+              (jsown:with-injective-reader
+                (jsown:parse (car message)))))
+        (star.databases.couchdb:from-json json-document 'actor-event))
+    (star.consumers:delivery-processing-error (condition)
+      (error condition))
+    (error (condition)
+      (error 'star.consumers:schema-invalid-delivery-error
+             :cause condition
+             :reason (princ-to-string condition)))))
+
 (defun handle-event-message (self message)
   "Decode one event delivery and return settlement to the Rabbit owner thread."
   (declare (ignore self))
-  (let ((json-document
-          (jsown:with-injective-reader
-            (jsown:parse (car message)))))
-    (tell *actor-event-receiver*
-          (star.databases.couchdb:from-json json-document 'actor-event))
-    (star.consumers:settlement-ack "actor event accepted")))
+  (tell *actor-event-receiver* (decode-actor-event-delivery message))
+  (star.consumers:settlement-ack "actor event accepted"))
 
 (defun start-event-consumer (n)
-  "Initialize owner-thread event consumers."
+  "Initialize bounded-retry owner-thread event consumers."
   (let ((consumer
           (star.consumers:create-rabbit-consumer
            :name "event-consumers"
@@ -50,8 +59,15 @@
            :routing-key "event.#"
            :test-fn #'identity
            :handler-fn #'handle-event-message
-           :on-error :dead-letter
-           :on-filter :filtered-ack)))
+           :on-error :retry
+           :on-filter :filtered-ack
+           :max-retries star:*rabbit-max-retries*
+           :retry-base-delay-ms star:*rabbit-retry-base-delay-ms*
+           :retry-max-delay-ms star:*rabbit-retry-max-delay-ms*
+           :retry-jitter-ratio star:*rabbit-retry-jitter-ratio*
+           :quarantine-fn #'star.rabbit:persist-quarantine-record
+           :quarantine-exchange star:*rabbit-quarantine-exchange*
+           :quarantine-queue star:*rabbit-quarantine-queue*)))
     (star.consumers:start-consumer consumer)))
 
 (defun log-actor-event (actor-name &key event-type details source-id)

--- a/source/consumers/package.lisp
+++ b/source/consumers/package.lisp
@@ -1,6 +1,6 @@
 (uiop:define-package :star.consumers
   (:use :cl)
-  (:documentation "Owner-thread stream consumers with explicit settlement results.")
+  (:documentation "Owner-thread Rabbit consumers with bounded retries and quarantine.")
   (:export
    #:consumer
    #:consumer-name
@@ -71,4 +71,43 @@
    #:stream-read
    #:rabbit-consumer
    #:make-rabbit-worker-consumer
-   #:create-rabbit-consumer))
+   #:create-rabbit-consumer
+   #:retry-policy
+   #:make-retry-policy
+   #:retry-policy-max-retries
+   #:retry-policy-base-delay-ms
+   #:retry-policy-max-delay-ms
+   #:retry-policy-jitter-ratio
+   #:retry-delay-ms
+   #:retry-action-for
+   #:delivery-processing-error
+   #:delivery-error-cause
+   #:delivery-error-reason
+   #:delivery-error-class
+   #:delivery-error-retryable-p
+   #:transient-delivery-error
+   #:permanent-delivery-error
+   #:conflict-delivery-error
+   #:unauthorized-delivery-error
+   #:schema-invalid-delivery-error
+   #:internal-delivery-error
+   #:classify-delivery-condition
+   #:retrying-rabbit-consumer
+   #:retrying-rabbit-queue-stream
+   #:retry-consumer-policy
+   #:retry-stream-policy
+   #:retry-stream-current-body
+   #:retry-stream-current-properties
+   #:retry-stream-current-routing-key
+   #:retry-stream-current-exchange
+   #:retry-stream-current-received-at
+   #:delivery-attempt
+   #:delivery-trace-id
+   #:delivery-message-id
+   #:delivery-first-seen-at
+   #:rabbit-property
+   #:rabbit-header
+   #:retry-properties
+   #:quarantine-record
+   #:quarantine-replay-envelope
+   #:*retry-sleep-function*))

--- a/source/consumers/retry-policy.lisp
+++ b/source/consumers/retry-policy.lisp
@@ -1,0 +1,560 @@
+(in-package :star.consumers)
+
+(defparameter *retry-sleep-function* #'sleep)
+
+(defstruct (retry-policy
+             (:constructor make-retry-policy
+                 (&key
+                    (max-retries 4)
+                    (base-delay-ms 250)
+                    (max-delay-ms 30000)
+                    (jitter-ratio 0.20d0))))
+  (max-retries 4 :type (integer 0 *))
+  (base-delay-ms 250 :type (integer 0 *))
+  (max-delay-ms 30000 :type (integer 0 *))
+  (jitter-ratio 0.20d0 :type (real 0 1)))
+
+(define-condition delivery-processing-error (error)
+  ((cause
+    :initarg :cause
+    :reader delivery-error-cause
+    :initform nil)
+   (reason
+    :initarg :reason
+    :reader delivery-error-reason
+    :initform "delivery processing failed"))
+  (:report
+   (lambda (condition stream)
+     (format stream "~a" (delivery-error-reason condition)))))
+
+(define-condition transient-delivery-error (delivery-processing-error) ())
+(define-condition permanent-delivery-error (delivery-processing-error) ())
+(define-condition conflict-delivery-error (permanent-delivery-error) ())
+(define-condition unauthorized-delivery-error (permanent-delivery-error) ())
+(define-condition schema-invalid-delivery-error (permanent-delivery-error) ())
+(define-condition internal-delivery-error (transient-delivery-error) ())
+
+(defun delivery-error-class (condition)
+  (etypecase condition
+    (schema-invalid-delivery-error :schema-invalid)
+    (unauthorized-delivery-error :unauthorized)
+    (conflict-delivery-error :conflict)
+    (internal-delivery-error :internal)
+    (transient-delivery-error :transient)
+    (permanent-delivery-error :permanent)
+    (delivery-processing-error :internal)))
+
+(defun delivery-error-retryable-p (condition)
+  (typep condition 'transient-delivery-error))
+
+(defun condition-class-name (condition)
+  (string-upcase
+   (symbol-name (class-name (class-of condition)))))
+
+(defun condition-name-contains-p (condition fragment)
+  (not (null (search (string-upcase fragment)
+                     (condition-class-name condition)))))
+
+(defun classify-delivery-condition (condition)
+  "Convert arbitrary handler conditions to the server failure taxonomy."
+  (cond
+    ((typep condition 'delivery-processing-error)
+     condition)
+    ((or (condition-name-contains-p condition "UNAUTHORIZED")
+         (condition-name-contains-p condition "FORBIDDEN"))
+     (make-condition 'unauthorized-delivery-error
+                     :cause condition
+                     :reason (princ-to-string condition)))
+    ((or (condition-name-contains-p condition "MUTATION-CONFLICT")
+         (condition-name-contains-p condition "MISSING-DOCUMENT-FOR-UPDATE")
+         (condition-name-contains-p condition "HTTP-REQUEST-CONFLICT"))
+     (make-condition 'conflict-delivery-error
+                     :cause condition
+                     :reason (princ-to-string condition)))
+    ((or (condition-name-contains-p condition "V09-DOCUMENT-ERROR")
+         (condition-name-contains-p condition "DOCUMENT-VALIDATION")
+         (condition-name-contains-p condition "SCHEMA"))
+     (make-condition 'schema-invalid-delivery-error
+                     :cause condition
+                     :reason (princ-to-string condition)))
+    ((or (condition-name-contains-p condition "TIMEOUT")
+         (condition-name-contains-p condition "CONNECTION")
+         (condition-name-contains-p condition "RABBITMQ")
+         (condition-name-contains-p condition "OUTBOX-STORE-CONFLICT"))
+     (make-condition 'transient-delivery-error
+                     :cause condition
+                     :reason (princ-to-string condition)))
+    (t
+     (make-condition 'internal-delivery-error
+                     :cause condition
+                     :reason (princ-to-string condition)))))
+
+(defun rabbit-property (properties key &optional default)
+  (let ((entry (assoc key properties :test #'eq)))
+    (if entry (cdr entry) default)))
+
+(defun copy-rabbit-properties (properties)
+  (loop for (key . value) in properties
+        collect (cons key
+                      (if (and (eq key :headers) (listp value))
+                          (copy-tree value)
+                          value))))
+
+(defun rabbit-headers (properties)
+  (or (rabbit-property properties :headers) nil))
+
+(defun header-name= (left right)
+  (string-equal (string left) (string right)))
+
+(defun rabbit-header (properties name &optional default)
+  (let ((entry (assoc name (rabbit-headers properties) :test #'header-name=)))
+    (if entry (cdr entry) default)))
+
+(defun set-rabbit-header (properties name value)
+  (let* ((copy (copy-rabbit-properties properties))
+         (headers (copy-tree (or (rabbit-property copy :headers) nil)))
+         (entry (assoc name headers :test #'header-name=)))
+    (if entry
+        (setf (cdr entry) value)
+        (push (cons name value) headers))
+    (let ((property-entry (assoc :headers copy :test #'eq)))
+      (if property-entry
+          (setf (cdr property-entry) headers)
+          (push (cons :headers headers) copy)))
+    copy))
+
+(defun set-rabbit-property (properties key value)
+  (let* ((copy (copy-rabbit-properties properties))
+         (entry (assoc key copy :test #'eq)))
+    (if entry
+        (setf (cdr entry) value)
+        (push (cons key value) copy))
+    copy))
+
+(defun delivery-attempt (properties)
+  (let ((value (rabbit-header properties "x-starintel-attempt" 0)))
+    (if (and (integerp value) (not (minusp value))) value 0)))
+
+(defun delivery-trace-id (properties)
+  (or (rabbit-header properties "x-starintel-trace-id")
+      (rabbit-property properties :correlation-id)
+      (cms-ulid:ulid)))
+
+(defun delivery-message-id (properties)
+  (or (rabbit-property properties :message-id)
+      (cms-ulid:ulid)))
+
+(defun delivery-first-seen-at (properties)
+  (or (rabbit-header properties "x-starintel-first-seen-at")
+      (spec:utc-now)))
+
+(defun append-attempt-history (properties attempt timestamp)
+  (let* ((existing
+           (rabbit-header properties "x-starintel-attempt-history" ""))
+         (entry (format nil "~d@~a" attempt timestamp))
+         (value (if (or (null existing) (string= existing ""))
+                    entry
+                    (format nil "~a,~a" existing entry))))
+    (set-rabbit-header properties "x-starintel-attempt-history" value)))
+
+(defun retry-properties (properties stream next-attempt delay-ms)
+  (let* ((timestamp (spec:utc-now))
+         (trace-id (delivery-trace-id properties))
+         (message-id (delivery-message-id properties))
+         (copy (set-rabbit-property properties :delivery-mode 2)))
+    (setf copy (set-rabbit-property copy :message-id message-id)
+          copy (set-rabbit-property copy :correlation-id trace-id)
+          copy (set-rabbit-header copy "x-starintel-attempt" next-attempt)
+          copy (set-rabbit-header copy "x-starintel-trace-id" trace-id)
+          copy (set-rabbit-header copy "x-starintel-first-seen-at"
+                                  (delivery-first-seen-at properties))
+          copy (set-rabbit-header copy "x-starintel-original-exchange"
+                                  (retry-stream-current-exchange stream))
+          copy (set-rabbit-header copy "x-starintel-original-routing-key"
+                                  (retry-stream-current-routing-key stream))
+          copy (set-rabbit-header copy "x-starintel-retry-delay-ms" delay-ms)
+          copy (append-attempt-history copy next-attempt timestamp))
+    copy))
+
+(defun retry-delay-ms (policy attempt &optional random-unit)
+  "Return capped exponential delay with symmetric jitter.
+
+ATTEMPT is the zero-based attempt that just failed. RANDOM-UNIT may be supplied
+by tests and must be between zero and one."
+  (let* ((base (retry-policy-base-delay-ms policy))
+         (cap (retry-policy-max-delay-ms policy))
+         (raw (min cap (* base (expt 2 attempt))))
+         (ratio (retry-policy-jitter-ratio policy))
+         (unit (or random-unit (random 1.0d0)))
+         (factor (+ 1.0d0 (* ratio (- (* 2.0d0 unit) 1.0d0)))))
+    (round (max 0 (* raw factor)))))
+
+(defun retry-action-for (policy failure attempt)
+  (if (and (delivery-error-retryable-p failure)
+           (< attempt (retry-policy-max-retries policy)))
+      :retry
+      :dead-letter))
+
+(defclass retrying-rabbit-queue-stream (rabbit-queue-stream)
+  ((retry-policy
+    :initarg :retry-policy
+    :accessor retry-stream-policy
+    :initform (make-retry-policy))
+   (quarantine-fn
+    :initarg :quarantine-fn
+    :accessor retry-stream-quarantine-fn
+    :initform nil)
+   (quarantine-exchange
+    :initarg :quarantine-exchange
+    :accessor retry-stream-quarantine-exchange
+    :initform "starintel.quarantine")
+   (quarantine-queue
+    :initarg :quarantine-queue
+    :accessor retry-stream-quarantine-queue
+    :initform "starintel-quarantine")
+   (current-body
+    :accessor retry-stream-current-body
+    :initform nil)
+   (current-properties
+    :accessor retry-stream-current-properties
+    :initform nil)
+   (current-routing-key
+    :accessor retry-stream-current-routing-key
+    :initform "")
+   (current-exchange
+    :accessor retry-stream-current-exchange
+    :initform "")
+   (current-received-at
+    :accessor retry-stream-current-received-at
+    :initform nil)))
+
+(defclass retrying-rabbit-consumer (rabbit-consumer)
+  ((retry-policy
+    :initarg :retry-policy
+    :accessor retry-consumer-policy
+    :initform (make-retry-policy))
+   (quarantine-fn
+    :initarg :quarantine-fn
+    :accessor retry-consumer-quarantine-fn
+    :initform nil)
+   (quarantine-exchange
+    :initarg :quarantine-exchange
+    :accessor retry-consumer-quarantine-exchange
+    :initform "starintel.quarantine")
+   (quarantine-queue
+    :initarg :quarantine-queue
+    :accessor retry-consumer-quarantine-queue
+    :initform "starintel-quarantine")))
+
+(defmethod open-stream ((stream retrying-rabbit-queue-stream))
+  (call-next-method)
+  (let ((connection (rabbit-stream-connection stream))
+        (channel (rabbit-stream-channel stream))
+        (exchange (retry-stream-quarantine-exchange stream))
+        (queue (retry-stream-quarantine-queue stream)))
+    (cl-rabbit:exchange-declare
+     connection channel exchange "topic" :durable t)
+    (cl-rabbit:queue-declare
+     connection channel :queue queue :durable t)
+    (cl-rabbit:queue-bind
+     connection channel
+     :queue queue
+     :exchange exchange
+     :routing-key "quarantine.#"))
+  stream)
+
+(defmethod consumer-read ((consumer retrying-rabbit-consumer))
+  (let* ((stream (consumer-stream consumer))
+         (envelope (stream-read stream))
+         (message (cl-rabbit:envelope/message envelope))
+         (body
+           (babel:octets-to-string
+            (cl-rabbit:message/body message)
+            :encoding :utf-8)))
+    (setf (retry-stream-current-body stream) body
+          (retry-stream-current-properties stream)
+          (cl-rabbit:message/properties message)
+          (retry-stream-current-routing-key stream)
+          (cl-rabbit:envelope/routing-key envelope)
+          (retry-stream-current-exchange stream)
+          (cl-rabbit:envelope/exchange envelope)
+          (retry-stream-current-received-at stream)
+          (spec:utc-now))
+    (cons body (cl-rabbit:envelope/delivery-tag envelope))))
+
+(defun current-delivery-attempt (consumer)
+  (let ((stream (consumer-stream consumer)))
+    (if (typep stream 'retrying-rabbit-queue-stream)
+        (delivery-attempt (retry-stream-current-properties stream))
+        0)))
+
+(defun configured-failure-settlement (consumer condition)
+  (if (typep consumer 'retrying-rabbit-consumer)
+      (let* ((failure (classify-delivery-condition condition))
+             (attempt (current-delivery-attempt consumer))
+             (action
+               (retry-action-for
+                (retry-consumer-policy consumer)
+                failure
+                attempt)))
+        (make-settlement action
+                         :reason (delivery-error-reason failure)
+                         :condition failure))
+      (make-settlement
+       (consumer-failure-action consumer)
+       :reason (princ-to-string condition)
+       :condition condition)))
+
+(defun json-safe-value (value)
+  (typecase value
+    (null :null)
+    (string value)
+    (integer value)
+    (float value)
+    ((member t) :true)
+    (symbol (string-downcase (symbol-name value)))
+    (t (princ-to-string value))))
+
+(defun rabbit-properties-json (properties)
+  (let ((object (jsown:empty-object)))
+    (dolist (entry properties object)
+      (let ((key (string-downcase (symbol-name (car entry))))
+            (value (cdr entry)))
+        (if (eq (car entry) :headers)
+            (let ((headers (jsown:empty-object)))
+              (dolist (header value)
+                (setf (jsown:val headers (string (car header)))
+                      (json-safe-value (cdr header))))
+              (setf (jsown:val object key) headers))
+            (setf (jsown:val object key) (json-safe-value value)))))))
+
+(defun quarantine-record (stream settlement)
+  (let* ((properties (retry-stream-current-properties stream))
+         (failure
+           (classify-delivery-condition
+            (or (consumer-settlement-condition settlement)
+                (make-condition 'permanent-delivery-error
+                                :reason (or (consumer-settlement-reason settlement)
+                                            "delivery rejected")))))
+         (attempt (delivery-attempt properties))
+         (record (jsown:empty-object)))
+    (setf (jsown:val record "_id")
+          (format nil "quarantine:~a" (cms-ulid:ulid))
+          (jsown:val record "type") "_server_quarantine"
+          (jsown:val record "status") "quarantined"
+          (jsown:val record "failure_class")
+          (string-downcase (symbol-name (delivery-error-class failure)))
+          (jsown:val record "failure_reason")
+          (delivery-error-reason failure)
+          (jsown:val record "condition_type")
+          (condition-class-name failure)
+          (jsown:val record "original_exchange")
+          (retry-stream-current-exchange stream)
+          (jsown:val record "original_routing_key")
+          (retry-stream-current-routing-key stream)
+          (jsown:val record "message_id")
+          (delivery-message-id properties)
+          (jsown:val record "trace_id")
+          (delivery-trace-id properties)
+          (jsown:val record "attempt_count") attempt
+          (jsown:val record "first_seen_at")
+          (delivery-first-seen-at properties)
+          (jsown:val record "received_at")
+          (or (retry-stream-current-received-at stream) (spec:utc-now))
+          (jsown:val record "failed_at") (spec:utc-now)
+          (jsown:val record "replayed_at") :null
+          (jsown:val record "replay_count") 0
+          (jsown:val record "original_body")
+          (or (retry-stream-current-body stream) "")
+          (jsown:val record "original_properties")
+          (rabbit-properties-json properties))
+    record))
+
+(defun ack-rabbit-delivery (stream delivery)
+  (cl-rabbit:basic-ack
+   (rabbit-stream-connection stream)
+   (rabbit-stream-channel stream)
+   (rabbit-delivery-tag delivery)))
+
+(defun republish-retry (stream delivery settlement)
+  (declare (ignore settlement))
+  (let* ((properties (retry-stream-current-properties stream))
+         (attempt (delivery-attempt properties))
+         (next-attempt (1+ attempt))
+         (delay-ms (retry-delay-ms (retry-stream-policy stream) attempt))
+         (next-properties
+           (retry-properties properties stream next-attempt delay-ms)))
+    (funcall *retry-sleep-function* (/ delay-ms 1000.0d0))
+    (cl-rabbit:basic-publish
+     (rabbit-stream-connection stream)
+     (rabbit-stream-channel stream)
+     :exchange (retry-stream-current-exchange stream)
+     :routing-key (retry-stream-current-routing-key stream)
+     :properties next-properties
+     :body (retry-stream-current-body stream))
+    (ack-rabbit-delivery stream delivery)))
+
+(defun publish-quarantine-record (stream record)
+  (cl-rabbit:basic-publish
+   (rabbit-stream-connection stream)
+   (rabbit-stream-channel stream)
+   :exchange (retry-stream-quarantine-exchange stream)
+   :routing-key
+   (format nil "quarantine.~a"
+           (jsown:val record "failure_class"))
+   :properties
+   (list (cons :content-type "application/json")
+         (cons :delivery-mode 2)
+         (cons :message-id (jsown:val record "_id"))
+         (cons :correlation-id (jsown:val record "trace_id")))
+   :body (jsown:to-json record)))
+
+(defun persist-and-publish-quarantine (stream delivery settlement)
+  (let ((record (quarantine-record stream settlement)))
+    (when (retry-stream-quarantine-fn stream)
+      (funcall (retry-stream-quarantine-fn stream) record))
+    (publish-quarantine-record stream record)
+    (ack-rabbit-delivery stream delivery)
+    record))
+
+(defmethod stream-settle
+    ((stream retrying-rabbit-queue-stream) delivery settlement)
+  (assert-rabbit-stream-owner stream)
+  (ecase (consumer-settlement-action settlement)
+    ((:ack :filtered-ack)
+     (ack-rabbit-delivery stream delivery))
+    (:retry
+     (republish-retry stream delivery settlement))
+    ((:dead-letter :reject)
+     (persist-and-publish-quarantine stream delivery settlement)))
+  settlement)
+
+(defun make-rabbit-worker-consumer (consumer worker-number)
+  "Clone retry configuration while preserving one stream per owner thread."
+  (let ((stream (consumer-stream consumer)))
+    (make-instance
+     'retrying-rabbit-consumer
+     :name (format nil "~a-~d" (consumer-name consumer) worker-number)
+     :workers 1
+     :stream
+     (make-instance
+      'retrying-rabbit-queue-stream
+      :queue-name (rabbit-stream-queue-name stream)
+      :exchange-name (rabbit-stream-exchange stream)
+      :exchange-type (rabbit-exchange-type stream)
+      :exchange-durable (rabbit-exchange-durable-p stream)
+      :routing-key (rabbit-stream-routing-key stream)
+      :host (rabbit-stream-host stream)
+      :port (rabbit-stream-port stream)
+      :user (rabbit-stream-user stream)
+      :password (rabbit-stream-password stream)
+      :vhost (rabbit-stream-vhost stream)
+      :queue-durable (rabbit-stream-queue-durable-p stream)
+      :prefetch-count (rabbit-stream-prefetch-count stream)
+      :retry-policy (retry-consumer-policy consumer)
+      :quarantine-fn (retry-consumer-quarantine-fn consumer)
+      :quarantine-exchange (retry-consumer-quarantine-exchange consumer)
+      :quarantine-queue (retry-consumer-quarantine-queue consumer))
+     :fn (consumer-fn consumer)
+     :test-fn (consumer-filter consumer)
+     :on-error (consumer-failure-action consumer)
+     :on-filter (consumer-filtered-action consumer)
+     :retry-policy (retry-consumer-policy consumer)
+     :quarantine-fn (retry-consumer-quarantine-fn consumer)
+     :quarantine-exchange (retry-consumer-quarantine-exchange consumer)
+     :quarantine-queue (retry-consumer-quarantine-queue consumer))))
+
+(defun create-rabbit-consumer
+    (&key
+       (name (error "Consumer name is required"))
+       (n 1)
+       (queue-name (error "Queue name is required"))
+       (exchange-name "documents")
+       (exchange-type "topic")
+       (exchange-durable t)
+       (routing-key (error "Routing key is required"))
+       (host "localhost")
+       (port 5672)
+       (username "guest")
+       (password "guest")
+       (vhost "/")
+       (queue-durable t)
+       (prefetch-count 200)
+       (on-error :retry)
+       (on-filter :filtered-ack)
+       (max-retries 4)
+       (retry-base-delay-ms 250)
+       (retry-max-delay-ms 30000)
+       (retry-jitter-ratio 0.20d0)
+       quarantine-fn
+       (quarantine-exchange "starintel.quarantine")
+       (quarantine-queue "starintel-quarantine")
+       (test-fn #'identity)
+       (handler-fn (error "Handler function is required")))
+  (unless (plusp n)
+    (error "Rabbit consumer worker count must be positive"))
+  (let ((policy
+          (make-retry-policy
+           :max-retries max-retries
+           :base-delay-ms retry-base-delay-ms
+           :max-delay-ms retry-max-delay-ms
+           :jitter-ratio retry-jitter-ratio)))
+    (make-instance
+     'retrying-rabbit-consumer
+     :name (string-downcase (string name))
+     :stream
+     (make-instance
+      'retrying-rabbit-queue-stream
+      :queue-name queue-name
+      :exchange-name exchange-name
+      :exchange-type exchange-type
+      :exchange-durable exchange-durable
+      :routing-key routing-key
+      :host host
+      :port port
+      :user username
+      :password password
+      :vhost vhost
+      :queue-durable queue-durable
+      :prefetch-count prefetch-count
+      :retry-policy policy
+      :quarantine-fn quarantine-fn
+      :quarantine-exchange quarantine-exchange
+      :quarantine-queue quarantine-queue)
+     :workers n
+     :fn handler-fn
+     :test-fn test-fn
+     :on-error on-error
+     :on-filter on-filter
+     :retry-policy policy
+     :quarantine-fn quarantine-fn
+     :quarantine-exchange quarantine-exchange
+     :quarantine-queue quarantine-queue)))
+
+(defun quarantine-replay-envelope (record &key corrected-body)
+  "Return BODY, PROPERTIES, EXCHANGE, and ROUTING-KEY for explicit replay."
+  (let* ((now (spec:utc-now))
+         (old-trace (jsown:val record "trace_id"))
+         (new-trace (cms-ulid:ulid))
+         (replay-count (1+ (or (jsown:val-safe record "replay_count") 0)))
+         (headers
+           (list
+            (cons "x-starintel-attempt" 0)
+            (cons "x-starintel-trace-id" new-trace)
+            (cons "x-starintel-parent-trace-id" old-trace)
+            (cons "x-starintel-first-seen-at" now)
+            (cons "x-starintel-attempt-history" "")
+            (cons "x-starintel-replay-of" (jsown:val record "_id"))
+            (cons "x-starintel-replay-count" replay-count)))
+         (properties
+           (list
+            (cons :content-type "application/json")
+            (cons :delivery-mode 2)
+            (cons :message-id (cms-ulid:ulid))
+            (cons :correlation-id new-trace)
+            (cons :headers headers))))
+    (values
+     (or corrected-body (jsown:val record "original_body"))
+     properties
+     (jsown:val record "original_exchange")
+     (jsown:val record "original_routing_key"))))

--- a/source/databases/quarantine.lisp
+++ b/source/databases/quarantine.lisp
@@ -1,0 +1,87 @@
+(in-package :star.databases.couchdb)
+
+(defun couchdb-save-quarantine-record (client database record)
+  "Persist one server-internal quarantine record before Rabbit settlement."
+  (let* ((response
+           (jsown:parse
+            (cl-couch:create-document
+             client database (jsown:to-json record))))
+         (saved (clone-outbox-json record)))
+    (when (outbox-object-has-key-p response "rev")
+      (setf (jsown:val saved "_rev") (jsown:val response "rev")))
+    saved))
+
+(defun couchdb-get-quarantine-record (client database quarantine-id)
+  (jsown:with-injective-reader
+    (jsown:parse
+     (cl-couch:get-document client database quarantine-id))))
+
+(defun couchdb-list-quarantine-records
+    (client database &key (status "quarantined") (limit 100))
+  "Return quarantine documents ordered by failure time through the checked-in view."
+  (let* ((result
+           (query-view client database "quarantine" "by_status"
+                       :start-key (vector status "")
+                       :end-key (vector status (string #\U10FFFF))
+                       :include-docs t
+                       :reduce nil
+                       :limit limit))
+         (rows (jsown:val result "rows")))
+    (loop for row in rows
+          collect (jsown:val row "doc"))))
+
+(defun update-quarantine-record
+    (client database quarantine-id updater &key (max-attempts 8))
+  (loop for attempt from 1 to max-attempts
+        do
+           (let* ((current
+                    (couchdb-get-quarantine-record
+                     client database quarantine-id))
+                  (updated (funcall updater (clone-outbox-json current))))
+             (handler-case
+                 (return
+                   (let* ((response
+                            (jsown:parse
+                             (cl-couch:create-document
+                              client database (jsown:to-json updated))))
+                          (saved (clone-outbox-json updated)))
+                     (when (outbox-object-has-key-p response "rev")
+                       (setf (jsown:val saved "_rev")
+                             (jsown:val response "rev")))
+                     saved))
+               (dexador:http-request-conflict ()
+                 (when (= attempt max-attempts)
+                   (error "Quarantine update conflict budget exhausted for ~a"
+                          quarantine-id)))))))
+
+(defun mark-quarantine-replayed
+    (client database quarantine-id new-trace-id)
+  (update-quarantine-record
+   client database quarantine-id
+   (lambda (record)
+     (setf (jsown:val record "status") "replayed"
+           (jsown:val record "replayed_at") (spec:utc-now)
+           (jsown:val record "replay_count")
+           (1+ (or (jsown:val-safe record "replay_count") 0))
+           (jsown:val record "last_replay_trace_id") new-trace-id)
+     record)))
+
+(defun replay-quarantine-record
+    (client database quarantine-id publish-fn &key corrected-body)
+  "Explicitly replay a quarantined delivery with fresh attempt history.
+
+PUBLISH-FN receives EXCHANGE, ROUTING-KEY, BODY, and PROPERTIES. The stored
+record is marked replayed only after publishing returns successfully."
+  (let ((record
+          (couchdb-get-quarantine-record client database quarantine-id)))
+    (unless (string= "quarantined" (jsown:val record "status"))
+      (error "Quarantine record ~a is not replayable from status ~a"
+             quarantine-id
+             (jsown:val record "status")))
+    (multiple-value-bind (body properties exchange routing-key)
+        (star.consumers:quarantine-replay-envelope
+         record :corrected-body corrected-body)
+      (funcall publish-fn exchange routing-key body properties)
+      (mark-quarantine-replayed
+       client database quarantine-id
+       (star.consumers:delivery-trace-id properties)))))

--- a/source/databases/quarantine.lisp
+++ b/source/databases/quarantine.lisp
@@ -18,11 +18,10 @@
 
 (defun couchdb-list-quarantine-records
     (client database &key (status "quarantined") (limit 100))
-  "Return quarantine documents ordered by failure time through the checked-in view."
+  "Return quarantine documents through the checked-in status view."
   (let* ((result
            (query-view client database "quarantine" "by_status"
-                       :start-key (vector status "")
-                       :end-key (vector status (string #\U10FFFF))
+                       :key status
                        :include-docs t
                        :reduce nil
                        :limit limit))

--- a/source/gserver-settings.lisp
+++ b/source/gserver-settings.lisp
@@ -35,7 +35,7 @@
 ;; HTTP API configuration
 (defparameter *http-api-address* +default-http-api-address+
   "The address on which the HTTP API listens.")
-(defparameter *http-api-port* 5000  "Port for the HTTP API.")
+(defparameter *http-api-port* 5000 "Port for the HTTP API.")
 (defparameter *http-api-base-path* "/api" "Base URL for the API endpoint.")
 (defparameter *http-cert-file* nil "Path to the HTTPS cert file.")
 (defparameter *http-key-file* nil "Path to the HTTPS key file.")
@@ -50,6 +50,18 @@
   "The RabbitMQ user name.")
 (defparameter *rabbit-password* +default-rabbit-password+
   "The RabbitMQ user password.")
+(defparameter *rabbit-max-retries* 4
+  "Maximum republished attempts after the original delivery.")
+(defparameter *rabbit-retry-base-delay-ms* 250
+  "Initial retry delay in milliseconds.")
+(defparameter *rabbit-retry-max-delay-ms* 30000
+  "Maximum exponential retry delay in milliseconds.")
+(defparameter *rabbit-retry-jitter-ratio* 0.20d0
+  "Symmetric retry jitter ratio.")
+(defparameter *rabbit-quarantine-exchange* "starintel.quarantine"
+  "Durable topic exchange receiving structured dead-letter records.")
+(defparameter *rabbit-quarantine-queue* "starintel-quarantine"
+  "Durable queue used for poison-message inspection.")
 
 ;; Other configurations
 (defparameter *slynk-port* +default-slynk-port+

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -6,6 +6,12 @@
    #:*rabbit-user*
    #:*rabbit-port*
    #:*rabbit-address*
+   #:*rabbit-max-retries*
+   #:*rabbit-retry-base-delay-ms*
+   #:*rabbit-retry-max-delay-ms*
+   #:*rabbit-retry-jitter-ratio*
+   #:*rabbit-quarantine-exchange*
+   #:*rabbit-quarantine-queue*
    #:*http-scheme*
    #:*http-key-file*
    #:*http-cert-file*
@@ -85,25 +91,35 @@
    #:missing-document-for-update
    #:couchdb-process-outbox-mutation
    #:couchdb-pending-outbox-documents
-   #:recover-couchdb-outbox)
-  (:documentation "CouchDB persistence, query, and outbox support."))
+   #:recover-couchdb-outbox
+   #:couchdb-save-quarantine-record
+   #:couchdb-get-quarantine-record
+   #:couchdb-list-quarantine-records
+   #:update-quarantine-record
+   #:mark-quarantine-replayed
+   #:replay-quarantine-record)
+  (:documentation "CouchDB persistence, query, outbox, and quarantine support."))
 
 (uiop:define-package :star.rabbit
   (:use :cl :star.consumers :sento.actor)
-  (:documentation "RabbitMQ document transport.")
+  (:documentation "RabbitMQ document transport with bounded retries and quarantine.")
   (:export
-   #:with-rabbit-send
-   #:with-rabbit-recv
    #:emit-document
+   #:publish-raw-message
    #:+injest-queue+
    #:+updates-queue+
    #:+injest-key+
    #:+update-key+
    #:+targets-key+
    #:transient-p
+   #:decode-rabbit-document
    #:handle-document
    #:handle-update-document
+   #:handle-target
    #:publish-outbox-event
+   #:persist-quarantine-record
+   #:inspect-quarantine
+   #:replay-quarantined-message
    #:recover-pending-publications
    #:test-make-doc
    #:test-send

--- a/source/rabbit.lisp
+++ b/source/rabbit.lisp
@@ -6,136 +6,130 @@
 (defvar +update-key+ "documents.update.#")
 (defvar +targets-key+ "documents.new.target.*")
 
-(defun settle-rabbit-delivery (connection channel delivery-tag settlement)
-  (ecase (consumer-settlement-action settlement)
-    ((:ack :filtered-ack)
-     (cl-rabbit:basic-ack connection channel delivery-tag))
-    (:retry
-     (cl-rabbit:basic-nack
-      connection channel delivery-tag :requeue t))
-    ((:dead-letter :reject)
-     (cl-rabbit:basic-nack
-      connection channel delivery-tag :requeue nil)))
-  settlement)
-
-(defmacro with-rabbit-recv
-    ((queue-name exchange-name exchange-type routing-key
-      &key
-        (port star:*rabbit-port*)
-        (host star:*rabbit-address*)
-        (username star:*rabbit-user*)
-        (password star:*rabbit-password*)
-        (vhost "/")
-        (durable nil)
-        (exclusive nil)
-        (auto-delete nil))
-     &body body)
-  "Compatibility owner-thread receive loop with structured settlement results."
-  `(cl-rabbit:with-connection (connection)
-     (let ((socket (cl-rabbit:tcp-socket-new connection)))
-       (cl-rabbit:socket-open socket ,host ,port)
-       (when (and ,username ,password)
-         (cl-rabbit:login-sasl-plain
-          connection ,vhost ,username ,password))
-       (cl-rabbit:with-channel (connection 1)
-         (cl-rabbit:exchange-declare
-          connection 1 ,exchange-name ,exchange-type)
-         (cl-rabbit:queue-declare
-          connection 1
-          :queue ,queue-name
-          :durable ,durable
-          :auto-delete ,auto-delete
-          :exclusive ,exclusive)
-         (cl-rabbit:queue-bind
-          connection 1
-          :queue ,queue-name
-          :exchange ,exchange-name
-          :routing-key ,routing-key)
-         (cl-rabbit:basic-consume connection 1 ,queue-name)
-         (loop
-           for result = (cl-rabbit:consume-message connection)
-           for message = (cl-rabbit:envelope/message result)
-           for delivery-tag = (cl-rabbit:envelope/delivery-tag result)
-           for settlement =
-             (handler-case
-                 (normalize-settlement (progn ,@body))
-               (condition (error)
-                 (log:error "Rabbit handler failed: ~a" error)
-                 (settlement-retry (princ-to-string error) error)))
-           do (settle-rabbit-delivery
-               connection 1 delivery-tag settlement))))))
-
-(defun emit-document
-    (exchange routing-key body
+(defun publish-raw-message
+    (exchange routing-key body properties
      &key
-       (properties nil)
-       (immediate nil)
-       (mandatory nil)
        (port star:*rabbit-port*)
        (host star:*rabbit-address*)
        (username star:*rabbit-user*)
        (password star:*rabbit-password*)
        (vhost "/"))
-  (let ((canonical-body (star.documents:v09-document-json body)))
-    (cl-rabbit:with-connection (connection)
-      (let ((socket (cl-rabbit:tcp-socket-new connection)))
-        (cl-rabbit:socket-open socket host port)
-        (when (and username password)
-          (cl-rabbit:login-sasl-plain
-           connection vhost username password))
-        (cl-rabbit:with-channel (connection 1)
-          (cl-rabbit:exchange-declare
-           connection 1 exchange "topic" :durable t)
-          (cl-rabbit:basic-publish
-           connection
-           1
-           :routing-key routing-key
-           :exchange exchange
-           :mandatory mandatory
-           :immediate immediate
-           :properties properties
-           :body canonical-body))))))
+  "Publish raw Rabbit content with caller-supplied provenance properties."
+  (cl-rabbit:with-connection (connection)
+    (let ((socket (cl-rabbit:tcp-socket-new connection)))
+      (cl-rabbit:socket-open socket host port)
+      (when (and username password)
+        (cl-rabbit:login-sasl-plain
+         connection vhost username password))
+      (cl-rabbit:with-channel (connection 1)
+        (cl-rabbit:exchange-declare
+         connection 1 exchange "topic" :durable t)
+        (cl-rabbit:basic-publish
+         connection 1
+         :routing-key routing-key
+         :exchange exchange
+         :properties properties
+         :body body))))
+  t)
 
-(defun message->string (message &key (encoding :utf-8))
-  (babel:octets-to-string
-   (cl-rabbit:message/body message)
-   :encoding encoding))
+(defun emit-document
+    (exchange routing-key body
+     &key
+       (properties nil)
+       (port star:*rabbit-port*)
+       (host star:*rabbit-address*)
+       (username star:*rabbit-user*)
+       (password star:*rabbit-password*)
+       (vhost "/"))
+  (publish-raw-message
+   exchange
+   routing-key
+   (star.documents:v09-document-json body)
+   properties
+   :port port
+   :host host
+   :username username
+   :password password
+   :vhost vhost))
 
-(defun message->object (message)
-  (star.documents:ensure-v09-document (message->string message)))
-
-(defun insert (client database document)
-  (format nil "~a~%"
-          (couch:create-document
-           client
-           database
-           (star.documents:v09-document-json document))))
+(defun decode-rabbit-document (message &key route-dtype)
+  "Parse and validate one delivery body as a permanent schema boundary."
+  (handler-case
+      (star.documents:ensure-v09-document
+       (car message)
+       :route-dtype route-dtype)
+    (star.consumers:delivery-processing-error (condition)
+      (error condition))
+    (error (condition)
+      (error 'star.consumers:schema-invalid-delivery-error
+             :cause condition
+             :reason (princ-to-string condition)))))
 
 (defun publish-outbox-event (routing-key payload event-id)
   "Publish one physical delivery carrying a stable logical EVENT-ID."
-  (declare (ignore event-id))
-  (emit-document "documents" routing-key payload)
+  (emit-document
+   "documents"
+   routing-key
+   payload
+   :properties
+   (list (cons :content-type "application/json")
+         (cons :delivery-mode 2)
+         (cons :message-id event-id)))
   t)
 
-(defun process-rabbit-document-mutation (self message operation)
-  (declare (ignore self))
-  (let ((document
-          (star.documents:ensure-v09-document (car message))))
-    (anypool:with-connection
-        (client star.databases.couchdb:*couchdb-pool*)
-      (star.databases.couchdb:couchdb-process-outbox-mutation
-       client
-       star:*couchdb-default-database*
-       #'publish-outbox-event
-       document
-       operation))
-    (settlement-ack "outbox mutation persisted and published")))
+(defun persist-quarantine-record (record)
+  "Durably persist RECORD before its original Rabbit delivery is ACKed."
+  (anypool:with-connection
+      (client star.databases.couchdb:*couchdb-pool*)
+    (star.databases.couchdb:couchdb-save-quarantine-record
+     client
+     star:*couchdb-default-database*
+     record)))
+
+(defun inspect-quarantine (&key (status "quarantined") (limit 100))
+  (anypool:with-connection
+      (client star.databases.couchdb:*couchdb-pool*)
+    (star.databases.couchdb:couchdb-list-quarantine-records
+     client
+     star:*couchdb-default-database*
+     :status status
+     :limit limit)))
+
+(defun replay-quarantined-message (quarantine-id &key corrected-body)
+  "Replay one corrected quarantine record with a new trace and attempt history."
+  (anypool:with-connection
+      (client star.databases.couchdb:*couchdb-pool*)
+    (star.databases.couchdb:replay-quarantine-record
+     client
+     star:*couchdb-default-database*
+     quarantine-id
+     #'publish-raw-message
+     :corrected-body corrected-body)))
+
+(defun process-rabbit-document-mutation (message operation)
+  (let ((document (decode-rabbit-document message)))
+    (if (star.documents:document-transient-p document)
+        (settlement-filtered-ack
+         "transient document intentionally not persisted")
+        (progn
+          (anypool:with-connection
+              (client star.databases.couchdb:*couchdb-pool*)
+            (star.databases.couchdb:couchdb-process-outbox-mutation
+             client
+             star:*couchdb-default-database*
+             #'publish-outbox-event
+             document
+             operation))
+          (settlement-ack
+           "durable mutation and publication completed")))))
 
 (defun handle-document (self message)
-  (process-rabbit-document-mutation self message :new))
+  (declare (ignore self))
+  (process-rabbit-document-mutation message :new))
 
 (defun handle-update-document (self message)
-  (process-rabbit-document-mutation self message :updated))
+  (declare (ignore self))
+  (process-rabbit-document-mutation message :updated))
 
 (defun recover-pending-publications ()
   "Republish pending durable outbox entries in per-document sequence order."
@@ -148,67 +142,67 @@
 
 (defun transient-p (message)
   (star.documents:document-transient-p
-   (star.documents:ensure-v09-document (car message))))
-
-(defun insertp (message)
-  (not (transient-p message)))
+   (decode-rabbit-document message)))
 
 (defun handle-target (self message)
   (declare (ignore self))
-  (let ((body
-          (star.documents:ensure-v09-document
-           (car message)
-           :route-dtype "target")))
-    (tell star.actors:*targets* (cons 1 body))
-    (settlement-ack "target submitted to local actor")))
+  (let ((body (decode-rabbit-document message :route-dtype "target")))
+    (if (star.documents:document-transient-p body)
+        (settlement-filtered-ack
+         "transient target intentionally ignored")
+        (progn
+          (tell star.actors:*targets* (cons 1 body))
+          (settlement-ack "target accepted by actor mailbox")))))
+
+(defun consumer-retry-options ()
+  (list
+   :max-retries star:*rabbit-max-retries*
+   :retry-base-delay-ms star:*rabbit-retry-base-delay-ms*
+   :retry-max-delay-ms star:*rabbit-retry-max-delay-ms*
+   :retry-jitter-ratio star:*rabbit-retry-jitter-ratio*
+   :quarantine-fn #'persist-quarantine-record
+   :quarantine-exchange star:*rabbit-quarantine-exchange*
+   :quarantine-queue star:*rabbit-quarantine-queue*))
+
+(defun make-document-consumer
+    (&key name queue-name routing-key handler-fn)
+  (apply
+   #'create-rabbit-consumer
+   :name name
+   :n star:*injest-workers*
+   :queue-name queue-name
+   :exchange-name "documents"
+   :routing-key routing-key
+   :username star:*rabbit-user*
+   :password star:*rabbit-password*
+   :host star:*rabbit-address*
+   :port star:*rabbit-port*
+   :handler-fn handler-fn
+   :test-fn #'identity
+   :on-error :retry
+   :on-filter :filtered-ack
+   (consumer-retry-options)))
 
 (defun start-consumers ()
-  (log:info "Starting owner-thread v0.9 document consumers.")
+  (log:info "Starting bounded-retry v0.9 document consumers.")
   (let ((document-consumers
-          (create-rabbit-consumer
+          (make-document-consumer
            :name "documents-ingest"
-           :n star:*injest-workers*
            :queue-name +injest-queue+
-           :exchange-name "documents"
            :routing-key +injest-key+
-           :username star:*rabbit-user*
-           :password star:*rabbit-password*
-           :host star:*rabbit-address*
-           :port star:*rabbit-port*
-           :handler-fn #'handle-document
-           :test-fn #'insertp
-           :on-error :retry
-           :on-filter :filtered-ack))
+           :handler-fn #'handle-document))
         (update-consumers
-          (create-rabbit-consumer
+          (make-document-consumer
            :name "documents-update"
-           :n star:*injest-workers*
            :queue-name +updates-queue+
-           :exchange-name "documents"
            :routing-key +update-key+
-           :username star:*rabbit-user*
-           :password star:*rabbit-password*
-           :host star:*rabbit-address*
-           :port star:*rabbit-port*
-           :handler-fn #'handle-update-document
-           :test-fn #'insertp
-           :on-error :retry
-           :on-filter :filtered-ack))
+           :handler-fn #'handle-update-document))
         (target-consumers
-          (create-rabbit-consumer
+          (make-document-consumer
            :name "documents-targets"
-           :n star:*injest-workers*
            :queue-name "documents-targets"
-           :exchange-name "documents"
            :routing-key +targets-key+
-           :username star:*rabbit-user*
-           :password star:*rabbit-password*
-           :host star:*rabbit-address*
-           :port star:*rabbit-port*
-           :handler-fn #'handle-target
-           :test-fn #'insertp
-           :on-error :retry
-           :on-filter :filtered-ack)))
+           :handler-fn #'handle-target)))
     (start-consumer document-consumers)
     (start-consumer update-consumers)
     (start-consumer target-consumers)

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -8,46 +8,48 @@
   :build-pathname "star-server"
   :entry-point "star::main"
   :components   ((:file "consumers/package")
-                 (:file "consumers/consumers")
-                 (:file "consumers/owner-fixes")
-                 (:file "producers/package")
-                 (:file "producers/producers")
-                 (:file "document-v09-package")
-                 (:file "package")
-                 (:file "document-schema-profile")
-                 (:file "document-v09")
-                 (:file "document-codec")
-                 (:file "gserver-settings")
-                 (:file "databases/couchdb")
-                 (:file "databases/couchdb-v09")
-                 (:file "databases/outbox")
-                 (:file "init")
-                 (:file "actors")
-                 (:file "actors-v09")
-                 (:file "actor-systems/event-actor")
-                 (:file "actor-systems/matcher-actor")
-                 (:file "rabbit")
-                 (:file "frontends/http-api")
-                 (:file "frontends/http-api-v09")
-                 (:file "main"))
+                  (:file "consumers/consumers")
+                  (:file "consumers/owner-fixes")
+                  (:file "consumers/retry-policy")
+                  (:file "producers/package")
+                  (:file "producers/producers")
+                  (:file "document-v09-package")
+                  (:file "package")
+                  (:file "document-schema-profile")
+                  (:file "document-v09")
+                  (:file "document-codec")
+                  (:file "gserver-settings")
+                  (:file "databases/couchdb")
+                  (:file "databases/couchdb-v09")
+                  (:file "databases/outbox")
+                  (:file "databases/quarantine")
+                  (:file "init")
+                  (:file "actors")
+                  (:file "actors-v09")
+                  (:file "actor-systems/event-actor")
+                  (:file "actor-systems/matcher-actor")
+                  (:file "rabbit")
+                  (:file "frontends/http-api")
+                  (:file "frontends/http-api-v09")
+                  (:file "main"))
   :depends-on   (#:starintel
-                 #:cl-couch
-                 #:serapeum
-                 #:alexandria
-                 #:cl-rabbit
-                 #:sento
-                 #:babel
-                 #:uuid
-                 #:anypool
-                 #:clack
-                 #:ningle
-                 #:clingon
-                 #:slynk
-                 #:nhooks
-                 #:lparallel
-                 #:cl-stream
-                 #:cl-ppcre
-                 #:cms-ulid
-                 #:bordeaux-threads
-                 #:closer-mop
-                 #:ironclad))
+                  #:cl-couch
+                  #:serapeum
+                  #:alexandria
+                  #:cl-rabbit
+                  #:sento
+                  #:babel
+                  #:uuid
+                  #:anypool
+                  #:clack
+                  #:ningle
+                  #:clingon
+                  #:slynk
+                  #:nhooks
+                  #:lparallel
+                  #:cl-stream
+                  #:cl-ppcre
+                  #:cms-ulid
+                  #:bordeaux-threads
+                  #:closer-mop
+                  #:ironclad))

--- a/source/views/quarantine.json
+++ b/source/views/quarantine.json
@@ -1,0 +1,15 @@
+{
+  "_id": "_design/quarantine",
+  "language": "javascript",
+  "views": {
+    "by_status": {
+      "map": "function (doc) { if (doc.type === '_server_quarantine' && doc.status) { emit(doc.status, null); } }"
+    },
+    "by_failure_class": {
+      "map": "function (doc) { if (doc.type === '_server_quarantine' && doc.failure_class) { emit(doc.failure_class, null); } }"
+    },
+    "by_trace_id": {
+      "map": "function (doc) { if (doc.type === '_server_quarantine' && doc.trace_id) { emit(doc.trace_id, null); } }"
+    }
+  }
+}

--- a/tests/run-retry-quarantine-conformance.lisp
+++ b/tests/run-retry-quarantine-conformance.lisp
@@ -1,0 +1,235 @@
+(in-package :cl-user)
+
+(defclass retry-test-stream (star.consumers:retrying-rabbit-queue-stream)
+  ((settlements
+    :initform nil
+    :accessor retry-test-stream-settlements)))
+
+(defmethod star.consumers:stream-settle
+    ((stream retry-test-stream) delivery settlement)
+  (declare (ignore delivery))
+  (push settlement (retry-test-stream-settlements stream))
+  settlement)
+
+(defun retry-test-check (condition control &rest arguments)
+  (unless condition
+    (error (apply #'format nil control arguments))))
+
+(defun retry-test-properties (attempt)
+  (list
+   (cons :message-id "message-1")
+   (cons :correlation-id "trace-1")
+   (cons :headers
+         (list
+          (cons "x-starintel-attempt" attempt)
+          (cons "x-starintel-trace-id" "trace-1")
+          (cons "x-starintel-first-seen-at" "2026-07-26T00:00:00Z")))))
+
+(defun retry-test-stream (&key (attempt 0) (body "payload"))
+  (let ((stream
+          (make-instance
+           'retry-test-stream
+           :queue-name "retry-test"
+           :exchange-name "documents"
+           :routing-key "documents.ingest.person"
+           :retry-policy
+           (star.consumers:make-retry-policy
+            :max-retries 2
+            :base-delay-ms 100
+            :max-delay-ms 1000
+            :jitter-ratio 0.0d0))))
+    (setf (star.consumers:retry-stream-current-body stream) body
+          (star.consumers:retry-stream-current-properties stream)
+          (retry-test-properties attempt)
+          (star.consumers:retry-stream-current-exchange stream) "documents"
+          (star.consumers:retry-stream-current-routing-key stream)
+          "documents.ingest.person"
+          (star.consumers:retry-stream-current-received-at stream)
+          "2026-07-26T00:00:01Z")
+    stream))
+
+(defun retry-test-consumer (stream handler &key (max-retries 2))
+  (make-instance
+   'star.consumers:retrying-rabbit-consumer
+   :name "retry-test"
+   :workers 1
+   :stream stream
+   :fn handler
+   :test-fn #'identity
+   :on-error :retry
+   :on-filter :filtered-ack
+   :retry-policy
+   (star.consumers:make-retry-policy
+    :max-retries max-retries
+    :base-delay-ms 100
+    :max-delay-ms 1000
+    :jitter-ratio 0.0d0)))
+
+(defun retry-test-single-settlement (stream)
+  (let ((settlements (retry-test-stream-settlements stream)))
+    (retry-test-check (= 1 (length settlements))
+                      "Expected one settlement, got ~d"
+                      (length settlements))
+    (first settlements)))
+
+(defun test-invalid-json-dead-letters-immediately ()
+  (let* ((stream (retry-test-stream :attempt 0 :body "{not-json"))
+         (consumer
+           (retry-test-consumer
+            stream
+            (lambda (self delivery)
+              (declare (ignore self))
+              (star.rabbit:decode-rabbit-document delivery)))))
+    (star.consumers:consumer-process-delivery
+     consumer (cons "{not-json" 1))
+    (let ((settlement (retry-test-single-settlement stream)))
+      (retry-test-check
+       (eq :dead-letter
+           (star.consumers:consumer-settlement-action settlement))
+       "Invalid JSON did not dead-letter")
+      (retry-test-check
+       (typep (star.consumers:consumer-settlement-condition settlement)
+              'star.consumers:schema-invalid-delivery-error)
+       "Invalid JSON was not classified as schema-invalid"))))
+
+(defun test-transient-failure-is-bounded ()
+  (loop for attempt from 0 to 2
+        for expected in '(:retry :retry :dead-letter)
+        do
+           (let* ((stream (retry-test-stream :attempt attempt))
+                  (consumer
+                    (retry-test-consumer
+                     stream
+                     (lambda (self delivery)
+                       (declare (ignore self delivery))
+                       (error 'star.consumers:transient-delivery-error
+                              :reason "temporary outage"))
+                     :max-retries 2)))
+             (star.consumers:consumer-process-delivery
+              consumer (cons "payload" attempt))
+             (let ((settlement (retry-test-single-settlement stream)))
+               (retry-test-check
+                (eq expected
+                    (star.consumers:consumer-settlement-action settlement))
+                "Attempt ~d expected ~s but got ~s"
+                attempt expected
+                (star.consumers:consumer-settlement-action settlement))))))
+
+(defun test-conflict-is-permanent-and-idempotency-aware ()
+  (let* ((condition
+           (make-condition
+            'star.databases.couchdb:mutation-conflict
+            :mutation-id "mutation-1"
+            :document-id "person:1"
+            :reason "idempotency key reused"))
+         (failure
+           (star.consumers:classify-delivery-condition condition))
+         (policy
+           (star.consumers:make-retry-policy :max-retries 9)))
+    (retry-test-check
+     (typep failure 'star.consumers:conflict-delivery-error)
+     "Mutation conflict did not map to conflict failure")
+    (retry-test-check
+     (eq :dead-letter
+         (star.consumers:retry-action-for policy failure 0))
+     "Conflict was incorrectly made retryable")))
+
+(defun test-retry-backoff-is_exponential_bounded_and_jittered ()
+  (let ((policy
+          (star.consumers:make-retry-policy
+           :max-retries 4
+           :base-delay-ms 100
+           :max-delay-ms 250
+           :jitter-ratio 0.20d0)))
+    (retry-test-check
+     (= 80 (star.consumers:retry-delay-ms policy 0 0.0d0))
+     "Lower jitter bound was wrong")
+    (retry-test-check
+     (= 120 (star.consumers:retry-delay-ms policy 0 1.0d0))
+     "Upper jitter bound was wrong")
+    (retry-test-check
+     (= 250 (star.consumers:retry-delay-ms policy 5 0.5d0))
+     "Retry delay exceeded cap")))
+
+(defun test-quarantine-record-preserves-provenance ()
+  (let* ((stream (retry-test-stream :attempt 2 :body "broken-body"))
+         (settlement
+           (star.consumers:settlement-dead-letter
+            "bad schema"
+            (make-condition
+             'star.consumers:schema-invalid-delivery-error
+             :reason "bad schema")))
+         (record (star.consumers:quarantine-record stream settlement)))
+    (retry-test-check
+     (string= "quarantined" (jsown:val record "status"))
+     "Quarantine status missing")
+    (retry-test-check
+     (string= "schema-invalid" (jsown:val record "failure_class"))
+     "Failure class missing")
+    (retry-test-check
+     (string= "documents.ingest.person"
+              (jsown:val record "original_routing_key"))
+     "Original routing key missing")
+    (retry-test-check
+     (string= "message-1" (jsown:val record "message_id"))
+     "Message id missing")
+    (retry-test-check
+     (string= "trace-1" (jsown:val record "trace_id"))
+     "Trace id missing")
+    (retry-test-check
+     (= 2 (jsown:val record "attempt_count"))
+     "Attempt count missing")
+    (retry-test-check
+     (string= "broken-body" (jsown:val record "original_body"))
+     "Original body missing")))
+
+(defun test-corrected-replay-resets_attempts_and_preserves_lineage ()
+  (let ((record (jsown:empty-object)))
+    (setf (jsown:val record "_id") "quarantine:1"
+          (jsown:val record "trace_id") "old-trace"
+          (jsown:val record "replay_count") 1
+          (jsown:val record "original_body") "bad"
+          (jsown:val record "original_exchange") "documents"
+          (jsown:val record "original_routing_key")
+          "documents.ingest.person")
+    (multiple-value-bind (body properties exchange routing-key)
+        (star.consumers:quarantine-replay-envelope
+         record :corrected-body "corrected")
+      (retry-test-check (string= "corrected" body)
+                        "Corrected body was not used")
+      (retry-test-check (string= "documents" exchange)
+                        "Original exchange was lost")
+      (retry-test-check
+       (string= "documents.ingest.person" routing-key)
+       "Original routing key was lost")
+      (retry-test-check
+       (= 0 (star.consumers:delivery-attempt properties))
+       "Replay did not reset attempt count")
+      (retry-test-check
+       (string= "old-trace"
+                (star.consumers:rabbit-header
+                 properties "x-starintel-parent-trace-id"))
+       "Replay did not preserve trace lineage")
+      (retry-test-check
+       (string= "quarantine:1"
+                (star.consumers:rabbit-header
+                 properties "x-starintel-replay-of"))
+       "Replay did not preserve quarantine provenance")
+      (retry-test-check
+       (= 2
+          (star.consumers:rabbit-header
+           properties "x-starintel-replay-count"))
+       "Replay count did not advance"))))
+
+(defun run-retry-quarantine-conformance-tests ()
+  (format t "~&Running bounded retry and quarantine tests~%")
+  (test-invalid-json-dead-letters-immediately)
+  (test-transient-failure-is-bounded)
+  (test-conflict-is-permanent-and-idempotency-aware)
+  (test-retry-backoff-is_exponential_bounded_and_jittered)
+  (test-quarantine-record-preserves-provenance)
+  (test-corrected-replay-resets_attempts_and_preserves_lineage)
+  (format t "~&Bounded retry and quarantine tests passed~%")
+  t)
+
+(run-retry-quarantine-conformance-tests)

--- a/tests/test_retry_quarantine_contract.py
+++ b/tests/test_retry_quarantine_contract.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RetryQuarantineContractTests(unittest.TestCase):
+    def test_single_owner_consumer_policy_replaces_legacy_receive_macro(self) -> None:
+        source = (ROOT / "source" / "rabbit.lisp").read_text(encoding="utf-8")
+        package = (ROOT / "source" / "package.lisp").read_text(encoding="utf-8")
+        self.assertNotIn("defmacro with-rabbit-recv", source.lower())
+        self.assertNotIn("#:with-rabbit-recv", package.lower())
+        self.assertIn("make-document-consumer", source)
+        self.assertIn("consumer-retry-options", source)
+
+    def test_failure_taxonomy_and_bounded_backoff_are_implemented(self) -> None:
+        source = (
+            ROOT / "source" / "consumers" / "retry-policy.lisp"
+        ).read_text(encoding="utf-8")
+        for name in (
+            "transient-delivery-error",
+            "permanent-delivery-error",
+            "conflict-delivery-error",
+            "unauthorized-delivery-error",
+            "schema-invalid-delivery-error",
+            "internal-delivery-error",
+            "retry-delay-ms",
+            "retry-action-for",
+        ):
+            self.assertIn(name, source)
+        self.assertIn("x-starintel-attempt", source)
+        self.assertIn("x-starintel-attempt-history", source)
+        self.assertIn("x-starintel-first-seen-at", source)
+
+    def test_quarantine_is_durable_inspectable_and_replayable(self) -> None:
+        policy = (
+            ROOT / "source" / "consumers" / "retry-policy.lisp"
+        ).read_text(encoding="utf-8")
+        database = (
+            ROOT / "source" / "databases" / "quarantine.lisp"
+        ).read_text(encoding="utf-8")
+        rabbit = (ROOT / "source" / "rabbit.lisp").read_text(encoding="utf-8")
+        for token in (
+            "failure_class",
+            "failure_reason",
+            "original_routing_key",
+            "message_id",
+            "trace_id",
+            "attempt_count",
+            "first_seen_at",
+            "failed_at",
+        ):
+            self.assertIn(token, policy)
+        self.assertIn("couchdb-save-quarantine-record", database)
+        self.assertIn("couchdb-list-quarantine-records", database)
+        self.assertIn("replay-quarantine-record", database)
+        self.assertIn("inspect-quarantine", rabbit)
+        self.assertIn("replay-quarantined-message", rabbit)
+        self.assertIn("x-starintel-parent-trace-id", policy)
+        self.assertIn("x-starintel-replay-of", policy)
+
+    def test_quarantine_design_document_is_valid(self) -> None:
+        document = json.loads(
+            (ROOT / "source" / "views" / "quarantine.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(document["_id"], "_design/quarantine")
+        self.assertEqual(
+            set(document["views"]),
+            {"by_status", "by_failure_class", "by_trace_id"},
+        )
+        for view in document["views"].values():
+            self.assertIn("_server_quarantine", view["map"])
+
+    def test_acceptance_matrix_is_executable_in_clos_gate(self) -> None:
+        tests = (
+            ROOT / "tests" / "run-retry-quarantine-conformance.lisp"
+        ).read_text(encoding="utf-8")
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        for name in (
+            "test-invalid-json-dead-letters-immediately",
+            "test-transient-failure-is-bounded",
+            "test-conflict-is-permanent-and-idempotency-aware",
+            "test-quarantine-record-preserves-provenance",
+            "test-corrected-replay-resets_attempts_and_preserves_lineage",
+        ):
+            self.assertIn(name, tests)
+        self.assertIn("run-retry-quarantine-conformance.lisp", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace indefinite Rabbit requeue loops with bounded republish attempts
- define transient, permanent, conflict, unauthorized, schema-invalid, and internal failure classes
- apply capped exponential backoff with symmetric jitter
- track message id, trace id, attempt count, first-seen time, original route, and attempt history in Rabbit properties
- quarantine permanent failures immediately and exhausted transient failures after the configured ceiling
- persist structured quarantine records in CouchDB before ACKing the original delivery
- publish quarantine records to a durable topic exchange and inspection queue
- add explicit inspection and corrected replay tooling
- reset replay attempts while preserving parent trace, original route, and quarantine lineage
- remove the duplicate `with-rabbit-recv` path so all consumers share the owner-thread policy
- apply the policy to document ingest, updates, targets, and actor events

## Delivery contract

- handler success or intentional filtering: ACK
- retryable failure below the ceiling: republish with incremented attempt/provenance headers, then ACK original
- permanent failure or exhausted retries: persist and publish quarantine record, then ACK original
- retry/quarantine publication failure: original delivery remains unsettled and the owner loop fails rather than losing the message

## Regression coverage

- invalid JSON dead-letters immediately
- transient failure retries attempts 0 and 1, then quarantines at attempt 2
- mutation conflict maps to permanent idempotency conflict
- exponential backoff respects jitter and maximum delay
- quarantine records retain structured failure and delivery provenance
- corrected replay resets attempts and preserves lineage
- source contract verifies the legacy consumer macro is gone

## Stack

- base: `agent/schema-org-v0.9`
- includes completed issues #11–#15

This remains draft until both fixture and CLOS retry/quarantine gates are green.

Closes #16