### PR TITLE
Validate CouchDB views through a canonical registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN qlot exec sbcl --non-interactive \
     --load tests/run-retry-quarantine-conformance.lisp \
     --load tests/run-target-recovery-conformance.lisp \
     --load tests/run-target-dispatch-acceptance.lisp \
-    --load tests/run-document-update-conformance.lisp
+    --load tests/run-document-update-conformance.lisp \
+    --load tests/run-view-registry-conformance.lisp
 
 FROM conformance AS star-server
 

--- a/source/databases/view-registry-package.lisp
+++ b/source/databases/view-registry-package.lisp
@@ -1,0 +1,29 @@
+(in-package :star.databases.couchdb)
+
+(export
+ '(view-spec
+   view-spec-name
+   view-spec-design-document
+   view-spec-view-name
+   view-spec-reducer-p
+   view-spec-default-reduce
+   view-spec-default-include-docs
+   view-spec-accepted-keywords
+   view-map-result
+   view-map-result-rows
+   view-document-result
+   view-document-result-documents
+   view-document-result-rows
+   view-reduced-result
+   view-reduced-result-rows
+   view-registry-error
+   view-registry-error-reason
+   registered-view-spec
+   registered-view-names
+   execute-registered-view
+   view-result-value
+   validate-view-registry
+   view-registry-matrix
+   social-posts-by-platform
+   documents-by-dataset)
+ :star.databases.couchdb)

--- a/source/databases/view-registry.lisp
+++ b/source/databases/view-registry.lisp
@@ -1,0 +1,370 @@
+(in-package :star.databases.couchdb)
+
+(defstruct (view-spec
+             (:constructor make-view-spec
+                 (name design-document view-name
+                  &key reducer-p
+                    (default-reduce nil)
+                    (default-include-docs t)
+                    accepted-keywords)))
+  name
+  design-document
+  view-name
+  (reducer-p nil)
+  (default-reduce nil)
+  (default-include-docs t)
+  accepted-keywords)
+
+(defstruct (view-map-result
+             (:constructor make-view-map-result (rows)))
+  rows)
+
+(defstruct (view-document-result
+             (:constructor make-view-document-result (documents rows)))
+  documents
+  rows)
+
+(defstruct (view-reduced-result
+             (:constructor make-view-reduced-result (rows)))
+  rows)
+
+(define-condition view-registry-error (error)
+  ((reason
+    :initarg :reason
+    :reader view-registry-error-reason))
+  (:report
+   (lambda (condition stream)
+     (format stream "CouchDB view registry error: ~a"
+             (view-registry-error-reason condition)))))
+
+(defparameter +view-wrapper-keywords+
+  '(:limit :start-key :end-key :keys :key :descending
+    :include-docs :update :skip :reduce :group :group-level :sort-fn))
+
+(defparameter *view-registry* (make-hash-table :test #'eq))
+
+(defun register-view-spec
+    (name design-document view-name
+     &key reducer-p (default-reduce nil) (default-include-docs t)
+       (accepted-keywords +view-wrapper-keywords+))
+  (setf (gethash name *view-registry*)
+        (make-view-spec
+         name design-document view-name
+         :reducer-p reducer-p
+         :default-reduce default-reduce
+         :default-include-docs default-include-docs
+         :accepted-keywords accepted-keywords)))
+
+(defun registered-view-spec (name)
+  (or (gethash name *view-registry*)
+      (error 'view-registry-error
+             :reason (format nil "view wrapper ~s is not registered" name))))
+
+(defun registered-view-names ()
+  (sort
+   (loop for name being the hash-keys of *view-registry* collect name)
+   #'string< :key #'symbol-name))
+
+(defun register-public-view-specs ()
+  (clrhash *view-registry*)
+  (register-view-spec 'messages-by-user "messages" "messages_by_user"
+                      :reducer-p t)
+  (register-view-spec 'messages-by-platform "messages" "messages_by_platform"
+                      :reducer-p t)
+  (register-view-spec 'messages-by-group "messages" "messages_by_group"
+                      :reducer-p t)
+  (register-view-spec 'social-posts-by-user "messages" "social_posts_by_user"
+                      :reducer-p t)
+  (register-view-spec 'social-posts-by-group "messages" "social_posts_by_group"
+                      :reducer-p t)
+  (register-view-spec 'social-posts-by-platform
+                      "messages" "social_posts_by_platform"
+                      :reducer-p t)
+  (register-view-spec 'by-channel "messages" "by_channel"
+                      :reducer-p t)
+  (register-view-spec 'groups "messages" "groups"
+                      :reducer-p t
+                      :default-reduce t
+                      :default-include-docs nil)
+  (register-view-spec 'count-by-dtype "data" "count_by_dtype"
+                      :reducer-p t
+                      :default-reduce t
+                      :default-include-docs nil)
+  (register-view-spec 'dataset-size "data" "dataset_size"
+                      :reducer-p t
+                      :default-reduce t
+                      :default-include-docs nil)
+  (register-view-spec 'documents-by-dataset "data" "by_dataset"
+                      :default-include-docs t)
+  (register-view-spec 'orgs-by-country "orgs" "by_country")
+  (register-view-spec 'orgs-by-name "orgs" "by_name")
+  (register-view-spec 'persons-by-name "persons" "by_name")
+  (register-view-spec 'persons-by-region "persons" "by_region")
+  (register-view-spec 'relations-edges "relations" "edges"
+                      :reducer-p t)
+  (register-view-spec 'relations-incoming-count
+                      "relations" "incoming_count"
+                      :reducer-p t
+                      :default-reduce t
+                      :default-include-docs nil)
+  (register-view-spec 'relations-outgoing-count
+                      "relations" "outgoing_count"
+                      :reducer-p t
+                      :default-reduce t
+                      :default-include-docs nil)
+  (register-view-spec 'targets-actor-counts "targets" "actor_count"
+                      :reducer-p t
+                      :default-reduce t
+                      :default-include-docs nil)
+  (register-view-spec 'targets-by-actor "targets" "by_actor")
+  (register-view-spec 'targets-target-count "targets" "target_count"
+                      :reducer-p t
+                      :default-reduce t
+                      :default-include-docs nil)
+  (register-view-spec 'users-by-platform "users" "by_platform")
+  (register-view-spec 'timeline-view "time" "timeline"
+                      :reducer-p t)
+  t)
+
+(register-public-view-specs)
+
+(defun view-plist-present-p (arguments keyword)
+  (loop for tail on arguments by #'cddr
+        thereis (eq (first tail) keyword)))
+
+(defun view-plist-value (arguments keyword default)
+  (if (view-plist-present-p arguments keyword)
+      (getf arguments keyword)
+      default))
+
+(defun validate-view-wrapper-arguments (spec arguments)
+  (when (oddp (length arguments))
+    (error 'view-registry-error
+           :reason (format nil "odd wrapper keyword list: ~s" arguments)))
+  (loop for (keyword value) on arguments by #'cddr
+        do (declare (ignore value))
+           (unless (member keyword
+                           (view-spec-accepted-keywords spec)
+                           :test #'eq)
+             (error 'view-registry-error
+                    :reason
+                    (format nil "wrapper ~a does not accept ~s"
+                            (view-spec-name spec) keyword))))
+  t)
+
+(defun view-sequence-list (value)
+  (cond
+    ((null value) nil)
+    ((vectorp value) (coerce value 'list))
+    ((listp value) value)
+    (t
+     (error 'view-registry-error
+            :reason (format nil "view rows are not an array: ~s" value)))))
+
+(defun validate-view-result-shape
+    (spec reduce include-docs group group-level)
+  (when (and reduce (not (view-spec-reducer-p spec)))
+    (error 'view-registry-error
+           :reason
+           (format nil "view ~a/~a has no reducer"
+                   (view-spec-design-document spec)
+                   (view-spec-view-name spec))))
+  (when (and reduce include-docs)
+    (error 'view-registry-error
+           :reason "reduced view requests cannot include documents"))
+  (when (and (or group (plusp group-level)) (not reduce))
+    (error 'view-registry-error
+           :reason "group/group-level requires reduce=true"))
+  t)
+
+(defun view-query-arguments
+    (arguments reduce include-docs group group-level)
+  (list
+   :limit (view-plist-value arguments :limit 50)
+   :start-key (view-plist-value arguments :start-key nil)
+   :end-key (view-plist-value arguments :end-key nil)
+   :keys (view-plist-value arguments :keys nil)
+   :key (view-plist-value arguments :key nil)
+   :descending (view-plist-value arguments :descending nil)
+   :include-docs include-docs
+   :update (view-plist-value arguments :update t)
+   :skip (view-plist-value arguments :skip 0)
+   :reduce reduce
+   :group group
+   :group-level group-level))
+
+(defun view-row-documents (rows)
+  (loop for row in rows
+        for document = (jsown:val-safe row "doc")
+        when document collect document))
+
+(defun execute-registered-view (name client database &rest arguments)
+  "Validate and execute one registered view, returning a typed result."
+  (let* ((spec (registered-view-spec name)))
+    (validate-view-wrapper-arguments spec arguments)
+    (let* ((reduce
+             (view-plist-value
+              arguments :reduce (view-spec-default-reduce spec)))
+           (include-docs
+             (view-plist-value
+              arguments :include-docs
+              (view-spec-default-include-docs spec)))
+           (group
+             (view-plist-value arguments :group (and reduce t)))
+           (group-level
+             (view-plist-value arguments :group-level 0)))
+      (validate-view-result-shape
+       spec reduce include-docs group group-level)
+      (let* ((response
+               (apply #'query-view
+                      client
+                      database
+                      (view-spec-design-document spec)
+                      (view-spec-view-name spec)
+                      (view-query-arguments
+                       arguments reduce include-docs group group-level)))
+             (rows
+               (view-sequence-list
+                (jsown:val-safe response "rows"))))
+        (cond
+          (reduce
+           (make-view-reduced-result rows))
+          (include-docs
+           (let* ((documents (view-row-documents rows))
+                  (sort-fn
+                    (view-plist-value
+                     arguments :sort-fn #'sort-docs-by-date)))
+             (make-view-document-result
+              (if sort-fn (funcall sort-fn documents) documents)
+              rows)))
+          (t
+           (make-view-map-result rows)))))))
+
+(defun view-result-value (result)
+  (etypecase result
+    (view-document-result
+     (view-document-result-documents result))
+    (view-map-result
+     (view-map-result-rows result))
+    (view-reduced-result
+     (view-reduced-result-rows result))))
+
+(defmacro define-registered-view-wrapper (name)
+  `(defun ,name (client database &rest arguments)
+     (view-result-value
+      (apply #'execute-registered-view
+             ',name client database arguments))))
+
+(define-registered-view-wrapper messages-by-user)
+(define-registered-view-wrapper messages-by-platform)
+(define-registered-view-wrapper messages-by-group)
+(define-registered-view-wrapper social-posts-by-user)
+(define-registered-view-wrapper social-posts-by-group)
+(define-registered-view-wrapper social-posts-by-platform)
+(define-registered-view-wrapper by-channel)
+(define-registered-view-wrapper groups)
+(define-registered-view-wrapper count-by-dtype)
+(define-registered-view-wrapper dataset-size)
+(define-registered-view-wrapper documents-by-dataset)
+(define-registered-view-wrapper orgs-by-country)
+(define-registered-view-wrapper orgs-by-name)
+(define-registered-view-wrapper persons-by-name)
+(define-registered-view-wrapper persons-by-region)
+(define-registered-view-wrapper relations-edges)
+(define-registered-view-wrapper relations-incoming-count)
+(define-registered-view-wrapper relations-outgoing-count)
+(define-registered-view-wrapper targets-actor-counts)
+(define-registered-view-wrapper targets-by-actor)
+(define-registered-view-wrapper targets-target-count)
+(define-registered-view-wrapper users-by-platform)
+
+(defun get-targets* (client database &rest actors)
+  (let ((documents
+          (apply #'targets-by-actor
+                 client database
+                 :keys actors
+                 :include-docs t
+                 :reduce nil
+                 nil)))
+    (loop for document in documents
+          for actor = (star.documents:document-value document "actor")
+          collect (cons actor document))))
+
+(defun export-by-dataset* (client database dataset path)
+  "Export map rows from data/by_dataset; never mix reduced and document rows."
+  (let ((total-exported 0)
+        (skip 0)
+        (page-size 100))
+    (with-open-file
+        (stream path :direction :output :if-exists :supersede)
+      (loop
+        for documents =
+          (documents-by-dataset
+           client database
+           :key dataset
+           :limit page-size
+           :skip skip
+           :include-docs t
+           :reduce nil)
+        while documents
+        do
+           (dolist (document documents)
+             (write-string (jsown:to-json document) stream)
+             (terpri stream)
+             (incf total-exported))
+           (incf skip page-size)))
+    total-exported))
+
+(defun read-view-registry-document (path)
+  (jsown:with-injective-reader
+    (jsown:parse
+     (uiop:read-file-string path))))
+
+(defun checked-in-design-document-map ()
+  (let ((documents (make-hash-table :test #'equal))
+        (directory
+          (uiop:merge-pathnames*
+           "views/"
+           (asdf:system-source-directory :starintel-gserver))))
+    (dolist (path (uiop:directory-files directory) documents)
+      (when (string-equal "json" (pathname-type path))
+        (let* ((document (read-view-registry-document path))
+               (id (jsown:val document "_id"))
+               (name (subseq id (length "_design/"))))
+          (setf (gethash name documents) document))))))
+
+(defun design-document-has-view-p (document view-name)
+  (let ((views (jsown:val-safe document "views")))
+    (and views (outbox-object-has-key-p views view-name))))
+
+(defun validate-view-registry (&optional (documents (checked-in-design-document-map)))
+  "Fail before serving traffic when a registered design/view is absent."
+  (dolist (name (registered-view-names) t)
+    (let* ((spec (registered-view-spec name))
+           (design-name (view-spec-design-document spec))
+           (document (gethash design-name documents)))
+      (unless document
+        (error 'view-registry-error
+               :reason
+               (format nil "wrapper ~a references missing design document ~a"
+                       name design-name)))
+      (unless (design-document-has-view-p
+               document (view-spec-view-name spec))
+        (error 'view-registry-error
+               :reason
+               (format nil "wrapper ~a references missing view ~a/~a"
+                       name design-name (view-spec-view-name spec)))))))
+
+(defun view-registry-matrix ()
+  (loop for name in (registered-view-names)
+        for spec = (registered-view-spec name)
+        collect
+        (list
+         :wrapper name
+         :design-document (view-spec-design-document spec)
+         :view (view-spec-view-name spec)
+         :accepted-keywords (copy-list (view-spec-accepted-keywords spec))
+         :reducer-p (view-spec-reducer-p spec)
+         :default-reduce (view-spec-default-reduce spec)
+         :default-include-docs
+         (view-spec-default-include-docs spec))))

--- a/source/databases/view-registry.lisp
+++ b/source/databases/view-registry.lisp
@@ -141,15 +141,15 @@
   (when (oddp (length arguments))
     (error 'view-registry-error
            :reason (format nil "odd wrapper keyword list: ~s" arguments)))
-  (loop for (keyword value) on arguments by #'cddr
-        do (declare (ignore value))
-           (unless (member keyword
-                           (view-spec-accepted-keywords spec)
-                           :test #'eq)
-             (error 'view-registry-error
+  (loop for tail on arguments by #'cddr
+        for keyword = (first tail)
+        unless (member keyword
+                       (view-spec-accepted-keywords spec)
+                       :test #'eq)
+          do (error 'view-registry-error
                     :reason
                     (format nil "wrapper ~a does not accept ~s"
-                            (view-spec-name spec) keyword))))
+                            (view-spec-name spec) keyword)))
   t)
 
 (defun view-sequence-list (value)
@@ -172,7 +172,9 @@
   (when (and reduce include-docs)
     (error 'view-registry-error
            :reason "reduced view requests cannot include documents"))
-  (when (and (or group (plusp group-level)) (not reduce))
+  (when (and (or group
+                 (and group-level (plusp group-level)))
+             (not reduce))
     (error 'view-registry-error
            :reason "group/group-level requires reduce=true"))
   t)
@@ -191,7 +193,7 @@
    :skip (view-plist-value arguments :skip 0)
    :reduce reduce
    :group group
-   :group-level group-level))
+   :group-level (or group-level 0)))
 
 (defun view-row-documents (rows)
   (loop for row in rows
@@ -200,7 +202,7 @@
 
 (defun execute-registered-view (name client database &rest arguments)
   "Validate and execute one registered view, returning a typed result."
-  (let* ((spec (registered-view-spec name)))
+  (let ((spec (registered-view-spec name)))
     (validate-view-wrapper-arguments spec arguments)
     (let* ((reduce
              (view-plist-value
@@ -280,12 +282,11 @@
 
 (defun get-targets* (client database &rest actors)
   (let ((documents
-          (apply #'targets-by-actor
-                 client database
-                 :keys actors
-                 :include-docs t
-                 :reduce nil
-                 nil)))
+          (targets-by-actor
+           client database
+           :keys actors
+           :include-docs t
+           :reduce nil)))
     (loop for document in documents
           for actor = (star.documents:document-value document "actor")
           collect (cons actor document))))
@@ -337,7 +338,8 @@
   (let ((views (jsown:val-safe document "views")))
     (and views (outbox-object-has-key-p views view-name))))
 
-(defun validate-view-registry (&optional (documents (checked-in-design-document-map)))
+(defun validate-view-registry
+    (&optional (documents (checked-in-design-document-map)))
   "Fail before serving traffic when a registered design/view is absent."
   (dolist (name (registered-view-names) t)
     (let* ((spec (registered-view-spec name))

--- a/source/frontends/http-view-registry.lisp
+++ b/source/frontends/http-view-registry.lisp
@@ -1,0 +1,180 @@
+(in-package :star.frontends.http-api)
+
+(defun view-http-param (params name)
+  (cdr (assoc name params :test #'string=)))
+
+(defun view-http-param-present-p (params name)
+  (not (null (assoc name params :test #'string=))))
+
+(defun view-http-integer (params name default)
+  (let ((value (view-http-param params name)))
+    (if value (parse-integer value) default)))
+
+(defun view-http-boolean (params name default)
+  (if (view-http-param-present-p params name)
+      (string-equal "true" (or (view-http-param params name) "false"))
+      default))
+
+(defun view-http-json-value (params name)
+  (let ((value (view-http-param params name)))
+    (when value
+      (jsown:with-injective-reader
+        (jsown:parse value)))))
+
+(defun view-http-common-arguments (params)
+  (let ((arguments
+          (list
+           :limit (view-http-integer params "limit" 50)
+           :descending (view-http-boolean params "descending" nil)
+           :skip (view-http-integer params "skip" 0))))
+    (when (view-http-param-present-p params "start_key")
+      (setf arguments
+            (append arguments
+                    (list :start-key
+                          (view-http-json-value params "start_key")))))
+    (when (view-http-param-present-p params "end_key")
+      (setf arguments
+            (append arguments
+                    (list :end-key
+                          (view-http-json-value params "end_key")))))
+    (when (view-http-param-present-p params "reduce")
+      (setf arguments
+            (append arguments
+                    (list :reduce
+                          (view-http-boolean params "reduce" nil)))))
+    (when (view-http-param-present-p params "include_docs")
+      (setf arguments
+            (append arguments
+                    (list :include-docs
+                          (view-http-boolean params "include_docs" nil)))))
+    arguments))
+
+(defun execute-http-view (name arguments)
+  (couchdb-handler (client *couchdb-pool*)
+    (jsown:to-json
+     (star.databases.couchdb:view-result-value
+      (apply #'star.databases.couchdb:execute-registered-view
+             name
+             client
+             star:*couchdb-default-database*
+             arguments)))))
+
+(defun execute-http-keyed-view (name params parameter)
+  (execute-http-view
+   name
+   (append
+    (view-http-common-arguments params)
+    (list :key (view-http-param params parameter)))))
+
+(defun execute-http-channel-view (params)
+  (let* ((reduce (view-http-boolean params "reduce" nil))
+         (group-name (view-http-param params "group"))
+         (channel (view-http-param params "channel"))
+         (arguments
+           (append
+            (view-http-common-arguments params)
+            (list
+             :key (list group-name channel)
+             :reduce reduce
+             :include-docs (not reduce)
+             :group reduce))))
+    (execute-http-view 'star.databases.couchdb:by-channel arguments)))
+
+(defun registered-view-route (path name parameter)
+  (setf (ningle:route *app* path :method :get)
+        (lambda (params)
+          (set-default-headers)
+          (execute-http-keyed-view name params parameter))))
+
+(registered-view-route
+ "/documents/messages/by-user"
+ 'star.databases.couchdb:messages-by-user
+ "user")
+
+(registered-view-route
+ "/documents/messages/by-platform"
+ 'star.databases.couchdb:messages-by-platform
+ "platform")
+
+(setf (ningle:route *app* "/documents/messages/by-channel" :method :get)
+      (lambda (params)
+        (set-default-headers)
+        (execute-http-channel-view params)))
+
+;; Compatibility alias retained for the old pluralized route.
+(setf (ningle:route *app* "/documents/messages/by-groups" :method :get)
+      (lambda (params)
+        (set-default-headers)
+        (execute-http-channel-view params)))
+
+(setf (ningle:route *app* "/documents/messages/groups" :method :get)
+      (lambda (params)
+        (set-default-headers)
+        (execute-http-view
+         'star.databases.couchdb:groups
+         (view-http-common-arguments params))))
+
+(registered-view-route
+ "/documents/social-media-posts/by-user"
+ 'star.databases.couchdb:social-posts-by-user
+ "user")
+
+(registered-view-route
+ "/documents/social-media-posts/by-group"
+ 'star.databases.couchdb:social-posts-by-group
+ "group")
+
+(registered-view-route
+ "/documents/social-media-posts/by-platform"
+ 'star.databases.couchdb:social-posts-by-platform
+ "platform")
+
+;; Historical typo remains an explicit compatibility alias.
+(registered-view-route
+ "/documents/socialmpost/by-user"
+ 'star.databases.couchdb:social-posts-by-user
+ "user")
+
+(setf (ningle:route *app* "/dataset-size" :method :get)
+      (lambda (params)
+        (set-default-headers)
+        (let* ((reduce
+                 (view-http-boolean params "reduce" t))
+               (arguments
+                 (append
+                  (view-http-common-arguments params)
+                  (list
+                   :reduce reduce
+                   :include-docs nil))))
+          (when (view-http-param-present-p params "dataset")
+            (setf arguments
+                  (append arguments
+                          (list :key
+                                (view-http-param params "dataset")))))
+          (execute-http-view
+           'star.databases.couchdb:dataset-size
+           arguments))))
+
+(setf (ningle:route *app* "/targets/:actor" :method :get)
+      (lambda (params)
+        (set-default-headers)
+        (execute-http-view
+         'star.databases.couchdb:targets-by-actor
+         (list
+          :key (cdr (assoc :actor params :test #'string=))
+          :include-docs t
+          :reduce nil))))
+
+(defparameter *http-view-registry-matrix*
+  '(("/documents/messages/by-user" messages-by-user document)
+    ("/documents/messages/by-platform" messages-by-platform document)
+    ("/documents/messages/by-channel" by-channel map-or-reduced)
+    ("/documents/messages/by-groups" by-channel map-or-reduced)
+    ("/documents/messages/groups" groups reduced)
+    ("/documents/social-media-posts/by-user" social-posts-by-user document)
+    ("/documents/social-media-posts/by-group" social-posts-by-group document)
+    ("/documents/social-media-posts/by-platform"
+     social-posts-by-platform document)
+    ("/documents/socialmpost/by-user" social-posts-by-user document)
+    ("/dataset-size" dataset-size reduced)
+    ("/targets/:actor" targets-by-actor document)))

--- a/source/init.lisp
+++ b/source/init.lisp
@@ -1,41 +1,49 @@
 (in-package :starintel-gserver)
 
 (defun read-view-document (path)
-  (jsown:parse
-   (with-open-file (stream path)
-     (let ((content (make-string (file-length stream))))
-       (read-sequence content stream)
-       content))))
+  (jsown:with-injective-reader
+    (jsown:parse (uiop:read-file-string path))))
 
 (defun upsert-view-document (client database document)
   (let ((document-id (jsown:val document "_id")))
     (handler-case
-        (let* ((current (jsown:parse
-                         (cl-couch:get-document client database document-id)))
+        (let* ((current
+                 (jsown:with-injective-reader
+                   (jsown:parse
+                    (cl-couch:get-document client database document-id))))
                (revision (jsown:val current "_rev")))
           (setf (jsown:val document "_rev") revision)
-          (cl-couch:create-document client database (jsown:to-json document)))
+          (cl-couch:create-document
+           client database (jsown:to-json document)))
       (dexador:http-request-not-found ()
-        (cl-couch:create-document client database (jsown:to-json document))))))
+        (cl-couch:create-document
+         client database (jsown:to-json document))))))
 
 (defun init-views (client database)
   "Create or update every checked-in CouchDB design document."
-  (let ((files (uiop:directory-files
-                (uiop:merge-pathnames* "views/"
-                                       (asdf:system-source-directory :starintel-gserver)))))
+  (let ((files
+          (uiop:directory-files
+           (uiop:merge-pathnames*
+            "views/"
+            (asdf:system-source-directory :starintel-gserver)))))
     (loop for file in files
-          for document = (read-view-document file)
-          do (upsert-view-document client database document))))
+          when (string-equal "json" (pathname-type file))
+            do (upsert-view-document
+                client database (read-view-document file)))))
 
 (defun init-db ()
-  "Create the database when missing and always synchronize v0.9 design documents."
-  (let* ((client (cl-couch:new-couchdb *couchdb-host*
-                                       *couchdb-port*
-                                       :scheme (string-downcase *couchdb-scheme*)))
+  "Create the database, install design docs, and validate every wrapper target."
+  (let* ((client
+           (cl-couch:new-couchdb
+            *couchdb-host*
+            *couchdb-port*
+            :scheme (string-downcase *couchdb-scheme*)))
          (database *couchdb-default-database*))
     (cl-couch:password-auth client *couchdb-user* *couchdb-password*)
     (handler-case
         (cl-couch:get-database client database)
       (dexador:http-request-not-found ()
         (cl-couch:create-database client database)))
-    (init-views client database)))
+    (star.databases.couchdb:validate-view-registry)
+    (init-views client database)
+    t))

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -22,6 +22,8 @@
                   (:file "databases/couchdb")
                   (:file "databases/couchdb-v09")
                   (:file "databases/outbox")
+                  (:file "databases/view-registry-package")
+                  (:file "databases/view-registry")
                   (:file "databases/document-update-package")
                   (:file "databases/document-update")
                   (:file "databases/quarantine")
@@ -39,6 +41,7 @@
                   (:file "frontends/http-api")
                   (:file "frontends/http-api-v09")
                   (:file "frontends/http-document-update")
+                  (:file "frontends/http-view-registry")
                   (:file "main"))
   :depends-on   (#:starintel
                   #:cl-couch

--- a/source/views/data.json
+++ b/source/views/data.json
@@ -1,1 +1,21 @@
-{"_id":"_design/data","views":{"count_by_dtype":{"map":"function(doc) {\n  if (doc.dtype && doc.dtype !== \"Relation\") {\n    emit(doc.dtype, 1);\n  }\n}","reduce":"_count"},"dataset_size":{"reduce":"_count","map":"function (doc) {\n  emit(doc.dataset, 1);\n  \n}"},"total":{"reduce":"_sum","map":"function (doc) {\n  emit(null, 1);\n}"}},"language":"javascript"}
+{
+  "_id": "_design/data",
+  "language": "javascript",
+  "views": {
+    "count_by_dtype": {
+      "map": "function (doc) { if (doc.dtype !== undefined && doc.dtype !== null) { emit(String(doc.dtype).toLowerCase(), 1); } }",
+      "reduce": "_count"
+    },
+    "dataset_size": {
+      "map": "function (doc) { if (doc.dataset !== undefined) { emit(doc.dataset, 1); } }",
+      "reduce": "_count"
+    },
+    "by_dataset": {
+      "map": "function (doc) { if (doc.dataset !== undefined) { emit(doc.dataset, doc._id); } }"
+    },
+    "total": {
+      "map": "function (doc) { emit(null, 1); }",
+      "reduce": "_sum"
+    }
+  }
+}

--- a/source/views/targets.json
+++ b/source/views/targets.json
@@ -1,1 +1,28 @@
-{"_id":"_design/targets","language":"javascript","views":{"by_actor":{"map":"function(doc){function v(k){return doc.data&&doc.data[k]!==undefined?doc.data[k]:doc[k];}if(doc.dtype==='target'||doc.dtype==='investigation-target'){emit(v('actor'),v('target'));}}"},"actor-targets":{"map":"function(doc){function v(k){return doc.data&&doc.data[k]!==undefined?doc.data[k]:doc[k];}if(doc.dtype==='target'||doc.dtype==='investigation-target'){emit(v('actor'),v('target'));}}"},"actor-target-count":{"map":"function(doc){function v(k){return doc.data&&doc.data[k]!==undefined?doc.data[k]:doc[k];}if(doc.dtype==='target'||doc.dtype==='investigation-target'){emit(v('actor'),1);}}","reduce":"_count"},"target-count":{"map":"function(doc){function v(k){return doc.data&&doc.data[k]!==undefined?doc.data[k]:doc[k];}if(doc.dtype==='target'||doc.dtype==='investigation-target'){emit(v('target'),1);}}","reduce":"_sum"}}}
+{
+  "_id": "_design/targets",
+  "language": "javascript",
+  "views": {
+    "by_actor": {
+      "map": "function (doc) { function v(k) { return doc.data && doc.data[k] !== undefined ? doc.data[k] : doc[k]; } if (doc.dtype === 'target' || doc.dtype === 'investigation-target') { emit(v('actor'), v('target')); } }"
+    },
+    "actor_count": {
+      "map": "function (doc) { function v(k) { return doc.data && doc.data[k] !== undefined ? doc.data[k] : doc[k]; } if (doc.dtype === 'target' || doc.dtype === 'investigation-target') { emit(v('actor'), 1); } }",
+      "reduce": "_count"
+    },
+    "target_count": {
+      "map": "function (doc) { function v(k) { return doc.data && doc.data[k] !== undefined ? doc.data[k] : doc[k]; } if (doc.dtype === 'target' || doc.dtype === 'investigation-target') { emit(v('target'), 1); } }",
+      "reduce": "_count"
+    },
+    "actor-targets": {
+      "map": "function (doc) { function v(k) { return doc.data && doc.data[k] !== undefined ? doc.data[k] : doc[k]; } if (doc.dtype === 'target' || doc.dtype === 'investigation-target') { emit(v('actor'), v('target')); } }"
+    },
+    "actor-target-count": {
+      "map": "function (doc) { function v(k) { return doc.data && doc.data[k] !== undefined ? doc.data[k] : doc[k]; } if (doc.dtype === 'target' || doc.dtype === 'investigation-target') { emit(v('actor'), 1); } }",
+      "reduce": "_count"
+    },
+    "target-count": {
+      "map": "function (doc) { function v(k) { return doc.data && doc.data[k] !== undefined ? doc.data[k] : doc[k]; } if (doc.dtype === 'target' || doc.dtype === 'investigation-target') { emit(v('target'), 1); } }",
+      "reduce": "_count"
+    }
+  }
+}

--- a/source/views/users.json
+++ b/source/views/users.json
@@ -1,0 +1,9 @@
+{
+  "_id": "_design/users",
+  "language": "javascript",
+  "views": {
+    "by_platform": {
+      "map": "function (doc) { function v(k) { return doc.data && doc.data[k] !== undefined ? doc.data[k] : doc[k]; } if (doc.dtype === 'user') { emit(v('platform'), doc._id); } }"
+    }
+  }
+}

--- a/tests/run-view-registry-conformance.lisp
+++ b/tests/run-view-registry-conformance.lisp
@@ -1,0 +1,239 @@
+(in-package :cl-user)
+
+(defun view-registry-check (condition control &rest arguments)
+  (unless condition
+    (error (apply #'format nil control arguments))))
+
+(defun view-registry-response (&rest rows)
+  (let ((response (jsown:empty-object)))
+    (setf (jsown:val response "rows") (coerce rows 'vector))
+    response))
+
+(defun view-registry-document-row (id)
+  (let ((row (jsown:empty-object))
+        (document (jsown:empty-object)))
+    (setf (jsown:val document "_id") id
+          (jsown:val document "dtype") "message"
+          (jsown:val document "date_added") "2026-07-26T00:00:00Z"
+          (jsown:val row "id") id
+          (jsown:val row "key") "key"
+          (jsown:val row "value") id
+          (jsown:val row "doc") document)
+    row))
+
+(defun view-registry-map-row (key value)
+  (let ((row (jsown:empty-object)))
+    (setf (jsown:val row "key") key
+          (jsown:val row "value") value)
+    row))
+
+(defmacro with-mocked-query-view ((function) &body body)
+  `(let ((original
+           (symbol-function 'star.databases.couchdb:query-view)))
+     (unwind-protect
+          (progn
+            (setf (symbol-function 'star.databases.couchdb:query-view)
+                  ,function)
+            ,@body)
+       (setf (symbol-function 'star.databases.couchdb:query-view)
+             original))))
+
+(defun test-checked-in-design-documents-satisfy_registry ()
+  (view-registry-check
+   (star.databases.couchdb:validate-view-registry)
+   "Checked-in view registry validation failed")
+  (dolist (entry (star.databases.couchdb:view-registry-matrix))
+    (view-registry-check (getf entry :wrapper)
+                         "Registry entry lacks wrapper: ~s" entry)
+    (view-registry-check (getf entry :design-document)
+                         "Registry entry lacks design document: ~s" entry)
+    (view-registry-check (getf entry :view)
+                         "Registry entry lacks view: ~s" entry)))
+
+(defun test-missing-expected-view_fails_validation ()
+  (let* ((documents
+           (star.databases.couchdb::checked-in-design-document-map))
+         (messages
+           (star.databases.couchdb::clone-outbox-json
+            (gethash "messages" documents))))
+    (setf (jsown:val messages "views") (jsown:empty-object)
+          (gethash "messages" documents) messages)
+    (handler-case
+        (progn
+          (star.databases.couchdb:validate-view-registry documents)
+          (error "Missing view passed registry validation"))
+      (star.databases.couchdb:view-registry-error () t))))
+
+(defun test_typed_document_map_and_reduced_results ()
+  (let ((calls nil))
+    (with-mocked-query-view
+        ((lambda (client database ddoc view &rest arguments)
+           (push (list client database ddoc view arguments) calls)
+           (cond
+             ((getf arguments :reduce)
+              (view-registry-response
+               (view-registry-map-row "key" 3)))
+             ((getf arguments :include-docs)
+              (view-registry-response
+               (view-registry-document-row "message:1")))
+             (t
+              (view-registry-response
+               (view-registry-map-row "key" "message:1"))))))
+      (let ((documents
+              (star.databases.couchdb:execute-registered-view
+               'star.databases.couchdb:messages-by-user
+               :client "db"
+               :key "user:1"
+               :reduce nil
+               :include-docs t
+               :sort-fn nil))
+            (map-result
+              (star.databases.couchdb:execute-registered-view
+               'star.databases.couchdb:documents-by-dataset
+               :client "db"
+               :key "default"
+               :reduce nil
+               :include-docs nil))
+            (reduced
+              (star.databases.couchdb:execute-registered-view
+               'star.databases.couchdb:count-by-dtype
+               :client "db"
+               :reduce t
+               :include-docs nil
+               :group t)))
+        (view-registry-check
+         (typep documents 'star.databases.couchdb:view-document-result)
+         "Document request returned ~s" (type-of documents))
+        (view-registry-check
+         (typep map-result 'star.databases.couchdb:view-map-result)
+         "Map request returned ~s" (type-of map-result))
+        (view-registry-check
+         (typep reduced 'star.databases.couchdb:view-reduced-result)
+         "Reduced request returned ~s" (type-of reduced))
+        (view-registry-check
+         (= 1
+            (length
+             (star.databases.couchdb:view-document-result-documents
+              documents)))
+         "Document result did not retain docs")
+        (view-registry-check (= 3 (length calls))
+                             "Expected three queries, got ~d"
+                             (length calls))))))
+
+(defun test_by_channel_accepts_map_and_reduced_modes ()
+  (with-mocked-query-view
+      ((lambda (client database ddoc view &rest arguments)
+         (declare (ignore client database))
+         (view-registry-check (string= "messages" ddoc)
+                              "by-channel used design ~a" ddoc)
+         (view-registry-check (string= "by_channel" view)
+                              "by-channel used view ~a" view)
+         (if (getf arguments :reduce)
+             (view-registry-response
+              (view-registry-map-row '("group" "channel") 2))
+             (view-registry-response
+              (view-registry-document-row "message:channel")))))
+    (let ((map-result
+            (star.databases.couchdb:execute-registered-view
+             'star.databases.couchdb:by-channel
+             :client "db"
+             :key '("group" "channel")
+             :reduce nil
+             :include-docs t
+             :group nil
+             :sort-fn nil))
+          (reduced-result
+            (star.databases.couchdb:execute-registered-view
+             'star.databases.couchdb:by-channel
+             :client "db"
+             :key '("group" "channel")
+             :reduce t
+             :include-docs nil
+             :group t)))
+      (view-registry-check
+       (typep map-result 'star.databases.couchdb:view-document-result)
+       "by-channel map mode returned ~s" (type-of map-result))
+      (view-registry-check
+       (typep reduced-result 'star.databases.couchdb:view-reduced-result)
+       "by-channel reduced mode returned ~s"
+       (type-of reduced-result)))))
+
+(defun test_impossible_result_shapes_fail_before_query ()
+  (let ((queries 0))
+    (with-mocked-query-view
+        ((lambda (&rest arguments)
+           (declare (ignore arguments))
+           (incf queries)
+           (view-registry-response)))
+      (dolist (arguments
+               (list
+                (list
+                 'star.databases.couchdb:documents-by-dataset
+                 :reduce t :include-docs nil)
+                (list
+                 'star.databases.couchdb:messages-by-user
+                 :reduce t :include-docs t)
+                (list
+                 'star.databases.couchdb:messages-by-user
+                 :reduce nil :include-docs t :group t)))
+        (handler-case
+            (progn
+              (apply #'star.databases.couchdb:execute-registered-view
+                     (first arguments) :client "db" (rest arguments))
+              (error "Invalid view shape was accepted: ~s" arguments))
+          (star.databases.couchdb:view-registry-error () t)))
+      (view-registry-check (zerop queries)
+                           "Invalid requests reached CouchDB ~d time(s)"
+                           queries))))
+
+(defun test_compatibility_wrappers_preserve_list_results ()
+  (with-mocked-query-view
+      ((lambda (&rest arguments)
+         (declare (ignore arguments))
+         (view-registry-response
+          (view-registry-document-row "message:compat"))))
+    (let ((documents
+            (star.databases.couchdb:messages-by-user
+             :client "db"
+             :key "user:1"
+             :include-docs t
+             :reduce nil
+             :sort-fn nil)))
+      (view-registry-check (listp documents)
+                           "Compatibility wrapper returned ~s"
+                           (type-of documents))
+      (view-registry-check (= 1 (length documents))
+                           "Compatibility wrapper lost documents"))))
+
+(defun test_social_post_views_use_canonical_dtype ()
+  (let* ((documents
+           (star.databases.couchdb::checked-in-design-document-map))
+         (messages (gethash "messages" documents))
+         (views (jsown:val messages "views")))
+    (dolist (view-name
+             '("social_posts_by_user"
+               "social_posts_by_group"
+               "social_posts_by_platform"))
+      (let ((map-source
+              (jsown:val (jsown:val views view-name) "map")))
+        (view-registry-check
+         (search "social-media-post" map-source)
+         "~a does not use canonical social-media-post dtype"
+         view-name)
+        (view-registry-check
+         (not (search "social-media-posts" map-source))
+         "~a retains plural dtype drift" view-name)))))
+
+(defun run-view-registry-conformance-tests ()
+  (format t "~&Running CouchDB view registry tests~%")
+  (test-checked-in-design-documents-satisfy_registry)
+  (test-missing-expected-view_fails_validation)
+  (test_typed_document_map_and_reduced_results)
+  (test_by_channel_accepts_map_and_reduced_modes)
+  (test_impossible_result_shapes_fail_before_query)
+  (test_compatibility_wrappers_preserve_list_results)
+  (test_social_post_views_use_canonical_dtype)
+  (format t "~&CouchDB view registry tests passed~%")
+  t)
+
+(run-view-registry-conformance-tests)

--- a/tests/test_view_registry_contract.py
+++ b/tests/test_view_registry_contract.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWS = ROOT / "source" / "views"
+
+EXPECTED = {
+    "messages-by-user": ("messages", "messages_by_user"),
+    "messages-by-platform": ("messages", "messages_by_platform"),
+    "messages-by-group": ("messages", "messages_by_group"),
+    "social-posts-by-user": ("messages", "social_posts_by_user"),
+    "social-posts-by-group": ("messages", "social_posts_by_group"),
+    "social-posts-by-platform": ("messages", "social_posts_by_platform"),
+    "by-channel": ("messages", "by_channel"),
+    "groups": ("messages", "groups"),
+    "count-by-dtype": ("data", "count_by_dtype"),
+    "dataset-size": ("data", "dataset_size"),
+    "documents-by-dataset": ("data", "by_dataset"),
+    "orgs-by-country": ("orgs", "by_country"),
+    "orgs-by-name": ("orgs", "by_name"),
+    "persons-by-name": ("persons", "by_name"),
+    "persons-by-region": ("persons", "by_region"),
+    "relations-edges": ("relations", "edges"),
+    "relations-incoming-count": ("relations", "incoming_count"),
+    "relations-outgoing-count": ("relations", "outgoing_count"),
+    "targets-actor-counts": ("targets", "actor_count"),
+    "targets-by-actor": ("targets", "by_actor"),
+    "targets-target-count": ("targets", "target_count"),
+    "users-by-platform": ("users", "by_platform"),
+    "timeline-view": ("time", "timeline"),
+}
+
+
+class ViewRegistryContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = (
+            ROOT / "source" / "databases" / "view-registry.lisp"
+        ).read_text(encoding="utf-8")
+        self.designs = {
+            path.stem: json.loads(path.read_text(encoding="utf-8"))
+            for path in VIEWS.glob("*.json")
+        }
+
+    def test_every_registered_wrapper_targets_checked_in_view(self) -> None:
+        for wrapper, (design, view) in EXPECTED.items():
+            pattern = re.compile(
+                rf"register-view-spec\s+'{re.escape(wrapper)}\s+"
+                rf'"{re.escape(design)}"\s+"{re.escape(view)}"',
+                re.DOTALL,
+            )
+            self.assertRegex(self.registry, pattern, wrapper)
+            self.assertIn(design, self.designs, wrapper)
+            self.assertEqual(self.designs[design]["_id"], f"_design/{design}")
+            self.assertIn(view, self.designs[design].get("views", {}), wrapper)
+
+    def test_target_canonical_names_and_legacy_aliases_coexist(self) -> None:
+        views = self.designs["targets"]["views"]
+        for name in ("by_actor", "actor_count", "target_count"):
+            self.assertIn(name, views)
+        for alias in ("actor-targets", "actor-target-count", "target-count"):
+            self.assertIn(alias, views)
+
+    def test_data_and_users_missing_views_are_installed(self) -> None:
+        self.assertIn("by_dataset", self.designs["data"]["views"])
+        self.assertIn("by_platform", self.designs["users"]["views"])
+        self.assertIn("doc.dtype === 'user'", self.designs["users"]["views"]["by_platform"]["map"])
+
+    def test_social_post_views_use_one_canonical_dtype(self) -> None:
+        views = self.designs["messages"]["views"]
+        for name in (
+            "social_posts_by_user",
+            "social_posts_by_group",
+            "social_posts_by_platform",
+        ):
+            source = views[name]["map"]
+            self.assertIn("social-media-post", source)
+            self.assertNotIn("social-media-posts", source)
+
+    def test_registry_validates_keywords_and_result_shapes(self) -> None:
+        for token in (
+            ":group",
+            ":group-level",
+            "reduced view requests cannot include documents",
+            "group/group-level requires reduce=true",
+            "has no reducer",
+            "view-document-result",
+            "view-map-result",
+            "view-reduced-result",
+        ):
+            self.assertIn(token, self.registry)
+        self.assertIn("define-registered-view-wrapper by-channel", self.registry)
+
+    def test_startup_validation_precedes_view_install_and_traffic(self) -> None:
+        source = (ROOT / "source" / "init.lisp").read_text(encoding="utf-8")
+        validation = source.index("validate-view-registry")
+        installation = source.rindex("(init-views client database)")
+        self.assertLess(validation, installation)
+
+    def test_http_routes_use_registry_and_keep_explicit_aliases(self) -> None:
+        source = (
+            ROOT / "source" / "frontends" / "http-view-registry.lisp"
+        ).read_text(encoding="utf-8")
+        for route in (
+            "/documents/messages/by-user",
+            "/documents/messages/by-platform",
+            "/documents/messages/by-channel",
+            "/documents/messages/by-groups",
+            "/documents/messages/groups",
+            "/documents/social-media-posts/by-user",
+            "/documents/social-media-posts/by-group",
+            "/documents/social-media-posts/by-platform",
+            "/documents/socialmpost/by-user",
+            "/dataset-size",
+            "/targets/:actor",
+        ):
+            self.assertIn(route, source)
+        self.assertIn("execute-registered-view", source)
+        self.assertIn("*http-view-registry-matrix*", source)
+
+    def test_executable_acceptance_matrix_is_in_docker_gate(self) -> None:
+        tests = (
+            ROOT / "tests" / "run-view-registry-conformance.lisp"
+        ).read_text(encoding="utf-8")
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        for name in (
+            "test-checked-in-design-documents-satisfy_registry",
+            "test-missing-expected-view_fails_validation",
+            "test_typed_document_map_and_reduced_results",
+            "test_by_channel_accepts_map_and_reduced_modes",
+            "test_impossible_result_shapes_fail_before_query",
+            "test_social_post_views_use_canonical_dtype",
+        ):
+            self.assertIn(name, tests)
+        self.assertIn("run-view-registry-conformance.lisp", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one registry for every public CouchDB wrapper, design document, view name, accepted keyword, reducer capability, and default result shape
- return distinct typed internal results for document rows, map rows, and reduced rows
- preserve existing wrapper list return values through generated compatibility wrappers
- reject reduce/include-docs/group combinations before issuing CouchDB requests
- validate every registered design/view against checked-in JSON before startup proceeds
- add canonical `data/by_dataset` and `users/by_platform` views
- add canonical target count names while retaining legacy aliases
- normalize dtype counts and keep social-media-post views on one canonical dtype
- fix dataset export to query map documents instead of the reduced dataset-size view
- route message, channel, social post, dataset-size, and target HTTP endpoints through the registry
- retain explicit HTTP compatibility aliases for historical routes

## Regression coverage

- every registered wrapper references an installed design/view
- missing expected views fail validation
- document, map, and reduced queries return distinct typed results
- by-channel supports both map and reduced modes with group keywords
- impossible result-shape combinations fail before CouchDB
- compatibility wrappers still return document/row lists
- canonical target aliases and missing data/users views are installed
- social post maps use only `social-media-post`
- startup validation executes before design-doc installation and traffic
- every registered HTTP route appears in an explicit endpoint matrix

## Stack

- base: `agent/schema-org-v0.9`
- includes completed issues #11–#19

This remains draft until fixture and executable CLOS view-registry gates are green.

Closes #20