### PR TITLE
Make CouchDB document updates revision-safe and immutable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN qlot exec sbcl --non-interactive \
     --load tests/run-consumer-owner-conformance.lisp \
     --load tests/run-retry-quarantine-conformance.lisp \
     --load tests/run-target-recovery-conformance.lisp \
-    --load tests/run-target-dispatch-acceptance.lisp
+    --load tests/run-target-dispatch-acceptance.lisp \
+    --load tests/run-document-update-conformance.lisp
 
 FROM conformance AS star-server
 

--- a/source/databases/document-update-package.lisp
+++ b/source/databases/document-update-package.lisp
@@ -1,0 +1,17 @@
+(in-package :star.databases.couchdb)
+
+(export
+ '(document-update-outcome
+   document-update-outcome-status
+   document-update-outcome-document
+   document-update-outcome-attempts
+   document-update-outcome-reason
+   document-update-validation-error
+   document-update-validation-reason
+   document-update-store-conflict
+   merge-document-update
+   prepare-document-insert
+   upsert-document-update
+   couchdb-upsert-document-update
+   document-update-outcome-json)
+ :star.databases.couchdb)

--- a/source/databases/document-update.lisp
+++ b/source/databases/document-update.lisp
@@ -1,0 +1,203 @@
+(in-package :star.databases.couchdb)
+
+(defstruct (document-update-outcome
+             (:constructor make-document-update-outcome
+                 (status &key document attempts reason)))
+  status
+  document
+  (attempts 0 :type (integer 0 *))
+  reason)
+
+(define-condition document-update-validation-error (error)
+  ((reason
+    :initarg :reason
+    :reader document-update-validation-reason))
+  (:report
+   (lambda (condition stream)
+     (format stream "Document update validation failed: ~a"
+             (document-update-validation-reason condition)))))
+
+(define-condition document-update-store-conflict (error) ())
+
+(defparameter +document-update-invariant-keys+
+  '("_id" "dtype" "schema_version" "dataset" "date_added")
+  "Envelope fields that a patch cannot change after document creation.")
+
+(defun document-update-json-object-p (value)
+  (and (consp value) (eq (first value) :obj)))
+
+(defun clone-document-update-json (value)
+  (jsown:with-injective-reader
+    (jsown:parse (jsown:to-json value))))
+
+(defun document-update-value (object key &optional default)
+  (if (and object (outbox-object-has-key-p object key))
+      (jsown:val object key)
+      default))
+
+(defun document-update-string= (left right)
+  (and (stringp left) (stringp right) (string= left right)))
+
+(defun server-private-extension-key-p (key)
+  (and (stringp key)
+       (>= (length key) 8)
+       (string= "_server_" key :end2 8)))
+
+(defun assert-compatible-update-field (existing patch key)
+  (when (outbox-object-has-key-p patch key)
+    (let ((incoming (jsown:val patch key))
+          (current (document-update-value existing key)))
+      (unless (equal incoming current)
+        (error 'document-update-validation-error
+               :reason
+               (format nil "patch cannot change ~a from ~s to ~s"
+                       key current incoming))))))
+
+(defun validate-document-update-compatibility (document-id existing patch)
+  (unless (document-update-json-object-p patch)
+    (error 'document-update-validation-error
+           :reason "patch must be a JSON object"))
+  (let ((patch-id (document-update-value patch "_id")))
+    (when (and patch-id (not (document-update-string= patch-id document-id)))
+      (error 'document-update-validation-error
+             :reason
+             (format nil "patch _id ~s does not match route id ~s"
+                     patch-id document-id))))
+  (when existing
+    (dolist (key +document-update-invariant-keys+)
+      (assert-compatible-update-field existing patch key)))
+  t)
+
+(defun merge-document-update-value (current incoming path)
+  (if (and (document-update-json-object-p current)
+           (document-update-json-object-p incoming))
+      (let ((result (clone-document-update-json current)))
+        (jsown:do-json-keys (key value) incoming
+          (unless (or (and (null path)
+                           (member key +document-update-invariant-keys+
+                                   :test #'string=))
+                      (and (equal path '("extensions"))
+                           (server-private-extension-key-p key)))
+            (setf (jsown:val result key)
+                  (if (outbox-object-has-key-p result key)
+                      (merge-document-update-value
+                       (jsown:val result key)
+                       value
+                       (append path (list key)))
+                      (clone-document-update-json value)))))
+        result)
+      (clone-document-update-json incoming)))
+
+(defun merge-document-update (document-id existing patch)
+  "Return a new merged document; EXISTING and PATCH remain unchanged.
+
+Caller `_rev` is ignored. The current `_rev` and server-private extension fields
+remain controlled by persistence."
+  (validate-document-update-compatibility document-id existing patch)
+  (let ((merged (merge-document-update-value existing patch nil)))
+    (setf (jsown:val merged "_id") document-id)
+    (when (outbox-object-has-key-p existing "_rev")
+      (setf (jsown:val merged "_rev") (jsown:val existing "_rev")))
+    merged))
+
+(defun prepare-document-insert (document-id patch)
+  "Return a new insert candidate with caller `_rev` removed."
+  (validate-document-update-compatibility document-id nil patch)
+  (let ((candidate
+          (copy-json-object-excluding
+           (clone-document-update-json patch)
+           '("_rev"))))
+    (setf (jsown:val candidate "_id") document-id)
+    candidate))
+
+(defun validated-document-update (candidate)
+  (handler-case
+      (star.documents:ensure-v09-document candidate)
+    (error (condition)
+      (error 'document-update-validation-error
+             :reason (princ-to-string condition)))))
+
+(defun document-update-wire-equal-p (left right)
+  (string= (jsown:to-json left) (jsown:to-json right)))
+
+(defun upsert-document-update
+    (load-fn save-fn document-id patch &key (max-attempts 8))
+  "Create or update DOCUMENT-ID with immutable, bounded optimistic retries.
+
+LOAD-FN receives DOCUMENT-ID and returns the latest document or NIL. SAVE-FN
+receives the validated candidate and must signal DOCUMENT-UPDATE-STORE-CONFLICT
+when its CouchDB revision loses a compare-and-swap race."
+  (unless (and (integerp max-attempts) (plusp max-attempts))
+    (error "MAX-ATTEMPTS must be a positive integer"))
+  (let ((immutable-patch (clone-document-update-json patch)))
+    (loop for attempt from 1 to max-attempts
+          do
+             (let ((existing (funcall load-fn document-id)))
+               (handler-case
+                   (let* ((candidate
+                            (if existing
+                                (merge-document-update
+                                 document-id existing immutable-patch)
+                                (prepare-document-insert
+                                 document-id immutable-patch)))
+                          (validated (validated-document-update candidate)))
+                     (when (and existing
+                                (document-update-wire-equal-p
+                                 existing validated))
+                       (return
+                         (make-document-update-outcome
+                          :duplicate
+                          :document existing
+                          :attempts attempt)))
+                     (handler-case
+                         (let ((saved (funcall save-fn validated)))
+                           (return
+                             (make-document-update-outcome
+                              (if existing :updated :created)
+                              :document saved
+                              :attempts attempt)))
+                       (document-update-store-conflict ()
+                         (when (= attempt max-attempts)
+                           (return
+                             (make-document-update-outcome
+                              :conflict-exhausted
+                              :document existing
+                              :attempts attempt
+                              :reason
+                              "optimistic concurrency retry budget exhausted")))))
+                 (document-update-validation-error (condition)
+                   (return
+                     (make-document-update-outcome
+                      :validation-failed
+                      :document existing
+                      :attempts attempt
+                      :reason
+                      (document-update-validation-reason condition)))))))))
+
+(defun couchdb-upsert-document-update
+    (client database document-id patch &key (max-attempts 8))
+  "CouchDB adapter for UPSERT-DOCUMENT-UPDATE."
+  (upsert-document-update
+   (lambda (id)
+     (couchdb-load-outbox-document client database id))
+   (lambda (candidate)
+     (handler-case
+         (couchdb-save-outbox-document client database candidate)
+       (outbox-store-conflict ()
+         (error 'document-update-store-conflict))))
+   document-id
+   patch
+   :max-attempts max-attempts))
+
+(defun document-update-outcome-json (outcome)
+  (let ((object (jsown:empty-object)))
+    (setf (jsown:val object "status")
+          (string-downcase
+           (symbol-name (document-update-outcome-status outcome)))
+          (jsown:val object "attempts")
+          (document-update-outcome-attempts outcome)
+          (jsown:val object "reason")
+          (or (document-update-outcome-reason outcome) :null)
+          (jsown:val object "document")
+          (or (document-update-outcome-document outcome) :null))
+    object))

--- a/source/databases/document-update.lisp
+++ b/source/databases/document-update.lisp
@@ -127,20 +127,33 @@ fields remain controlled by persistence."
 (defun document-update-wire-equal-p (left right)
   (string= (jsown:to-json left) (jsown:to-json right)))
 
-(defun prepare-validated-document-update
+(defun prepare-document-update-candidate
     (document-id existing immutable-patch)
-  "Return validated candidate and NIL, or NIL and a validation condition."
+  "Return raw candidate and NIL, or NIL and a compatibility condition."
   (handler-case
       (values
-       (validated-document-update
-        (if existing
-            (merge-document-update
-             document-id existing immutable-patch)
-            (prepare-document-insert
-             document-id immutable-patch)))
+       (if existing
+           (merge-document-update
+            document-id existing immutable-patch)
+           (prepare-document-insert
+            document-id immutable-patch))
        nil)
     (document-update-validation-error (condition)
       (values nil condition))))
+
+(defun validate-prepared-document-update (candidate)
+  "Return normalized candidate and NIL, or NIL and a validation condition."
+  (handler-case
+      (values (validated-document-update candidate) nil)
+    (document-update-validation-error (condition)
+      (values nil condition))))
+
+(defun update-validation-outcome (existing attempt condition)
+  (make-document-update-outcome
+   :validation-failed
+   :document existing
+   :attempts attempt
+   :reason (document-update-validation-reason condition)))
 
 (defun upsert-document-update
     (load-fn save-fn document-id patch &key (max-attempts 8))
@@ -155,42 +168,45 @@ when its CouchDB revision loses a compare-and-swap race."
     (loop for attempt from 1 to max-attempts
           do
              (let ((existing (funcall load-fn document-id)))
-               (multiple-value-bind (validated validation-error)
-                   (prepare-validated-document-update
+               (multiple-value-bind (candidate preparation-error)
+                   (prepare-document-update-candidate
                     document-id existing immutable-patch)
-                 (when validation-error
+                 (when preparation-error
                    (return
-                     (make-document-update-outcome
-                      :validation-failed
-                      :document existing
-                      :attempts attempt
-                      :reason
-                      (document-update-validation-reason
-                       validation-error))))
+                     (update-validation-outcome
+                      existing attempt preparation-error)))
+                 ;; Compare before normalization so a revision-only request cannot
+                 ;; create a phantom write merely because schema metadata is filled.
                  (when (and existing
                             (document-update-wire-equal-p
-                             existing validated))
+                             existing candidate))
                    (return
                      (make-document-update-outcome
                       :duplicate
                       :document existing
                       :attempts attempt)))
-                 (handler-case
-                     (let ((saved (funcall save-fn validated)))
-                       (return
-                         (make-document-update-outcome
-                          (if existing :updated :created)
-                          :document saved
-                          :attempts attempt)))
-                   (document-update-store-conflict ()
-                     (when (= attempt max-attempts)
-                       (return
-                         (make-document-update-outcome
-                          :conflict-exhausted
-                          :document existing
-                          :attempts attempt
-                          :reason
-                          "optimistic concurrency retry budget exhausted"))))))))))
+                 (multiple-value-bind (validated validation-error)
+                     (validate-prepared-document-update candidate)
+                   (when validation-error
+                     (return
+                       (update-validation-outcome
+                        existing attempt validation-error)))
+                   (handler-case
+                       (let ((saved (funcall save-fn validated)))
+                         (return
+                           (make-document-update-outcome
+                            (if existing :updated :created)
+                            :document saved
+                            :attempts attempt)))
+                     (document-update-store-conflict ()
+                       (when (= attempt max-attempts)
+                         (return
+                           (make-document-update-outcome
+                            :conflict-exhausted
+                            :document existing
+                            :attempts attempt
+                            :reason
+                            "optimistic concurrency retry budget exhausted")))))))))))
 
 (defun couchdb-upsert-document-update
     (client database document-id patch &key (max-attempts 8))

--- a/source/databases/document-update.lisp
+++ b/source/databases/document-update.lisp
@@ -179,7 +179,7 @@ when its CouchDB revision loses a compare-and-swap race."
                       :document existing
                       :attempts attempt
                       :reason
-                      (document-update-validation-reason condition)))))))))
+                      (document-update-validation-reason condition))))))))))
 
 (defun couchdb-upsert-document-update
     (client database document-id patch &key (max-attempts 8))

--- a/source/databases/document-update.lisp
+++ b/source/databases/document-update.lisp
@@ -19,6 +19,10 @@
 
 (define-condition document-update-store-conflict (error) ())
 
+(defparameter +document-update-persistence-keys+
+  '("_id" "_rev")
+  "Envelope fields controlled only by CouchDB persistence.")
+
 (defparameter +document-update-invariant-keys+
   '("_id" "dtype" "schema_version" "dataset" "date_added")
   "Envelope fields that a patch cannot change after document creation.")
@@ -74,6 +78,9 @@
       (let ((result (clone-document-update-json current)))
         (jsown:do-json-keys (key value) incoming
           (unless (or (and (null path)
+                           (member key +document-update-persistence-keys+
+                                   :test #'string=))
+                      (and (null path)
                            (member key +document-update-invariant-keys+
                                    :test #'string=))
                       (and (equal path '("extensions"))
@@ -91,8 +98,8 @@
 (defun merge-document-update (document-id existing patch)
   "Return a new merged document; EXISTING and PATCH remain unchanged.
 
-Caller `_rev` is ignored. The current `_rev` and server-private extension fields
-remain controlled by persistence."
+Caller `_rev` is never copied. The current `_rev` and server-private extension
+fields remain controlled by persistence."
   (validate-document-update-compatibility document-id existing patch)
   (let ((merged (merge-document-update-value existing patch nil)))
     (setf (jsown:val merged "_id") document-id)

--- a/source/databases/document-update.lisp
+++ b/source/databases/document-update.lisp
@@ -127,6 +127,21 @@ fields remain controlled by persistence."
 (defun document-update-wire-equal-p (left right)
   (string= (jsown:to-json left) (jsown:to-json right)))
 
+(defun prepare-validated-document-update
+    (document-id existing immutable-patch)
+  "Return validated candidate and NIL, or NIL and a validation condition."
+  (handler-case
+      (values
+       (validated-document-update
+        (if existing
+            (merge-document-update
+             document-id existing immutable-patch)
+            (prepare-document-insert
+             document-id immutable-patch)))
+       nil)
+    (document-update-validation-error (condition)
+      (values nil condition))))
+
 (defun upsert-document-update
     (load-fn save-fn document-id patch &key (max-attempts 8))
   "Create or update DOCUMENT-ID with immutable, bounded optimistic retries.
@@ -140,46 +155,42 @@ when its CouchDB revision loses a compare-and-swap race."
     (loop for attempt from 1 to max-attempts
           do
              (let ((existing (funcall load-fn document-id)))
-               (handler-case
-                   (let* ((candidate
-                            (if existing
-                                (merge-document-update
-                                 document-id existing immutable-patch)
-                                (prepare-document-insert
-                                 document-id immutable-patch)))
-                          (validated (validated-document-update candidate)))
-                     (when (and existing
-                                (document-update-wire-equal-p
-                                 existing validated))
-                       (return
-                         (make-document-update-outcome
-                          :duplicate
-                          :document existing
-                          :attempts attempt)))
-                     (handler-case
-                         (let ((saved (funcall save-fn validated)))
-                           (return
-                             (make-document-update-outcome
-                              (if existing :updated :created)
-                              :document saved
-                              :attempts attempt)))
-                       (document-update-store-conflict ()
-                         (when (= attempt max-attempts)
-                           (return
-                             (make-document-update-outcome
-                              :conflict-exhausted
-                              :document existing
-                              :attempts attempt
-                              :reason
-                              "optimistic concurrency retry budget exhausted")))))
-                 (document-update-validation-error (condition)
+               (multiple-value-bind (validated validation-error)
+                   (prepare-validated-document-update
+                    document-id existing immutable-patch)
+                 (when validation-error
                    (return
                      (make-document-update-outcome
                       :validation-failed
                       :document existing
                       :attempts attempt
                       :reason
-                      (document-update-validation-reason condition))))))))))
+                      (document-update-validation-reason
+                       validation-error))))
+                 (when (and existing
+                            (document-update-wire-equal-p
+                             existing validated))
+                   (return
+                     (make-document-update-outcome
+                      :duplicate
+                      :document existing
+                      :attempts attempt)))
+                 (handler-case
+                     (let ((saved (funcall save-fn validated)))
+                       (return
+                         (make-document-update-outcome
+                          (if existing :updated :created)
+                          :document saved
+                          :attempts attempt)))
+                   (document-update-store-conflict ()
+                     (when (= attempt max-attempts)
+                       (return
+                         (make-document-update-outcome
+                          :conflict-exhausted
+                          :document existing
+                          :attempts attempt
+                          :reason
+                          "optimistic concurrency retry budget exhausted"))))))))))
 
 (defun couchdb-upsert-document-update
     (client database document-id patch &key (max-attempts 8))

--- a/source/frontends/http-document-update.lisp
+++ b/source/frontends/http-document-update.lisp
@@ -1,0 +1,28 @@
+(in-package :star.frontends.http-api)
+
+(defun request-json-body ()
+  (jsown:with-injective-reader
+    (jsown:parse
+     (babel:octets-to-string
+      (lack.request:request-content (ningle:context :request))
+      :encoding :utf-8))))
+
+(setf (ningle:route *app* "/document/:id" :method :put)
+      (lambda (params)
+        (set-default-headers)
+        (let ((document-id (cdr (assoc :id params :test #'string=))))
+          (handler-case
+              (let ((patch (request-json-body)))
+                (couchdb-handler (client *couchdb-pool*)
+                  (jsown:to-json
+                   (star.databases.couchdb:document-update-outcome-json
+                    (star.databases.couchdb:couchdb-upsert-document-update
+                     client
+                     star:*couchdb-default-database*
+                     document-id
+                     patch)))))
+            (error (condition)
+              (status-msg
+               "Invalid document update request"
+               'error
+               :info (princ-to-string condition)))))))

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -22,6 +22,8 @@
                   (:file "databases/couchdb")
                   (:file "databases/couchdb-v09")
                   (:file "databases/outbox")
+                  (:file "databases/document-update-package")
+                  (:file "databases/document-update")
                   (:file "databases/quarantine")
                   (:file "databases/target-acceptance")
                   (:file "init")
@@ -36,6 +38,7 @@
                   (:file "rabbit")
                   (:file "frontends/http-api")
                   (:file "frontends/http-api-v09")
+                  (:file "frontends/http-document-update")
                   (:file "main"))
   :depends-on   (#:starintel
                   #:cl-couch

--- a/tests/run-document-update-conformance.lisp
+++ b/tests/run-document-update-conformance.lisp
@@ -1,0 +1,218 @@
+(in-package :cl-user)
+
+(defun update-check (condition control &rest arguments)
+  (unless condition
+    (error (apply #'format nil control arguments))))
+
+(defun update-test-document
+    (id &key (revision "2-current") (target "example.org"))
+  (let ((document (jsown:empty-object))
+        (data (jsown:empty-object)))
+    (setf (jsown:val data "actor") "scanner"
+          (jsown:val data "target") target
+          (jsown:val data "delay") 0
+          (jsown:val data "recurring") :false
+          (jsown:val data "options") #()
+          (jsown:val document "_id") id
+          (jsown:val document "_rev") revision
+          (jsown:val document "dataset") "default"
+          (jsown:val document "dtype") "target"
+          (jsown:val document "schema_version") "0.9.0"
+          (jsown:val document "version") 1
+          (jsown:val document "date_added") "2026-07-26T00:00:00Z"
+          (jsown:val document "date_updated") "2026-07-26T00:00:00Z"
+          (jsown:val document "sources") #()
+          (jsown:val document "evidence") #()
+          (jsown:val document "data") data)
+    document))
+
+(defun update-test-patch (&key revision target id dtype)
+  (let ((patch (jsown:empty-object)))
+    (when revision
+      (setf (jsown:val patch "_rev") revision))
+    (when id
+      (setf (jsown:val patch "_id") id))
+    (when dtype
+      (setf (jsown:val patch "dtype") dtype))
+    (when target
+      (let ((data (jsown:empty-object)))
+        (setf (jsown:val data "target") target
+              (jsown:val patch "data") data)))
+    patch))
+
+(defun test-stale-client-revision-refetches-and-updates ()
+  (let* ((existing (update-test-document "target:stale"))
+         (patch (update-test-patch
+                 :revision "1-stale" :target "updated.example"))
+         (existing-before (jsown:to-json existing))
+         (patch-before (jsown:to-json patch))
+         (saved nil)
+         (outcome
+           (star.databases.couchdb:upsert-document-update
+            (lambda (id)
+              (declare (ignore id))
+              (star.databases.couchdb::clone-document-update-json existing))
+            (lambda (candidate)
+              (setf saved
+                    (star.databases.couchdb::clone-document-update-json
+                     candidate))
+              candidate)
+            "target:stale"
+            patch)))
+    (update-check
+     (eq :updated
+         (star.databases.couchdb:document-update-outcome-status outcome))
+     "Stale revision outcome was ~s"
+     (star.databases.couchdb:document-update-outcome-status outcome))
+    (update-check
+     (string= "2-current" (jsown:val saved "_rev"))
+     "Stale revision overwrote latest revision: ~s"
+     (jsown:val saved "_rev"))
+    (update-check
+     (string= "updated.example"
+              (jsown:val (jsown:val saved "data") "target"))
+     "Patch data was not merged")
+    (update-check (string= existing-before (jsown:to-json existing))
+                  "Existing document was mutated")
+    (update-check (string= patch-before (jsown:to-json patch))
+                  "Patch was mutated")))
+
+(defun test-missing-document-strips_stale_revision_before_create ()
+  (let* ((patch (update-test-document
+                 "target:create" :revision "9-stale-create"))
+         (patch-before (jsown:to-json patch))
+         (saved nil)
+         (outcome
+           (star.databases.couchdb:upsert-document-update
+            (lambda (id) (declare (ignore id)) nil)
+            (lambda (candidate)
+              (setf saved
+                    (star.databases.couchdb::clone-document-update-json
+                     candidate))
+              candidate)
+            "target:create"
+            patch)))
+    (update-check
+     (eq :created
+         (star.databases.couchdb:document-update-outcome-status outcome))
+     "Missing document outcome was not created")
+    (update-check
+     (not (star.databases.couchdb::outbox-object-has-key-p saved "_rev"))
+     "New insert retained caller revision")
+    (update-check (string= patch-before (jsown:to-json patch))
+                  "Insert patch was mutated")))
+
+(defun test-patch-cannot_change_identity_or_schema ()
+  (dolist (patch
+           (list
+            (update-test-patch :id "target:other")
+            (update-test-patch :dtype "person")))
+    (let ((outcome
+            (star.databases.couchdb:upsert-document-update
+             (lambda (id)
+               (declare (ignore id))
+               (update-test-document "target:protected"))
+             (lambda (candidate)
+               (declare (ignore candidate))
+               (error "Invalid patch reached save"))
+             "target:protected"
+             patch)))
+      (update-check
+       (eq :validation-failed
+           (star.databases.couchdb:document-update-outcome-status outcome))
+       "Protected field patch returned ~s"
+       (star.databases.couchdb:document-update-outcome-status outcome)))))
+
+(defun test-conflict_retries_are_bounded_and_refetch_latest_revision ()
+  (let ((loads 0)
+        (saves 0)
+        (seen-revisions nil)
+        (patch (update-test-patch
+                :revision "1-stale" :target "retry.example")))
+    (let ((outcome
+            (star.databases.couchdb:upsert-document-update
+             (lambda (id)
+               (declare (ignore id))
+               (incf loads)
+               (update-test-document
+                "target:retry"
+                :revision (format nil "~d-current" loads)))
+             (lambda (candidate)
+               (incf saves)
+               (push (jsown:val candidate "_rev") seen-revisions)
+               (error 'star.databases.couchdb:document-update-store-conflict))
+             "target:retry"
+             patch
+             :max-attempts 3)))
+      (update-check
+       (eq :conflict-exhausted
+           (star.databases.couchdb:document-update-outcome-status outcome))
+       "Retry exhaustion returned ~s"
+       (star.databases.couchdb:document-update-outcome-status outcome))
+      (update-check (= 3 loads) "Expected 3 refetches, got ~d" loads)
+      (update-check (= 3 saves) "Expected 3 saves, got ~d" saves)
+      (update-check
+       (equal (reverse seen-revisions)
+              '("1-current" "2-current" "3-current"))
+       "Retries reused a stale revision: ~s"
+       (reverse seen-revisions)))))
+
+(defun test_revision_only_patch_is_duplicate ()
+  (let ((saved nil)
+        (existing (update-test-document "target:duplicate")))
+    (let ((outcome
+            (star.databases.couchdb:upsert-document-update
+             (lambda (id) (declare (ignore id)) existing)
+             (lambda (candidate)
+               (declare (ignore candidate))
+               (setf saved t))
+             "target:duplicate"
+             (update-test-patch :revision "1-stale"))))
+      (update-check
+       (eq :duplicate
+           (star.databases.couchdb:document-update-outcome-status outcome))
+       "Revision-only patch was not duplicate")
+      (update-check (not saved) "Duplicate patch reached save"))))
+
+(defun test-server_private_extensions_are_preserved ()
+  (let* ((existing (update-test-document "target:private"))
+         (extensions (jsown:empty-object))
+         (server-state (jsown:empty-object))
+         (patch (jsown:empty-object))
+         (patch-extensions (jsown:empty-object))
+         (forged-state (jsown:empty-object)))
+    (setf (jsown:val server-state "status") "pending"
+          (jsown:val extensions "_server_outbox") server-state
+          (jsown:val existing "extensions") extensions
+          (jsown:val forged-state "status") "forged"
+          (jsown:val patch-extensions "_server_outbox") forged-state
+          (jsown:val patch-extensions "client_note") "allowed"
+          (jsown:val patch "extensions") patch-extensions)
+    (let ((merged
+            (star.databases.couchdb:merge-document-update
+             "target:private" existing patch)))
+      (update-check
+       (string= "pending"
+                (jsown:val
+                 (jsown:val
+                  (jsown:val merged "extensions") "_server_outbox")
+                 "status"))
+       "Patch overwrote server-private extension")
+      (update-check
+       (string= "allowed"
+                (jsown:val
+                 (jsown:val merged "extensions") "client_note"))
+       "Client extension was not merged"))))
+
+(defun run-document-update-conformance-tests ()
+  (format t "~&Running revision-safe document update tests~%")
+  (test-stale-client-revision-refetches-and-updates)
+  (test-missing-document-strips_stale_revision_before_create)
+  (test-patch-cannot_change_identity_or_schema)
+  (test-conflict_retries_are_bounded_and_refetch_latest_revision)
+  (test_revision_only_patch_is_duplicate)
+  (test-server_private_extensions_are_preserved)
+  (format t "~&Revision-safe document update tests passed~%")
+  t)
+
+(run-document-update-conformance-tests)

--- a/tests/test_document_update_contract.py
+++ b/tests/test_document_update_contract.py
@@ -57,7 +57,7 @@ class DocumentUpdateContractTests(unittest.TestCase):
         dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
         for name in (
             "test-stale-client-revision-refetches-and-updates",
-            "test-missing-document-strips_stale_revision_before-create",
+            "test-missing-document-strips_stale_revision_before_create",
             "test-patch-cannot_change_identity_or_schema",
             "test-conflict_retries_are_bounded_and_refetch_latest_revision",
             "test_revision_only_patch_is_duplicate",

--- a/tests/test_document_update_contract.py
+++ b/tests/test_document_update_contract.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DocumentUpdateContractTests(unittest.TestCase):
+    def test_update_service_has_structured_outcomes(self) -> None:
+        source = (
+            ROOT / "source" / "databases" / "document-update.lisp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("defstruct (document-update-outcome", source)
+        for status in (
+            ":created",
+            ":updated",
+            ":duplicate",
+            ":conflict-exhausted",
+            ":validation-failed",
+        ):
+            self.assertIn(status, source)
+
+    def test_revision_and_identity_are_persistence_controlled(self) -> None:
+        source = (
+            ROOT / "source" / "databases" / "document-update.lisp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("+document-update-persistence-keys+", source)
+        self.assertIn("'(\"_id\" \"_rev\")", source)
+        self.assertIn("copy-json-object-excluding", source)
+        self.assertIn("'(\"_rev\")", source)
+        self.assertIn("patch cannot change", source)
+        self.assertIn("server-private-extension-key-p", source)
+
+    def test_merge_is_explicitly_immutable_and_retries_are_bounded(self) -> None:
+        source = (
+            ROOT / "source" / "databases" / "document-update.lisp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("clone-document-update-json", source)
+        self.assertIn("immutable-patch", source)
+        self.assertIn("loop for attempt from 1 to max-attempts", source)
+        self.assertIn("optimistic concurrency retry budget exhausted", source)
+        self.assertNotIn("merge-jsown", source)
+
+    def test_http_put_uses_canonical_update_service(self) -> None:
+        source = (
+            ROOT / "source" / "frontends" / "http-document-update.lisp"
+        ).read_text(encoding="utf-8")
+        self.assertIn('"/document/:id" :method :put', source)
+        self.assertIn("couchdb-upsert-document-update", source)
+        self.assertIn("document-update-outcome-json", source)
+
+    def test_acceptance_matrix_runs_in_clos_gate(self) -> None:
+        tests = (
+            ROOT / "tests" / "run-document-update-conformance.lisp"
+        ).read_text(encoding="utf-8")
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        for name in (
+            "test-stale-client-revision-refetches-and-updates",
+            "test-missing-document-strips_stale_revision_before-create",
+            "test-patch-cannot_change_identity_or_schema",
+            "test-conflict_retries_are_bounded_and_refetch_latest_revision",
+            "test_revision_only_patch_is_duplicate",
+            "test-server_private_extensions_are_preserved",
+        ):
+            self.assertIn(name, tests)
+        self.assertIn("run-document-update-conformance.lisp", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one canonical document update/upsert service
- treat `_id` and `_rev` as persistence-controlled fields
- ignore stale caller revisions and preserve the latest fetched CouchDB revision
- strip `_rev` before missing-document inserts
- recursively merge caller-owned JSON fields without mutating fetched or caller objects
- prevent patches from changing document id, dtype, schema version, dataset, or creation time
- preserve server-private `extensions._server_*` state while allowing client extension updates
- validate the complete merged/created document through the v0.9 boundary
- refetch and recompute on bounded optimistic-concurrency conflicts
- return structured created, updated, duplicate, validation-failed, and conflict-exhausted outcomes
- route HTTP `PUT /document/:id` through the canonical service

## Regression coverage

- stale client revision succeeds using the latest fetched `_rev`
- missing document with stale `_rev` inserts without a revision
- `_id` and dtype changes fail validation
- conflict retries refetch each latest revision and stop at the configured ceiling
- revision-only patches return duplicate without writing
- server-private extensions cannot be overwritten
- fetched and caller objects remain unchanged

## Stack

- base: `agent/schema-org-v0.9`
- includes completed issues #11–#18

This remains draft until fixture and CLOS document-update gates are green.

Closes #19