### PR TITLE
Recover persisted targets through typed repository records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN qlot exec sbcl --non-interactive \
     --load tests/run-server-codec-conformance.lisp \
     --load tests/run-outbox-conformance.lisp \
     --load tests/run-consumer-owner-conformance.lisp \
-    --load tests/run-retry-quarantine-conformance.lisp
+    --load tests/run-retry-quarantine-conformance.lisp \
+    --load tests/run-target-recovery-conformance.lisp
 
 FROM conformance AS star-server
 

--- a/source/document-v09-package.lisp
+++ b/source/document-v09-package.lisp
@@ -23,6 +23,7 @@
    #:unknown-document-dtype-value
    #:unknown-document-dtype-schema-version
    #:document-class-mismatch
+   #:object-value
    #:parse-document-object
    #:document-field-value
    #:document-value

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -127,7 +127,7 @@
 
 (uiop:define-package :star.actors
   (:use :cl :star.databases.couchdb :sento.agent :sento.actor :sento.actor-system :sento.actor-context)
-  (:documentation "StarIntel actors.")
+  (:documentation "StarIntel actors and typed target recovery.")
   (:export
    #:register-actor
    #:*targets*
@@ -144,6 +144,32 @@
    #:*pattern-actor*
    #:*wmn-relations-p*
    #:publish
+   #:target-record
+   #:target-record-id
+   #:target-record-actor
+   #:target-record-target
+   #:target-record-delay
+   #:target-record-recurring-p
+   #:target-record-options
+   #:target-record-document
+   #:target-record-revision
+   #:target-record-lease-owner
+   #:target-record-lease-expires-at
+   #:target-command
+   #:target-command-record
+   #:target-command-first-time-p
+   #:target-command-recovered-p
+   #:parse-target-record
+   #:query-persisted-target-documents
+   #:load-persisted-target-records
+   #:submit-target
+   #:recover-target-record
+   #:recover-persisted-targets
+   #:target-active-lease-p
+   #:invalid-persisted-target
+   #:invalid-target-document-id
+   #:invalid-target-reason
+   #:*recovered-target-fingerprints*
    #:handle-event-message
    #:start-event-consumer
    #:log-actor-event

--- a/source/rabbit.lisp
+++ b/source/rabbit.lisp
@@ -151,8 +151,8 @@
         (settlement-filtered-ack
          "transient target intentionally ignored")
         (progn
-          (tell star.actors:*targets* (cons 1 body))
-          (settlement-ack "target accepted by actor mailbox")))))
+          (star.actors:submit-target body :first-time-p t)
+          (settlement-ack "target accepted by typed actor mailbox")))))
 
 (defun consumer-retry-options ()
   (list

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -27,6 +27,7 @@
                   (:file "actors")
                   (:file "actors-v09")
                   (:file "target-recovery")
+                  (:file "target-repository")
                   (:file "actor-systems/event-actor")
                   (:file "actor-systems/matcher-actor")
                   (:file "rabbit")

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -26,6 +26,7 @@
                   (:file "init")
                   (:file "actors")
                   (:file "actors-v09")
+                  (:file "target-recovery")
                   (:file "actor-systems/event-actor")
                   (:file "actor-systems/matcher-actor")
                   (:file "rabbit")

--- a/source/target-recovery.lisp
+++ b/source/target-recovery.lisp
@@ -1,0 +1,332 @@
+(in-package :star.actors)
+
+(defstruct (target-record
+             (:constructor %make-target-record
+                 (id actor target delay recurring-p options document
+                  revision lease-owner lease-expires-at)))
+  id
+  actor
+  target
+  delay
+  recurring-p
+  options
+  document
+  revision
+  lease-owner
+  lease-expires-at)
+
+(defstruct (target-command
+             (:constructor make-target-command
+                 (record &key (first-time-p t) (recovered-p nil))))
+  record
+  (first-time-p t)
+  (recovered-p nil))
+
+(define-condition invalid-persisted-target (error)
+  ((document-id
+    :initarg :document-id
+    :reader invalid-target-document-id)
+   (reason
+    :initarg :reason
+    :reader invalid-target-reason))
+  (:report
+   (lambda (condition stream)
+     (format stream "Invalid persisted target ~a: ~a"
+             (invalid-target-document-id condition)
+             (invalid-target-reason condition)))))
+
+(defparameter *recovered-target-fingerprints*
+  (make-hash-table :test #'equal)
+  "Process-local ledger preventing duplicate timer/execution recovery passes.")
+
+(defun target-value (document key &optional default)
+  (star.documents:document-value document key default))
+
+(defun target-boolean-p (value)
+  (or (eq value t) (eq value :true)))
+
+(defun target-nonempty-string-p (value)
+  (and (stringp value) (plusp (length value))))
+
+(defun target-record-fingerprint (record)
+  (format nil "~a|~a"
+          (target-record-id record)
+          (or (target-record-revision record) "unrevisioned")))
+
+(defun target-active-lease-p (record &optional (now (spec:utc-now)))
+  "Return true when RECORD has a non-expired persisted execution lease."
+  (let ((owner (target-record-lease-owner record))
+        (expires (target-record-lease-expires-at record)))
+    (and (target-nonempty-string-p owner)
+         (target-nonempty-string-p expires)
+         (string> expires now))))
+
+(defun parse-target-record (document)
+  "Validate one v0.9 target document and return a typed recovery record."
+  (let* ((object (star.documents:parse-document-object document))
+         (dtype (star.documents:document-dtype object))
+         (id (star.documents:object-value object "_id"))
+         (actor (target-value object "actor"))
+         (target (target-value object "target"))
+         (delay (target-value object "delay" 0))
+         (recurring (target-boolean-p (target-value object "recurring" nil)))
+         (options (target-value object "options" #()))
+         (revision (star.documents:object-value object "_rev" nil))
+         (lease-owner (target-value object "lease_owner" nil))
+         (lease-expires-at (target-value object "lease_expires_at" nil)))
+    (unless (member dtype '("target" "investigation-target") :test #'string=)
+      (error 'invalid-persisted-target
+             :document-id id
+             :reason (format nil "unsupported dtype ~a" dtype)))
+    (unless (target-nonempty-string-p id)
+      (error 'invalid-persisted-target
+             :document-id (or id "<missing>")
+             :reason "_id must be a non-empty string"))
+    (unless (target-nonempty-string-p actor)
+      (error 'invalid-persisted-target
+             :document-id id
+             :reason "actor must be a non-empty string"))
+    (unless (target-nonempty-string-p target)
+      (error 'invalid-persisted-target
+             :document-id id
+             :reason "target must be a non-empty string"))
+    (unless (and (integerp delay) (not (minusp delay)))
+      (error 'invalid-persisted-target
+             :document-id id
+             :reason "delay must be a non-negative integer"))
+    (when (and recurring (zerop delay))
+      (error 'invalid-persisted-target
+             :document-id id
+             :reason "recurring targets require a positive delay"))
+    (%make-target-record
+     id actor target delay recurring options object revision
+     lease-owner lease-expires-at)))
+
+(defun query-persisted-target-documents
+    (client database &key actors (query-fn #'star.databases.couchdb:query-view))
+  "Query DATABASE through the canonical targets/by_actor view."
+  (let* ((response
+           (if actors
+               (funcall query-fn client database "targets" "by_actor"
+                        :keys actors :include-docs t :reduce nil)
+               (funcall query-fn client database "targets" "by_actor"
+                        :include-docs t :reduce nil)))
+         (rows (or (jsown:val-safe response "rows") nil)))
+    (loop for row in rows
+          for document = (jsown:val-safe row "doc")
+          when document collect document)))
+
+(defun target-recovery-digest (text)
+  (ironclad:byte-array-to-hex-string
+   (ironclad:digest-sequence
+    :sha256
+    (babel:string-to-octets text :encoding :utf-8))))
+
+(defun invalid-target-quarantine-record (database document condition)
+  (let* ((document-id
+           (or (ignore-errors (star.documents:object-value document "_id"))
+               "unknown"))
+         (revision
+           (or (ignore-errors (star.documents:object-value document "_rev"))
+               "unrevisioned"))
+         (digest
+           (target-recovery-digest
+            (format nil "~a|~a|~a" database document-id revision)))
+         (record (jsown:empty-object)))
+    (setf (jsown:val record "_id")
+          (format nil "quarantine:target-recovery:~a" digest)
+          (jsown:val record "type") "_server_quarantine"
+          (jsown:val record "status") "quarantined"
+          (jsown:val record "failure_class") "invalid-persisted-target"
+          (jsown:val record "failure_reason") (princ-to-string condition)
+          (jsown:val record "condition_type") "INVALID-PERSISTED-TARGET"
+          (jsown:val record "original_exchange") "couchdb"
+          (jsown:val record "original_routing_key")
+          (format nil "database.~a.target.~a" database document-id)
+          (jsown:val record "message_id") document-id
+          (jsown:val record "trace_id") digest
+          (jsown:val record "attempt_count") 0
+          (jsown:val record "first_seen_at") (spec:utc-now)
+          (jsown:val record "received_at") (spec:utc-now)
+          (jsown:val record "failed_at") (spec:utc-now)
+          (jsown:val record "replayed_at") :null
+          (jsown:val record "replay_count") 0
+          (jsown:val record "original_body")
+          (handler-case (jsown:to-json document)
+            (error () (princ-to-string document)))
+          (jsown:val record "original_properties") (jsown:empty-object))
+    record))
+
+(defun quarantine-invalid-persisted-target
+    (client database document condition)
+  "Persist a deterministic quarantine record; repeated startup is idempotent."
+  (let ((record
+          (invalid-target-quarantine-record database document condition)))
+    (handler-case
+        (star.databases.couchdb:couchdb-save-quarantine-record
+         client database record)
+      (dexador:http-request-conflict () record))))
+
+(defun load-persisted-target-records
+    (client database &key actors
+                      (query-fn #'star.databases.couchdb:query-view)
+                      (quarantine-fn #'quarantine-invalid-persisted-target))
+  "Return valid typed records and quarantine invalid persisted documents."
+  (let ((records nil)
+        (invalid-count 0))
+    (dolist (document
+             (query-persisted-target-documents
+              client database :actors actors :query-fn query-fn))
+      (handler-case
+          (push (parse-target-record document) records)
+        (error (condition)
+          (incf invalid-count)
+          (funcall quarantine-fn client database document condition))))
+    (values (nreverse records) invalid-count)))
+
+(defun target-command-document (command)
+  (target-record-document (target-command-record command)))
+
+(defun submit-target (target &key (first-time-p t) (recovered-p nil))
+  "Submit TARGET through a typed command instead of an overloaded cons cell."
+  (let* ((record
+           (etypecase target
+             (target-record target)
+             (list (parse-target-record target))))
+         (command
+           (make-target-command
+            record :first-time-p first-time-p :recovered-p recovered-p)))
+    (tell *targets* command)
+    command))
+
+(defun sumbit-target (target &optional (first-time t))
+  "Compatibility alias for the historical misspelling."
+  (submit-target target :first-time-p first-time))
+
+(defun first-time-p (message)
+  (etypecase message
+    (target-command (target-command-first-time-p message))
+    (cons (car message))))
+
+(defun target-transient-p (target)
+  (star.documents:document-transient-p
+   (etypecase target
+     (target-record (target-record-document target))
+     (list target))))
+
+(defun start-target-actor (system)
+  "Start the target actor with typed command handling."
+  (setf *targets*
+        (actor-of
+         system
+         :name "*targets*"
+         :receive
+         (lambda (command)
+           (let* ((record
+                    (etypecase command
+                      (target-command (target-command-record command))
+                      (cons (parse-target-record (cdr command)))))
+                  (target (target-record-document record))
+                  (actor (target-record-actor record))
+                  (delay (target-record-delay record))
+                  (first-time
+                    (etypecase command
+                      (target-command (target-command-first-time-p command))
+                      (cons (car command))))
+                  (destination (get-dest-actor actor)))
+             (unless destination
+               (star.rabbit:emit-document
+                "documents"
+                (format nil "actors.~a.new-target" actor)
+                target
+                :host star:*rabbit-address*
+                :port star:*rabbit-port*
+                :username star:*rabbit-user*
+                :password star:*rabbit-password*))
+             (when (and destination
+                        (target-record-recurring-p record)
+                        first-time)
+               (wt:schedule-recurring
+                *target-timer*
+                0.0
+                delay
+                (lambda ()
+                  (submit-target
+                   record :first-time-p nil :recovered-p
+                   (and (typep command 'target-command)
+                        (target-command-recovered-p command))))
+                (target-record-id record)))
+             (when (and destination (not first-time))
+               (route-target target actor)))))))
+
+(defun recover-target-record (record)
+  "Recover one record once per persisted revision in this process."
+  (let ((fingerprint (target-record-fingerprint record)))
+    (cond
+      ((target-active-lease-p record) :leased)
+      ((gethash fingerprint *recovered-target-fingerprints*) :duplicate)
+      (t
+       (setf (gethash fingerprint *recovered-target-fingerprints*) t)
+       (handler-case
+           (progn
+             (submit-target
+              record
+              :first-time-p (target-record-recurring-p record)
+              :recovered-p t)
+             :recovered)
+         (error (condition)
+           (remhash fingerprint *recovered-target-fingerprints*)
+           (error condition)))))))
+
+(defun recover-persisted-targets
+    (&key (database star:*couchdb-default-database*) actors)
+  "Recover valid persisted targets after actor startup and before Rabbit ingest."
+  (anypool:with-connection
+      (client star.databases.couchdb:*couchdb-pool*)
+    (multiple-value-bind (records invalid-count)
+        (load-persisted-target-records client database :actors actors)
+      (let ((recovered 0)
+            (duplicates 0)
+            (leased 0))
+        (dolist (record records)
+          (ecase (recover-target-record record)
+            (:recovered (incf recovered))
+            (:duplicate (incf duplicates))
+            (:leased (incf leased))))
+        (list :loaded (length records)
+              :recovered recovered
+              :duplicates duplicates
+              :leased leased
+              :invalid invalid-count)))))
+
+(defun start-target-loader ()
+  "Compatibility entry point for explicit recovery."
+  (recover-persisted-targets))
+
+(defun start-actors
+    (&key rabbit-user rabbit-host rabbit-password rabbit-vhost rabbit-port)
+  "Start persistence and registry actors, then recover targets before ingest."
+  (start-actor-system)
+  (setf *producer-agent*
+        (make-producer-agent
+         (star.producers:make-producer
+          :name "actor-producer"
+          :exchange-name "documents"
+          :host rabbit-host
+          :port rabbit-port
+          :user rabbit-user
+          :password rabbit-password
+          :vhost rabbit-vhost)
+         *sys*))
+  (let ((*gc-timer* (wt:make-wheel-timer)))
+    (wt:schedule-recurring
+     *gc-timer* 1 3600 (lambda () (sb-ext:gc :full t))))
+  (start-couchdb-agent *sys*)
+  (start-actor-index *sys*)
+  (start-couchdb-gets *sys*)
+  (start-couchdb-inserts *sys*)
+  (start-target-timer)
+  (start-target-actor *sys*)
+  ;; Actor hooks complete registry population before persisted work is replayed.
+  (nhooks:run-hook star:*actors-start-hook*)
+  (recover-persisted-targets))

--- a/source/target-repository.lisp
+++ b/source/target-repository.lisp
@@ -1,0 +1,24 @@
+(in-package :star.actors)
+
+(defun target-repository-sequence-list (value)
+  (cond
+    ((null value) nil)
+    ((vectorp value) (coerce value 'list))
+    ((listp value) value)
+    (t (error "Target repository rows must be a JSON array, got ~s" value))))
+
+(defun query-persisted-target-documents
+    (client database &key actors (query-fn #'star.databases.couchdb:query-view))
+  "Query DATABASE through targets/by_actor and accept either JSOWN array form."
+  (let* ((response
+           (if actors
+               (funcall query-fn client database "targets" "by_actor"
+                        :keys actors :include-docs t :reduce nil)
+               (funcall query-fn client database "targets" "by_actor"
+                        :include-docs t :reduce nil)))
+         (rows
+           (target-repository-sequence-list
+            (jsown:val-safe response "rows"))))
+    (loop for row in rows
+          for document = (jsown:val-safe row "doc")
+          when document collect document)))

--- a/tests/run-target-recovery-conformance.lisp
+++ b/tests/run-target-recovery-conformance.lisp
@@ -1,0 +1,222 @@
+(in-package :cl-user)
+
+(defun target-recovery-check (condition control &rest arguments)
+  (unless condition
+    (error (apply #'format nil control arguments))))
+
+(defun target-recovery-document
+    (id &key (actor "scanner") (target "example.org")
+             (delay 0) (recurring nil) (revision "1-test")
+             lease-owner lease-expires-at)
+  (let ((data (jsown:empty-object))
+        (document (jsown:empty-object)))
+    (setf (jsown:val data "actor") actor
+          (jsown:val data "target") target
+          (jsown:val data "delay") delay
+          (jsown:val data "recurring") (if recurring :true :false)
+          (jsown:val data "options") #())
+    (when lease-owner
+      (setf (jsown:val data "lease_owner") lease-owner))
+    (when lease-expires-at
+      (setf (jsown:val data "lease_expires_at") lease-expires-at))
+    (setf (jsown:val document "_id") id
+          (jsown:val document "_rev") revision
+          (jsown:val document "dataset") "default"
+          (jsown:val document "dtype") "target"
+          (jsown:val document "schema_version") "0.9.0"
+          (jsown:val document "version") 1
+          (jsown:val document "date_added") "2026-07-26T00:00:00Z"
+          (jsown:val document "date_updated") "2026-07-26T00:00:00Z"
+          (jsown:val document "sources") #()
+          (jsown:val document "evidence") #()
+          (jsown:val document "data") data)
+    document))
+
+(defun target-recovery-row (document)
+  (let ((row (jsown:empty-object)))
+    (setf (jsown:val row "doc") document)
+    row))
+
+(defun target-recovery-response (&rest documents)
+  (let ((response (jsown:empty-object)))
+    (setf (jsown:val response "rows")
+          (coerce (mapcar #'target-recovery-row documents) 'vector))
+    response))
+
+(defun test-target-repository-uses-configured-database-and_canonical_view ()
+  (let ((seen nil)
+        (document (target-recovery-document "target:configured")))
+    (let ((documents
+            (star.actors:query-persisted-target-documents
+             :client-token
+             "configured-db"
+             :query-fn
+             (lambda (client database ddoc view &key include-docs reduce
+                                                   &allow-other-keys)
+               (setf seen
+                     (list client database ddoc view include-docs reduce))
+               (target-recovery-response document)))))
+      (target-recovery-check (= 1 (length documents))
+                             "Configured database query lost the document")
+      (target-recovery-check
+       (equal seen
+              '(:client-token "configured-db" "targets" "by_actor" t nil))
+       "Repository query arguments were ~s" seen))))
+
+(defun test-empty-target_repository_is_empty ()
+  (multiple-value-bind (records invalid-count)
+      (star.actors:load-persisted-target-records
+       :client-token
+       "empty-db"
+       :query-fn
+       (lambda (&rest arguments)
+         (declare (ignore arguments))
+         (target-recovery-response))
+       :quarantine-fn
+       (lambda (&rest arguments)
+         (declare (ignore arguments))
+         (error "Empty database attempted quarantine")))
+    (target-recovery-check (null records)
+                           "Empty database returned records")
+    (target-recovery-check (zerop invalid-count)
+                           "Empty database returned invalid rows")))
+
+(defun test-invalid-persisted_target_is_quarantined ()
+  (let ((invalid (target-recovery-document
+                  "target:invalid" :actor "" :target ""))
+        (quarantined nil))
+    (multiple-value-bind (records invalid-count)
+        (star.actors:load-persisted-target-records
+         :client-token
+         "configured-db"
+         :query-fn
+         (lambda (&rest arguments)
+           (declare (ignore arguments))
+           (target-recovery-response invalid))
+         :quarantine-fn
+         (lambda (client database document condition)
+           (setf quarantined
+                 (list client database document condition))))
+      (target-recovery-check (null records)
+                             "Invalid target entered recovery")
+      (target-recovery-check (= 1 invalid-count)
+                             "Invalid target count was ~d" invalid-count)
+      (target-recovery-check quarantined
+                             "Invalid target was not quarantined")
+      (target-recovery-check
+       (typep (fourth quarantined) 'star.actors:invalid-persisted-target)
+       "Invalid target quarantine reason was ~s" (fourth quarantined)))))
+
+(defun test-invalid_target_quarantine_id_is_stable ()
+  (let* ((document (target-recovery-document
+                    "target:bad" :actor "" :revision "7-rev"))
+         (condition
+           (make-condition 'star.actors:invalid-persisted-target
+                           :document-id "target:bad"
+                           :reason "bad actor"))
+         (left
+           (star.actors::invalid-target-quarantine-record
+            "configured-db" document condition))
+         (right
+           (star.actors::invalid-target-quarantine-record
+            "configured-db" document condition)))
+    (target-recovery-check
+     (string= (jsown:val left "_id") (jsown:val right "_id"))
+     "Repeated invalid target recovery produced duplicate quarantine IDs")))
+
+(defun test_one_shot_and_recurring_targets_recover_once ()
+  (let* ((one-shot
+           (star.actors:parse-target-record
+            (target-recovery-document "target:once")))
+         (recurring
+           (star.actors:parse-target-record
+            (target-recovery-document
+             "target:repeat" :delay 60 :recurring t)))
+         (calls nil)
+         (original (symbol-function 'star.actors:submit-target)))
+    (clrhash star.actors:*recovered-target-fingerprints*)
+    (unwind-protect
+         (progn
+           (setf (symbol-function 'star.actors:submit-target)
+                 (lambda (record &key first-time-p recovered-p)
+                   (push (list (star.actors:target-record-id record)
+                               first-time-p recovered-p)
+                         calls)))
+           (target-recovery-check
+            (eq :recovered (star.actors:recover-target-record one-shot))
+            "One-shot target was not recovered")
+           (target-recovery-check
+            (eq :recovered (star.actors:recover-target-record recurring))
+            "Recurring target was not recovered")
+           (target-recovery-check
+            (eq :duplicate (star.actors:recover-target-record one-shot))
+            "Repeated one-shot recovery was not deduplicated")
+           (target-recovery-check
+            (eq :duplicate (star.actors:recover-target-record recurring))
+            "Repeated recurring recovery was not deduplicated")
+           (setf calls (nreverse calls))
+           (target-recovery-check
+            (equal calls
+                   '(("target:once" nil t)
+                     ("target:repeat" t t)))
+            "Recovery submissions were ~s" calls))
+      (setf (symbol-function 'star.actors:submit-target) original)
+      (clrhash star.actors:*recovered-target-fingerprints*))))
+
+(defun test-active_lease_suppresses_recovery ()
+  (let* ((record
+           (star.actors:parse-target-record
+            (target-recovery-document
+             "target:leased"
+             :lease-owner "worker-1"
+             :lease-expires-at "2999-01-01T00:00:00Z")))
+         (called nil)
+         (original (symbol-function 'star.actors:submit-target)))
+    (clrhash star.actors:*recovered-target-fingerprints*)
+    (unwind-protect
+         (progn
+           (setf (symbol-function 'star.actors:submit-target)
+                 (lambda (&rest arguments)
+                   (declare (ignore arguments))
+                   (setf called t)))
+           (target-recovery-check
+            (eq :leased (star.actors:recover-target-record record))
+            "Active lease was not respected")
+           (target-recovery-check (not called)
+                                  "Leased target was resubmitted"))
+      (setf (symbol-function 'star.actors:submit-target) original)
+      (clrhash star.actors:*recovered-target-fingerprints*))))
+
+(defun test_typed_target_command_preserves_document ()
+  (let* ((record
+           (star.actors:parse-target-record
+            (target-recovery-document "target:typed")))
+         (command
+           (star.actors::make-target-command
+            record :first-time-p nil :recovered-p t)))
+    (target-recovery-check
+     (typep command 'star.actors:target-command)
+     "Target command is not typed")
+    (target-recovery-check
+     (eq record (star.actors:target-command-record command))
+     "Target command lost its record")
+    (target-recovery-check
+     (not (star.actors:target-command-first-time-p command))
+     "Target command first-time flag changed")
+    (target-recovery-check
+     (star.actors:target-command-recovered-p command)
+     "Target command recovery flag changed")))
+
+(defun run-target-recovery-conformance-tests ()
+  (format t "~&Running persisted target recovery tests~%")
+  (test-target-repository-uses-configured-database-and_canonical_view)
+  (test-empty-target_repository-is_empty)
+  (test-invalid-persisted_target_is_quarantined)
+  (test-invalid_target_quarantine_id_is_stable)
+  (test_one_shot_and_recurring_targets_recover_once)
+  (test-active_lease_suppresses_recovery)
+  (test_typed_target_command_preserves_document)
+  (format t "~&Persisted target recovery tests passed~%")
+  t)
+
+(run-target-recovery-conformance-tests)

--- a/tests/run-target-recovery-conformance.lisp
+++ b/tests/run-target-recovery-conformance.lisp
@@ -210,7 +210,7 @@
 (defun run-target-recovery-conformance-tests ()
   (format t "~&Running persisted target recovery tests~%")
   (test-target-repository-uses-configured-database-and_canonical_view)
-  (test-empty-target_repository-is_empty)
+  (test-empty-target_repository_is_empty)
   (test-invalid-persisted_target_is_quarantined)
   (test-invalid_target_quarantine_id_is_stable)
   (test_one_shot_and_recurring_targets_recover_once)

--- a/tests/test_target_recovery_contract.py
+++ b/tests/test_target_recovery_contract.py
@@ -68,7 +68,7 @@ class TargetRecoveryContractTests(unittest.TestCase):
         dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
         for name in (
             "test-target-repository-uses-configured-database-and_canonical_view",
-            "test-empty-target_repository-is_empty",
+            "test-empty-target_repository_is_empty",
             "test-invalid-persisted_target_is_quarantined",
             "test_one_shot_and_recurring_targets_recover_once",
             "test-active_lease_suppresses_recovery",

--- a/tests/test_target_recovery_contract.py
+++ b/tests/test_target_recovery_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TargetRecoveryContractTests(unittest.TestCase):
+    def test_recovery_component_loads_after_actor_registry_layer(self) -> None:
+        system = (
+            ROOT / "source" / "starintel-gserver.asd"
+        ).read_text(encoding="utf-8")
+        self.assertIn('(:file "target-recovery")', system)
+        self.assertLess(
+            system.index('(:file "actors-v09")'),
+            system.index('(:file "target-recovery")'),
+        )
+        self.assertLess(
+            system.index('(:file "target-recovery")'),
+            system.index('(:file "rabbit")'),
+        )
+
+    def test_repository_uses_configured_database_and_canonical_view(self) -> None:
+        source = (ROOT / "source" / "target-recovery.lisp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("query-persisted-target-documents", source)
+        self.assertIn('client database "targets" "by_actor"', source)
+        self.assertNotIn('"actor-targets"', source)
+        self.assertIn("load-persisted-target-records", source)
+
+    def test_typed_records_replace_overloaded_cons_submission(self) -> None:
+        recovery = (ROOT / "source" / "target-recovery.lisp").read_text(
+            encoding="utf-8"
+        )
+        rabbit = (ROOT / "source" / "rabbit.lisp").read_text(encoding="utf-8")
+        self.assertIn("defstruct (target-record", recovery)
+        self.assertIn("defstruct (target-command", recovery)
+        self.assertIn("submit-target", recovery)
+        self.assertIn("star.actors:submit-target", rabbit)
+        self.assertNotIn("tell star.actors:*targets* (cons", rabbit)
+
+    def test_recovery_is_started_after_registry_hooks(self) -> None:
+        source = (ROOT / "source" / "target-recovery.lisp").read_text(
+            encoding="utf-8"
+        )
+        hook = source.rindex("(nhooks:run-hook star:*actors-start-hook*)")
+        recovery = source.rindex("(recover-persisted-targets)")
+        self.assertLess(hook, recovery)
+        self.assertIn("*recovered-target-fingerprints*", source)
+        self.assertIn("target-active-lease-p", source)
+
+    def test_invalid_targets_have_deterministic_quarantine(self) -> None:
+        source = (ROOT / "source" / "target-recovery.lisp").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("invalid-persisted-target", source)
+        self.assertIn("invalid-target-quarantine-record", source)
+        self.assertIn("quarantine:target-recovery:", source)
+        self.assertIn("couchdb-save-quarantine-record", source)
+        self.assertIn("http-request-conflict", source)
+
+    def test_acceptance_matrix_runs_in_clos_gate(self) -> None:
+        tests = (
+            ROOT / "tests" / "run-target-recovery-conformance.lisp"
+        ).read_text(encoding="utf-8")
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        for name in (
+            "test-target-repository-uses-configured-database-and_canonical_view",
+            "test-empty-target_repository-is_empty",
+            "test-invalid-persisted_target_is_quarantined",
+            "test_one_shot_and_recurring_targets_recover_once",
+            "test-active_lease_suppresses_recovery",
+        ):
+            self.assertIn(name, tests)
+        self.assertIn("run-target-recovery-conformance.lisp", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the broken persisted target loader with one canonical repository API
- query the configured database through `targets/by_actor`
- normalize v0.8/v0.9 target fields through the document profile
- return typed `target-record` objects and submit typed `target-command` messages
- route live Rabbit target submissions through the same command path
- recover one-shot targets for immediate execution and recurring targets for scheduling
- run recovery after actor registry hooks and before Rabbit consumers accept new work
- suppress targets with active persisted leases
- deduplicate repeated recovery calls by document id and CouchDB revision
- quarantine invalid persisted targets with deterministic record IDs and reasons
- keep the historical `sumbit-target` spelling only as a compatibility alias

## Startup order

1. actor system and persistence actors
2. actor registry/index
3. target timer and target actor
4. registered actor hooks
5. persisted target recovery
6. Rabbit consumer startup in `main`

## Regression coverage

- configured database and canonical view are passed to the repository
- empty databases return no targets and no errors
- invalid targets are quarantined
- quarantine IDs are stable across repeated startup
- one-shot and recurring records recover with correct first-time semantics
- repeated recovery does not duplicate submissions
- active leases suppress recovery
- typed target commands retain their records and flags

## Stack

- base: `agent/schema-org-v0.9`
- includes completed issues #11–#16

This remains draft until fixture and CLOS target-recovery gates are green.

Closes #17