### PR TITLE
Document StarIntel Server architecture, actors, specs, and configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,119 +1,207 @@
-#+title: Readme
+#+title: StarIntel Server
+#+options: toc:2
 
-* Star Server
-Starintel server is the new API server for interacting with the starintel system.
+* StarIntel Server
 
+StarIntel Server is the Common Lisp runtime for storing, routing, querying, and
+recursively enriching StarIntel documents.
 
+It combines:
 
-- Features:
-  - rabbitmq
-  - actor model
-  - hackable
+- CouchDB for durable documents, views, and full-text search.
+- RabbitMQ topic exchanges for document and actor traffic.
+- Sento actors for local concurrency, supervision boundaries, timers, and
+  message passing.
+- A Ningle/Clack/Hunchentoot HTTP API.
+- The =star-cl= document library and StarIntel specification adapters.
+- Nix-built binaries, tests, and container images.
 
+This repository is an experimental operator system, not a hardened public SaaS
+service.
 
-** *WARNINGS*
-*** Project status
-This repo is a mess!
-This project is experimental, DO NOT EXPOSE TO THE WEB.
+#+begin_quote
+*Do not expose the HTTP API or RabbitMQ directly to the public Internet.*
 
-*** Consumers and actors
+The HTTP API currently has no authentication or authorization and sends
+=Access-Control-Allow-Origin: *=. Put it behind an authenticated reverse proxy,
+restrict network access, and treat the Lisp init file as trusted executable
+code.
+#+end_quote
 
-In a future version the consumer that inserts will revert back to cl-gserver actor when I figure a good proto and learn more about sento.
+** What the server does
 
-Something along the lines of
+A document normally moves through this pipeline:
 
-#+begin_src lisp
-(tell *couchdb* (:db "starintel" :id "0HJY....." :document (as-json (spec:create-user :dataset "github" :name "lost-rob0t"))))
-#+end_src
-
-I will have to do more research to better utlize the sento system.
-
-** Documentation
-*** Containers
-See [[file:DOCKER.md][the Nix-built Compose stack guide]] for image builds,
-secret setup, migration, backup, and upgrades.
-*** HTTP
-For http documentation: [[file:./docs/http-api-docs.org][Api Documentation]]
-*** Setting up dev env
-star-server uses nixpkgs to managment the dev shell, which is like a venv for this project.
-
-it is not required
-
-First install the [[https://nixos.org/download/][Nix package manager]] and [[https://direnv.net/][Direnv]].
-
-Also Ensure you have [[https://www.quicklisp.org/beta/][Quicklisp]] installed also.
-
-#+Name: Setup dev env
-#+begin_src sh :async :results output replace
-git clone  --recurse-submodules https://github.com/lost-rob0t/starintel-gserver.git star-server && cd star-server;
-direnv allow .
-#+end_src
-
-Now nix should be pulling down everything and you will be placed inside a new shell with everything needed in $PATH.
-*** Compiling From Source without nix
-
-Ensure you have [[https://www.quicklisp.org/beta/][Quicklisp]].
-
-#+Name: Compile from source
-#+begin_src shell :async :results output replace
-git clone  --recurse-submodules https://github.com/lost-rob0t/starintel-gserver.git star-server && cd star-server;
-make build
-make install
-#+end_src
-*** Usage
-
-#+Name: Usage
-#+begin_src sh :async :results output replace
-./star-server
-#+end_src
-
-#+RESULTS: Usage
 #+begin_example
-NAME:
-  star-server - Starintel unified API and document consuming service.
-
-USAGE:
-  star-server [global-options] [<command>] [command-options] [arguments ...]
-
-OPTIONS:
-      --help     display usage information and exit
-      --version  display version and exit
-
-COMMANDS:
-  start  start the server
-
-AUTHORS:
-  nsaspy <nsaspy@airmail.cc>
-
-LICENSE:
-  GPL v3
-
+HTTP/client/actor
+      |
+      v
+documents.ingest.<dtype>
+      |
+      v
+CouchDB insert + _id/_rev enrichment
+      |
+      v
+documents.new.<dtype>
+      |
+      +--> local actor via TELL
+      +--> remote actor via RabbitMQ topic route
+      +--> derived documents and relations
+                 |
+                 +--> documents.ingest.<dtype>  (durable recursion)
+                 `--> documents.new.<dtype>     (event-only fan-out)
 #+end_example
 
+Actors can emit more StarIntel documents, relations, targets, and actor events.
+Those outputs can trigger more actors. This is *dataflow recursion*: the graph
+expands through messages rather than recursive function calls.
 
-#+Name: start
-#+begin_src shell :async :results output replace
-./star-server start --help
+** Quick start: Nix-built Compose stack
+
+Requirements: Nix with flakes, Docker Engine, Docker Compose v2, =curl=, =jq=,
+and =openssl=.
+
+#+begin_src sh
+cp .env.example .env
+install -d -m 0700 secrets
+openssl rand -base64 32 > secrets/couchdb_password
+openssl rand -base64 48 > secrets/couchdb_secret
+openssl rand -hex 24 | tr '[:lower:]' '[:upper:]' > secrets/erlang_cookie
+openssl rand -base64 32 > secrets/rabbitmq_password
+chmod 0600 secrets/*
+
+nix run .#load-images
+docker compose up --detach --wait
+curl --fail http://127.0.0.1:5000/health
 #+end_src
 
-#+RESULTS: start
+Default local endpoints:
+
+| Service             | Address                  |
+|---------------------+--------------------------|
+| StarIntel HTTP API  | http://127.0.0.1:5000    |
+| CouchDB             | http://127.0.0.1:5984    |
+| RabbitMQ AMQP       | 127.0.0.1:5672           |
+| RabbitMQ management | http://127.0.0.1:15672   |
+
+See [[file:DOCKER.md][DOCKER.md]] for image builds, secrets, persistence, migration, backup, FTS,
+and upgrades.
+
+** Submit a document
+
+The body must contain a =dtype=. The route chooses the RabbitMQ routing key but
+does not currently inject or validate the body dtype.
+
+#+begin_src sh
+curl --fail \
+  --header 'Content-Type: application/json' \
+  --request POST \
+  --data '{
+    "_id": "example-note",
+    "dataset": "demo",
+    "dtype": "note",
+    "sources": ["manual"],
+    "version": "0.8.0",
+    "dateAdded": 0,
+    "dateUpdated": 0,
+    "content": "first document"
+  }' \
+  http://127.0.0.1:5000/new/document/note
+#+end_src
+
+The API acknowledges queue publication, not CouchDB persistence. Read the
+document after the ingest consumer has processed it:
+
+#+begin_src sh
+curl --fail http://127.0.0.1:5000/document/example-note | jq
+#+end_src
+
+** Build and test
+
+#+begin_src sh
+nix build
+nix run .#star-unit-tests
+#+end_src
+
+With CouchDB and RabbitMQ available:
+
+#+begin_src sh
+nix run .#star-integration-tests
+#+end_src
+
+Full Nix image, health, FTS, restart, and persistence test:
+
+#+begin_src sh
+./scripts/stack-test.sh
+#+end_src
+
+See [[file:docs/testing.md][docs/testing.md]].
+
+** Run from Common Lisp
+
+The pinned Nix build is the supported reproducible path. For interactive
+development:
+
+#+begin_src sh
+nix develop
+sbcl --load run.lisp
+#+end_src
+
+Build the executable:
+
+#+begin_src sh
+nix build
+./result/bin/star-server start --init ./example_configs/init.lisp
+#+end_src
+
+The executable accepts:
+
 #+begin_example
-NAME:
-  star-server start - start the server
-
-USAGE:
-  star-server [global-options] start [options] [arguments ...]
-
-OPTIONS:
-      --help              display usage information and exit
-      --version           display version and exit
-  -d, --debugger <VALUE>  Enable Remote debugging
-  -i, --init <VALUE>      Path to init file [default: ./init.lisp] [env: $STAR_SERVER_INIT_FILE]
-
-AUTHORS:
-  nsaspy <nsaspy@airmail.cc>
-
-LICENSE:
-  GPL v3
-
+star-server start -i PATH
+star-server start --init PATH
 #+end_example
+
+The same path can be supplied through =STAR_SERVER_INIT_FILE=.
+
+** Documentation map
+
+| Document | Contents |
+|----------+----------|
+| [[file:docs/index.org][docs/index.org]] | Documentation index and implementation status |
+| [[file:docs/architecture.org][docs/architecture.org]] | Runtime structure, startup order, concurrency, and repository layout |
+| [[file:docs/actors.org][docs/actors.org]] | Creating, registering, targeting, scheduling, and operating actors |
+| [[file:docs/messaging.org][docs/messaging.org]] | RabbitMQ exchanges, queues, routing keys, recursion, delivery, and loop control |
+| [[file:docs/document-spec.org][docs/document-spec.org]] | StarIntel 0.9 and legacy 0.8 documents, types, relations, IDs, metadata, and provenance |
+| [[file:docs/configuration.org][docs/configuration.org]] | Environment, init files, secrets, advanced examples, and tuning |
+| [[file:docs/http-api-docs.org][docs/http-api-docs.org]] | HTTP endpoint reference and examples |
+| [[file:DOCKER.md][DOCKER.md]] | Nix-built container stack and operations |
+| [[file:docs/testing.md][docs/testing.md]] | Unit, integration, and stack tests |
+
+** Runtime status
+
+The documentation distinguishes three states:
+
+- *Active*: loaded by =source/starintel-gserver.asd= and started by =star::main=.
+- *Present but not active*: code exists in the repository but is not loaded by
+  the ASDF system or is not started by the current startup path.
+- *Stub/experimental*: API or actor code exists but is incomplete.
+
+Important current limits:
+
+- HTTP ingestion does not enforce the strict StarIntel 0.9 schema.
+- The server still uses legacy flat 0.8 constructors in parts of the actor code.
+- =source/actor-systems/user-finder.lisp= and =user-hunt.lisp= are not loaded by
+  the ASDF system.
+- The matcher actor framework is experimental; the URL extractor is loaded, but
+  a complete global pattern-dispatch loop is not wired.
+- =/new/event/:id= is a stub.
+- =*http-api-base-path*= and the HTTP certificate/key variables are not applied
+  by =start-http-api=.
+- The second =/dataset-size= route definition replaces or shadows the first,
+  depending on Ningle route behavior.
+
+These are documented facts, not supported guarantees.
+
+** License
+
+See [[file:LICENSE][LICENSE]].

--- a/docs/actors.org
+++ b/docs/actors.org
@@ -1,0 +1,307 @@
+#+title: Creating and operating actors
+#+options: toc:3
+
+* Actors
+
+StarIntel actors are message-driven transforms and operators. They consume
+targets or documents and may emit documents, relations, updates, targets, or
+actor events.
+
+** Actor kinds
+
+| Kind | Transport | Use |
+|------+-----------+-----|
+| Local Sento actor | In-process mailbox | Fast transforms, routing, timers, DB coordination |
+| Rabbit actor service | RabbitMQ queue | Independent process/language, isolation, horizontal scale |
+| Pattern subscriber | Local =tell= after a predicate match | Route selected documents to local actors |
+| Recurring target actor | Timer plus local/remote delivery | Periodic collection or refresh |
+| Actor-event receiver | Local or Rabbit event message | Append operational events to event DB |
+
+** Minimal local actor
+
+Create a file such as =actors/domain-enricher.lisp=:
+
+#+begin_src lisp
+(in-package :star.actors)
+
+(define-actor (*domain-enricher* *sys*)
+  (lambda (message)
+    (let* ((source-id (jsown:val message "_id"))
+           (dataset (or (jsown:val-safe message "dataset") "default"))
+           (domain (jsown:val-safe message "target")))
+      (when (and domain (not (string= domain "")))
+        (let ((document
+                (jsown:new-js
+                 ("_id" (format nil "domain:~a" (string-downcase domain)))
+                 ("dataset" dataset)
+                 ("dtype" "domain")
+                 ("sources" (list "domain-enricher"))
+                 ("version" "0.8.0")
+                 ("dateAdded" (spec:unix-now))
+                 ("dateUpdated" (spec:unix-now))
+                 ("recordType" "A")
+                 ("record" domain)
+                 ("resolvedAddresses" (list)))))
+          (publish
+           *producer-agent*
+           :body (jsown:to-json document)
+           :routing-key "documents.ingest.domain"
+           :properties (list (cons :type "domain")))
+          (log-actor-event
+           "domain-enricher"
+           :event-type "emitted"
+           :details (format nil "Emitted domain ~a" domain)
+           :source-id source-id))))))
+
+(nhooks:add-hook
+ star:*actors-start-hook*
+ (lambda ()
+   (register-actor "domain-enricher" *domain-enricher*)))
+#+end_src
+
+The =define-actor= macro:
+
+- defines the actor variable;
+- defines a =START-<NAME>= function;
+- creates the actor when the start hook runs;
+- adds that start function to =*actors-start-hook*=.
+
+The macro accepts a =:register= keyword, but the current implementation does not
+use it. Register the actor explicitly in a second hook as shown above.
+
+** Load a custom actor from the init file
+
+The init file runs before =start-actors=. It can load actor definitions whose
+start functions will later run on =*actors-start-hook*=:
+
+#+begin_src lisp
+(in-package :star)
+
+(load #P"/etc/starintel/actors/domain-enricher.lisp")
+#+end_src
+
+The file is trusted executable code. Never load actor files from an
+uncontrolled writable directory.
+
+For a built-in actor, add the file to the serial component order in
+=source/starintel-gserver.asd= before files that call its exported functions.
+
+** Register and resolve actor names
+
+Registration maps an operator-facing string name to a Sento actor reference:
+
+#+begin_src lisp
+(star.actors:register-actor "domain-enricher"
+                            star.actors::*domain-enricher*)
+
+(star.actors:get-dest-actor "domain-enricher")
+#+end_src
+
+Actor names in target documents must match the registered string exactly.
+
+** Target document
+
+Legacy target fields:
+
+| Field | Type | Meaning |
+|-------+------+---------|
+| =actor= | string | Registered local actor name or external actor name |
+| =target= | string | Target value or source document ID |
+| =delay= | integer | Recurrence interval in seconds |
+| =recurring= | boolean | Schedule repeated delivery |
+| =options= | array | Actor-defined options |
+| common metadata | object fields | =_id=, dataset, dtype, sources, version, timestamps |
+
+Submit a target through HTTP:
+
+#+begin_src sh
+curl --fail \
+  --header 'Content-Type: application/json' \
+  --request POST \
+  --data '{
+    "dataset": "demo",
+    "target": "example.org",
+    "delay": 3600,
+    "recurring": true,
+    "options": [{"record_types": ["A", "AAAA", "MX"]}]
+  }' \
+  http://127.0.0.1:5000/new/target/domain-enricher
+#+end_src
+
+The route sets =dtype= to =target= and =actor= from the URL.
+
+** Target routing
+
+When a persisted target arrives:
+
+1. the Rabbit target consumer tells the local target-router actor;
+2. the router looks up =actor= in the actor index;
+3. if found, it tells the local actor;
+4. if missing, it publishes to
+   =actors.<actor>.new.target= on the =documents= exchange;
+5. if =recurring= is true on the first delivery, the router schedules a timer
+   and later repeats the local/remote route.
+
+This allows the same target format to address in-process and external actors.
+
+** Actor communication
+
+*** Local actor to local actor
+
+#+begin_src lisp
+(tell destination message)
+#+end_src
+
+Use this when both actors share the process. It avoids serialization and
+RabbitMQ.
+
+*** Local actor to distributed pipeline
+
+#+begin_src lisp
+(publish *producer-agent*
+         :body json
+         :routing-key "documents.ingest.user"
+         :properties (list (cons :type "user")))
+#+end_src
+
+Use the =documents.ingest.*= path for durable derived documents.
+
+*** Local actor event
+
+#+begin_src lisp
+(log-actor-event
+ "domain-enricher"
+ :event-type "completed"
+ :details "Resolved target"
+ :source-id source-document-id)
+#+end_src
+
+*** External actor
+
+Bind a queue to =actors.<actor-name>.new.target=. Publish outputs back to the
+=documents= exchange. See [[file:messaging.org][messaging.org]].
+
+** Actor output contract
+
+An actor may return no documents. When it emits a document:
+
+- include a non-empty =dtype=;
+- preserve the source dataset unless intentionally crossing datasets;
+- generate a stable ID when the result is deterministic;
+- append provenance rather than replacing it;
+- publish to ingest for persistence;
+- emit relations as first-class documents;
+- make retries safe;
+- do not ACK an external Rabbit delivery before required writes/publications
+  complete.
+
+** Creating relations
+
+The current =star-cl= constructor uses keyword arguments:
+
+#+begin_src lisp
+(spec:new-relation
+ dataset
+ source-id
+ target-id
+ :predicate "derived-from"
+ :note "Created by domain-enricher")
+#+end_src
+
+Do not use an old positional fourth predicate argument. Some experimental actor
+files still contain calls written for an older signature.
+
+** Pattern subscribers
+
+A pattern contains:
+
+- a name;
+- a predicate function;
+- a list of actor references;
+- a transient flag intended to describe generated messages.
+
+#+begin_src lisp
+(add-pattern
+ (define-pattern
+     ("message-links" (list *domain-enricher*))
+   (lambda (document)
+     (string= (jsown:val document "dtype") "message"))))
+#+end_src
+
+When =notify-subs= is called and the predicate returns true, it tells each
+subscriber the document.
+
+The matcher framework is currently experimental. The URL extractor starts from
+a hook, but a complete actor that feeds every new document through
+=*document-patterns*= is not evident in the active runtime. Do not assume that
+adding a pattern alone creates a Rabbit subscription.
+
+** Recursive actor design
+
+A recursive actor should treat each invocation as one bounded graph expansion
+step.
+
+Recommended message contract:
+
+#+begin_src json
+{
+  "extensions": {
+    "star_server": {
+      "trace_id": "01J...",
+      "root_id": "root-id",
+      "parent_id": "source-id",
+      "actor_path": ["seed", "domain-enricher"],
+      "depth": 1,
+      "hop": 2,
+      "max_depth": 8,
+      "max_hops": 32,
+      "input_hash": "sha256:...",
+      "output_hash": "sha256:..."
+    }
+  }
+}
+#+end_src
+
+Before emitting more work:
+
+1. verify =depth < max_depth= and =hop < max_hops=;
+2. reject a non-repeatable actor already present in =actor_path=;
+3. compute a deterministic output ID;
+4. stop at a fixed point when output hash equals prior output hash;
+5. add a provenance relation;
+6. increment metadata;
+7. emit a terminal actor event when stopping.
+
+The server deep-merges nested update objects, so this extension object can be
+updated without deleting sibling metadata.
+
+** Error handling
+
+A local actor should catch errors it can classify, emit an actor event, and
+either:
+
+- drop a permanently invalid message;
+- emit an update marking the source failed;
+- create a retry target with delay;
+- let the actor runtime surface an unexpected failure.
+
+Do not create a zero-delay recursive retry loop.
+
+External actor services should use dead-letter exchanges or a retry queue with
+backoff. The core server does not declare those queues for you.
+
+** Testing an actor
+
+Unit-test the receive function as a pure transform where possible. Integration
+tests should verify:
+
+1. target publication;
+2. actor delivery;
+3. derived document publication;
+4. CouchDB persistence;
+5. relation/provenance creation;
+6. duplicate delivery idempotency;
+7. depth/hop termination;
+8. recurring target behavior.
+
+Run the repository test commands from [[file:testing.md][testing.md]].

--- a/docs/architecture.org
+++ b/docs/architecture.org
@@ -1,0 +1,204 @@
+#+title: StarIntel Server architecture
+#+options: toc:3
+
+* Architecture
+
+StarIntel Server is an event-driven Common Lisp service. CouchDB is the durable
+corpus, RabbitMQ is the distributed message bus, and Sento actors are the local
+message-passing runtime.
+
+** Component map
+
+#+begin_example
+                        +----------------------+
+HTTP / CLI / services ->| HTTP API             |
+                        | Ningle + Clack        |
+                        +----------+-----------+
+                                   |
+                                   | publish
+                                   v
+                         +---------+----------+
+                         | RabbitMQ           |
+                         | topic: documents   |
+                         +----+----------+----+
+                              |          |
+                   ingest/update          | actor-specific target
+                              |          |
+                              v          v
+                    +---------+--+   +---+----------------+
+                    | Consumers  |   | External actors    |
+                    | lparallel  |   | Rabbit consumers   |
+                    +-----+------+   +--------------------+
+                          |
+                          v
+                    +-----+------+
+                    | CouchDB    |
+                    | documents  |
+                    | views/FTS  |
+                    +-----+------+
+                          |
+                          | post-insert documents.new.<dtype>
+                          v
+                    +-----+--------------------+
+                    | Sento actor system       |
+                    | local actors, timers,    |
+                    | index, DB agents, events |
+                    +--------------------------+
+#+end_example
+
+** Startup order
+
+=star::main= performs the following operations in order:
+
+1. Resolve and load the init file. The init file is executable Common Lisp.
+2. Create the global lparallel kernel with =*ingest-workers*= workers.
+3. Initialize CouchDB:
+   - create the main database if missing;
+   - upsert design documents loaded from =source/views/*.json=;
+   - create the actor-event database if missing.
+4. Start the Sento actor system.
+5. Connect the pinned RabbitMQ producer agent.
+6. Start internal CouchDB, actor-index, target, and timer actors.
+7. Run =*actors-start-hook*= to start and register application actors.
+8. Start the HTTP API and its RabbitMQ connection.
+9. Start RabbitMQ ingest, update, and target consumers.
+10. Start two actor-event RabbitMQ consumers.
+11. Join all threads so the process remains alive.
+
+Startup is fail-fast: an uncaught initialization error terminates the process.
+
+** Concurrency model
+
+*** Sento actors
+
+Actors receive one message at a time through their mailbox. Actor references are
+stored in an agent-backed name index. Local actor communication uses =tell= and
+does not serialize through RabbitMQ.
+
+The actor system uses a pinned dispatcher sized from =*ingest-workers*=. The
+producer and CouchDB agents are pinned so their mutable connection state is only
+touched by one actor thread.
+
+*** lparallel consumers
+
+Each Rabbit consumer worker owns a RabbitMQ connection and channel. A worker:
+
+1. reads one delivery;
+2. submits its handler to an lparallel channel;
+3. waits for the handler result;
+4. lets the handler ACK or NACK the delivery.
+
+Rabbit QoS prefetch is 200 per worker connection.
+
+*** HTTP threads
+
+Hunchentoot is started with:
+
+- maximum thread count: 50;
+- maximum accept count: 100;
+- request timeout: 300 seconds.
+
+CouchDB HTTP requests use a pool with 20 maximum open and 10 maximum idle
+connections.
+
+** Durable data
+
+*** Main database
+
+=*couchdb-default-database*= defaults to =starintel=. It stores StarIntel
+documents and CouchDB design documents.
+
+*** Actor-event database
+
+=*couchdb-event-log-database*= defaults to =starintel-event-source=. It stores
+actor-event records separately from the main corpus.
+
+*** RabbitMQ state
+
+The Compose stack persists RabbitMQ state in =rabbitmq_data=. Document messages
+are not a substitute for CouchDB backups.
+
+*** Full-text index
+
+Clouseau indexes are derived data. The Compose stack persists them in
+=clouseau_index= for faster restart, but they can be rebuilt from CouchDB.
+
+** Repository layout
+
+| Path | Purpose | Runtime status |
+|------+---------+----------------|
+| =source/starintel-gserver.asd= | Loaded systems and component order | Active source of truth |
+| =source/main.lisp= | CLI command, startup, REPL entry, debugger helper | Active |
+| =source/gserver-settings.lisp= | Global defaults and environment reads | Active |
+| =source/init-loader.lisp= | Init-file resolution, bootstrap, and load | Active |
+| =source/actors.lisp= | Actor system, index, DB actors, target router, producer | Active |
+| =source/rabbit.lisp= | Routing constants, ingest/update/target handlers | Active |
+| =source/consumers/= | Generic and Rabbit stream consumers | Active |
+| =source/producers/= | Persistent Rabbit producer abstraction | Active |
+| =source/databases/couchdb.lisp= | DB initialization, JSON conversion, views | Active |
+| =source/frontends/http-api.lisp= | HTTP routes and server startup | Active |
+| =source/actor-systems/event-actor.lisp= | Actor-event storage and consumer | Active |
+| =source/actor-systems/matcher-actor.lisp= | Pattern subscriptions and URL extractor | Experimental |
+| =source/actor-systems/user-finder.lisp= | WhatsMyName actor | Not loaded by ASDF |
+| =source/actor-systems/user-hunt.lisp= | Older WhatsMyName consumer | Not loaded by ASDF |
+| =source/views/= | CouchDB map/reduce and FTS design documents | Installed at startup |
+| =cli/= | API client and command-line client systems | Built separately |
+| =ui/= | Separate Common Lisp UI system | Built separately |
+| =source/migrations/= | Migration system | Built separately |
+| =t/= | Unit and integration test code | Test-only |
+| =nix/=, =flake.nix= | Reproducible packages, binaries, and OCI images | Build system |
+| =docker/=, =docker-compose.yml= | Runtime images, entrypoints, and local stack | Deployment |
+| =scripts/= | Stack acceptance test and utilities | Operations |
+| =example_configs/= | Init-file examples | Operator input |
+| =docs/= | Operator and developer documentation | Documentation |
+
+** Loaded actor systems
+
+The ASDF system loads only:
+
+- =event-actor.lisp=
+- =matcher-actor.lisp=
+
+The user-finder and user-hunt files are not loaded. Adding a file to the
+repository does not activate it. Add it to the ASDF component list or load it
+from a trusted init file, then register its startup hook.
+
+** CouchDB views
+
+At load time, =gserver-settings.lisp= reads every JSON file under
+=source/views/=. During startup, =init-db= creates or updates each design
+document using its =_id= and current =_rev=.
+
+The Lisp view wrapper supports:
+
+- =limit=, =skip=, =descending=;
+- =key=, =keys=, =start-key=, =end-key=;
+- =include-docs=;
+- =update=, including ="lazy"=;
+- =reduce=, =group=, and =group-level=.
+
+Passing conflicting key modes raises an error.
+
+View wrappers cover messages, social posts, datasets, timelines, organizations,
+people, relations, targets, users, events, hosts, emails, domains, networks,
+URLs, and breaches.
+
+** Failure boundaries
+
+- Rabbit handler success must ACK the delivery.
+- Unexpected ingest/update errors NACK and requeue.
+- CouchDB insert conflict during initial ingest is NACKed without requeue.
+- Update conflicts are refetched and retried up to two times before requeue.
+- Rabbit publish is bounded by =*publish-timeout-seconds*=, default 5 seconds.
+- Actor exceptions stay inside the Sento actor boundary according to Sento
+  behavior; actor-specific recovery policy is not centralized in this repo.
+- HTTP publication success means the message reached the producer call. It does
+  not prove downstream persistence.
+
+** Security boundaries
+
+The current server has no built-in HTTP authentication, authorization, rate
+limiting, tenant isolation, or request schema enforcement. The init file can run
+arbitrary code. SLYNK provides remote Lisp evaluation. Use network isolation,
+least-privilege Rabbit/Couch credentials, an authenticated reverse proxy, and
+loopback-only debugger binding.

--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -1,0 +1,271 @@
+#+title: StarIntel Server configuration
+#+options: toc:3
+
+* Configuration
+
+StarIntel Server has three effective configuration layers:
+
+1. compiled defaults and environment reads in =source/gserver-settings.lisp=;
+2. an executable Common Lisp init file loaded before startup;
+3. container environment and secret-file expansion in
+   =docker/star-server-entrypoint.sh=.
+
+The init file runs last and can override global variables.
+
+** Init file selection
+
+Resolution order:
+
+1. =--init PATH= or =-i PATH=;
+2. =STAR_SERVER_INIT_FILE=;
+3. =./init.lisp=.
+
+When the selected file does not exist, the loader copies
+=example_configs/init.lisp= to that path, then loads it.
+
+The init file is arbitrary Common Lisp and has the same privileges as the
+server process.
+
+** Environment variables read by the Lisp runtime
+
+| Variable | Default | Runtime variable |
+|----------+---------+------------------|
+| =COUCHDB_HOST= | =127.0.0.1= | =star:*couchdb-host*= |
+| =COUCHDB_DATABASE= | =starintel= | =star:*couchdb-default-database*= |
+| =COUCHDB_USER= | =admin= | =star:*couchdb-user*= |
+| =COUCHDB_PASSWORD= | empty | =star:*couchdb-password*= |
+| =HTTP_API_LISTEN_ADDRESS= | =localhost= | =star:*http-api-address*= |
+| =RABBITMQ_ADDRESS= | =localhost= | =star:*rabbit-address*= |
+| =RABBITMQ_USER= | =guest= | =star:*rabbit-user*= |
+| =RABBITMQ_PASSWORD= | empty | =star:*rabbit-password*= |
+| =STAR_SERVER_INIT_FILE= | =./init.lisp= | init path |
+
+Current fixed defaults unless overridden in Lisp:
+
+| Runtime variable | Default |
+|------------------+---------|
+| =*couchdb-port*= | 5984 |
+| =*couchdb-scheme*= | ="http"= |
+| =*http-api-port*= | 5000 |
+| =*rabbit-port*= | 5672 |
+| =*ingest-workers*= | 4 |
+| =*bulk-max-documents*= | 500 |
+| =*couchdb-event-log-database*= | ="starintel-event-source"= |
+| =*slynk-port*= | 4009 |
+| =*publish-timeout-seconds*= | 5 |
+
+The Compose variables =STAR_SERVER_PORT=, =COUCHDB_PORT=, and =RABBITMQ_PORT=
+control host-side port mappings. They do not change the internal Lisp ports.
+
+** Secret files in containers
+
+The container entrypoint reads:
+
+- =COUCHDB_PASSWORD_FILE= and exports =COUCHDB_PASSWORD=;
+- =RABBITMQ_PASSWORD_FILE= and exports =RABBITMQ_PASSWORD=.
+
+It then drops to UID/GID 65532 and starts:
+
+#+begin_example
+/bin/star-server start -i /etc/starintel/init.lisp
+#+end_example
+
+Outside that image, =*_FILE= variables are not read by the Lisp code.
+
+** Complete init-file example
+
+#+begin_src lisp
+(in-package :star)
+
+;;; CouchDB
+(setf *couchdb-host* "127.0.0.1"
+      *couchdb-port* 5984
+      *couchdb-scheme* "http"
+      *couchdb-user* "admin"
+      *couchdb-password* (or (uiop:getenv "COUCHDB_PASSWORD") "")
+      *couchdb-default-database* "starintel"
+      *couchdb-event-log-database* "starintel-event-source")
+
+;;; RabbitMQ
+(setf *rabbit-address* "127.0.0.1"
+      *rabbit-port* 5672
+      *rabbit-user* "starintel"
+      *rabbit-password* (or (uiop:getenv "RABBITMQ_PASSWORD") ""))
+
+;;; HTTP
+(setf *http-api-address* "127.0.0.1"
+      *http-api-port* 5000
+      *bulk-max-documents* 500)
+
+;;; Concurrency
+(setf *ingest-workers* 8
+      star.actors:*publish-timeout-seconds* 5)
+
+;;; Logging
+(ensure-directories-exist #P"logs/")
+(log:config :daily "logs/star-server.log" :file2 :sane)
+
+;;; Custom actors are loaded now and started later by hooks.
+(load #P"/absolute/path/to/actors/domain-enricher.lisp")
+#+end_src
+
+** Local development
+
+#+begin_src lisp
+(in-package :star)
+
+(setf *couchdb-host* "127.0.0.1"
+      *rabbit-address* "127.0.0.1"
+      *http-api-address* "127.0.0.1"
+      *ingest-workers* 4)
+
+(log:config :sane)
+#+end_src
+
+Keep the API, Rabbit management UI, CouchDB, and SLYNK on loopback.
+
+** Docker internal networking
+
+The Compose image receives service DNS names from =docker-compose.yml=. The
+mounted init file should not replace them with host-loopback values:
+
+#+begin_src lisp
+(in-package :star)
+
+(setf *couchdb-host* (or (uiop:getenv "COUCHDB_HOST") "couchdb")
+      *rabbit-address* (or (uiop:getenv "RABBITMQ_ADDRESS") "rabbitmq")
+      *http-api-address* (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") "0.0.0.0"))
+#+end_src
+
+** Remote CouchDB and RabbitMQ
+
+#+begin_src lisp
+(in-package :star)
+
+(setf *couchdb-host* "couch.internal.example"
+      *couchdb-port* 6984
+      *couchdb-scheme* "https"
+      *couchdb-user* "starintel-writer"
+      *couchdb-password* (uiop:getenv "COUCHDB_PASSWORD")
+      *rabbit-address* "rabbit.internal.example"
+      *rabbit-port* 5671
+      *rabbit-user* "starintel"
+      *rabbit-password* (uiop:getenv "RABBITMQ_PASSWORD"))
+#+end_src
+
+Caveat: this repository's Rabbit client setup does not visibly configure TLS
+parameters. Changing the port to 5671 alone does not establish a verified TLS
+connection. Terminate through a trusted private tunnel/proxy or add explicit
+TLS support to the client before relying on it.
+
+CouchDB's scheme is configurable, but certificate verification behavior depends
+on =cl-couch=/Dexador configuration.
+
+** High-throughput ingest
+
+#+begin_src lisp
+(in-package :star)
+
+(setf *ingest-workers* 16
+      *bulk-max-documents* 2000
+      star.actors:*publish-timeout-seconds* 10)
+#+end_src
+
+Tune carefully:
+
+- each Rabbit consumer worker opens its own connection/channel;
+- each worker uses prefetch 200;
+- the actor pinned dispatcher size follows =*ingest-workers*=;
+- the HTTP CouchDB pool remains 20 open connections unless code is changed;
+- larger bulk limits increase HTTP handler time and partial-failure volume;
+- the producer remains serialized through one pinned producer agent.
+
+Scale external actors horizontally before turning one server into an
+unbounded fan-out engine.
+
+** Low-memory deployment
+
+#+begin_src lisp
+(in-package :star)
+
+(setf *ingest-workers* 2
+      *bulk-max-documents* 100)
+#+end_src
+
+Compose example:
+
+#+begin_example
+CLOUSEAU_JAVA_OPTS=-Xms128m -Xmx512m
+#+end_example
+
+The server schedules a full SBCL garbage collection once per hour.
+
+** Enable SLYNK deliberately
+
+#+begin_src lisp
+(in-package :star)
+
+(setf *slynk-port* 4009)
+(start-debugger)
+#+end_src
+
+SLYNK is remote code execution. Bind it through SSH/Unix forwarding or a
+loopback-only environment. The helper does not implement authentication.
+
+** Custom CouchDB view
+
+Add a JSON design document under =source/views/=. It is read when the Lisp
+system loads and upserted at database initialization.
+
+Example:
+
+#+begin_src json
+{
+  "_id": "_design/custom",
+  "views": {
+    "by_actor": {
+      "map": "function(doc) { if (doc.extensions && doc.extensions.star_server) emit(doc.extensions.star_server.actor, null); }"
+    }
+  }
+}
+#+end_src
+
+Because view files are collected at Lisp load time, rebuild/reload the system
+after adding a file.
+
+** Reverse proxy
+
+The server's built-in HTTP TLS variables and =*http-api-base-path*= are not
+currently applied by =start-http-api=. Terminate TLS and authentication at a
+reverse proxy.
+
+Minimum proxy controls:
+
+- authenticated access;
+- request body limit;
+- rate limiting;
+- timeout shorter than or aligned with the 300-second backend timeout;
+- explicit allowed origins instead of forwarding wildcard CORS;
+- network denial for direct backend access;
+- audit logs without sensitive document bodies.
+
+** Multi-dataset operation
+
+=dataset= is a document field, not a separate CouchDB database. The current
+server stores all datasets in =*couchdb-default-database*= and exposes views that
+filter/count by dataset.
+
+Use separate server/database deployments when you need hard isolation. Dataset
+strings alone provide no authorization boundary.
+
+** Configuration traps
+
+- =*star-server-version*= currently says =0.0.1= while ASDF and container
+  packages use =0.1.0=.
+- HTTP =POST /new/document/:dtype= does not set the body =dtype=.
+- The init template can overwrite environment-derived values.
+- =*http-api-cert*= and =*http-api-key*= are unused by the server startup.
+- =*http-api-base-path*= is unused; routes are mounted at root.
+- A missing init file is created automatically, which can hide a wrong path.
+- =COUCHDB_PASSWORD_FILE= and =RABBITMQ_PASSWORD_FILE= work only through the
+  container entrypoint.

--- a/docs/document-spec.org
+++ b/docs/document-spec.org
@@ -1,0 +1,390 @@
+#+title: StarIntel document specification in star-server
+#+options: toc:3
+
+* Document specification
+
+StarIntel Server currently sits between two document generations:
+
+1. *StarIntel 0.9.0*: the strict, schema-driven format implemented by the
+   validators in =lost-rob0t/star-cl= and =lost-rob0t/starintel-doc=.
+2. *Legacy flat 0.8.0*: Common Lisp classes and constructors still used by parts
+   of this server and its actor examples.
+
+The server reports the =star-cl= document version from =GET /=, but the HTTP and
+RabbitMQ ingest handlers do not currently call the strict 0.9 validator. A
+=document= with a non-empty =dtype= can reach CouchDB even when it does not
+conform to 0.9.
+
+** StarIntel 0.9 envelope
+
+The 0.9 adapters require:
+
+- a JSON object;
+- =schema_version= exactly ="0.9.0"=;
+- a canonical =dtype= from the schema;
+- fields and data types defined by the schema;
+- RFC 3339 date-time strings where the schema requires =date-time=;
+- no undeclared fields in closed schema sections.
+
+The adapters preserve unknown extension data and missing optional fields when
+the schema permits them.
+
+Conceptual envelope:
+
+#+begin_src json
+{
+  "schema_version": "0.9.0",
+  "dtype": "person",
+  "_id": "01J...",
+  "dataset": "investigation-a",
+  "sources": ["manual"],
+  "data": {
+    "fname": "Ada",
+    "lname": "Lovelace"
+  },
+  "extensions": {
+    "star_server": {
+      "trace_id": "01J...",
+      "root_id": "01J...",
+      "parent_id": null,
+      "actor_path": []
+    }
+  }
+}
+#+end_src
+
+Use the canonical schema distributed by the StarIntel conformance/spec
+repository. The adapters locate it through:
+
+| Variable | Meaning |
+|----------+---------|
+| =STARINTEL_SCHEMA= | Explicit path to =starintel-doc-v0.9.0.schema.json= |
+| =STARINTEL_CONFORMANCE_ROOT= | Root containing =schemas/starintel-doc-v0.9.0.schema.json= |
+
+The current server does not consume either variable directly; =star-cl='s
+validator does.
+
+** Rejected 0.9 aliases
+
+The 0.9 adapters explicitly reject these dtype aliases rather than silently
+normalizing them:
+
+#+begin_example
+organization
+organisation
+investigation_target
+social_media_post
+email_message
+financial_observation
+research_pass
+dataset_manifest
+actor_manifest
+legal_case
+lobbying_filing
+campaign_finance
+#+end_example
+
+Use the canonical dtype from the schema inventory.
+
+** Legacy flat 0.8 common fields
+
+The legacy Common Lisp =document= class serializes Lisp slot names to camelCase,
+while preserving leading underscore keys.
+
+| JSON field | Type | Meaning |
+|------------+------+---------|
+| =_id= | string | Document identity; ULID or deterministic hash |
+| =_rev= | string, optional | CouchDB revision; emitted only when syntactically valid |
+| =dataset= | string | Logical corpus/dataset |
+| =dtype= | string | Object type |
+| =sources= | array | Provenance labels/URIs/actor names |
+| =version= | string | Legacy document version, normally ="0.8.0"= |
+| =dateAdded= | integer | Unix timestamp |
+| =dateUpdated= | integer | Unix timestamp |
+
+When encoding legacy classes, missing strings become =""=, integers become =0=,
+lists become =[]=, booleans become =false=, and unknown values may become JSON
+=null=.
+
+** Legacy object types
+
+These are the concrete classes currently exported by =star-cl=. They are not a
+substitute for the canonical 0.9 schema.
+
+*** person
+
+| Field | Type |
+|-------+------|
+| =fname= | string |
+| =mname= | string |
+| =lname= | string |
+| =bio= | string |
+| =dob= | string |
+| =region= | string |
+| =misc= | array |
+| =etype= | string, default =person= |
+| =eid= | string |
+
+ID strategy: ULID.
+
+*** org
+
+| Field | Type |
+|-------+------|
+| =reg= | string |
+| =name= | string |
+| =bio= | string |
+| =country= | string |
+| =website= | string |
+| =etype= | string, default =org= |
+| =eid= | string |
+
+ID strategy: hash of name, registration, and country.
+
+*** relation
+
+| Field | Type | Meaning |
+|-------+------+---------|
+| =source= | string | Source document ID |
+| =target= | string | Target document ID |
+| =predicate= | string | Directed edge label |
+| =note= | string | Human/actor note |
+
+ID strategy: ULID. Relations are directed.
+
+*** target
+
+| Field | Type |
+|-------+------|
+| =actor= | string | Local registered actor or external actor name |
+| =target= | string | Target value/document ID |
+| =delay= | integer | Recurrence interval in seconds |
+| =recurring= | boolean | Re-deliver on timer |
+| =options= | array | Actor-defined values |
+
+ID strategy: hash of dataset, target, and actor.
+
+*** domain
+
+| Field | Type |
+|-------+------|
+| =recordType= | string |
+| =record= | string |
+| =resolvedAddresses= | array |
+
+ID strategy: hash of record and record type.
+
+*** host
+
+| Field | Type |
+|-------+------|
+| =hostname= | string |
+| =ip= | string |
+| =os= | string |
+| =ports= | array of service-like values |
+
+ID strategy: hash of IP.
+
+*** service
+
+Embedded object fields: =port= integer, =name= string, =ver= string.
+
+*** network
+
+Fields: =org= string, =subnet= string, =asn= integer. ID is derived from ASN and
+organization.
+
+*** url
+
+Fields: =url= string, =path= string, =query= string, =content= string. ID is
+derived from URL and content.
+
+*** email
+
+Fields: =user= string, =domain= string, =password= string. ID includes password
+only when non-empty.
+
+#+begin_quote
+Do not store credential material unless the collection and storage are lawful,
+authorized, necessary, and access-controlled. The current server has no
+field-level encryption or authorization.
+#+end_quote
+
+*** emailmessage
+
+Fields: =body=, =subject=, =to=, =from=, =headers= strings; =cc= and =bcc=
+arrays.
+
+*** user
+
+Fields: =url=, =name=, =platform=, =bio= strings and =misc= array.
+
+*** breach
+
+Fields: =total= integer, =description= string, =url= string.
+
+*** message
+
+Fields:
+
+- =content= string
+- =platform= string
+- =user= string
+- =isReply= boolean
+- =media= array
+- =messageId= string
+- =replyTo= string
+- =group= string
+- =channel= string
+- =mentions= array
+
+*** socialmpost
+
+Fields:
+
+- =content=, =user=, =url=, =title=, =group=, =replyTo= strings
+- =replies=, =media=, =links=, =tags= arrays
+- =replyCount=, =repostCount= integers
+
+*** phone
+
+Fields: =number=, =carrier=, =status=, =phoneType= strings.
+
+*** geo and address
+
+=geo=: =lat=, =long=, =alt= numbers.
+
+=address= extends geo with =city=, =state=, =postal=, =country=, =street=, and
+=street2=.
+
+** Relation predicates
+
+The current =star-cl= relation constructor validates predicates against an
+allowlist. Groups include:
+
+- identity: =same-as=, =duplicate-of=, =aka=, =alias-of=, =username-of=,
+  =email-of=, =phone-of=, =account-of=;
+- people/org: =member-of=, =employed-by=, =contractor-for=, =works-with=,
+  =manages=, =reports-to=;
+- ownership/control: =owns=, =owned-by=, =controls=, =controlled-by=,
+  =operates=, =operated-by=, =administers=, =administered-by=;
+- registration: =registered-to=, =registrant-of=, =whois-registrant-of=,
+  =whois-admin-of=, =whois-tech-of=;
+- location: =located-at=, =geolocated-at=, =seen-at=;
+- communication: =communicates-with=, =contacted=, =contacted-by=, =mentions=,
+  =replies-to=, =follows=;
+- web: =links-to=, =redirects-to=, =canonical-url-of=, =hosts=, =hosted-by=,
+  =served-by=;
+- DNS/network: =resolves-to=, =ptr-to=, =has-a=, =has-aaaa=, =has-cname=,
+  =has-ns=, =has-mx=, =has-txt=, =has-spf=, =has-dkim=, =has-dmarc=,
+  =has-soa=, =behind-cdn=, =belongs-to-asn=, =served-from=,
+  =shares-ip-with=, =shares-asn-with=;
+- services: =hosts-service=, =listens-on=, =exposes-port=, =runs=, =runs-on=;
+- credential/breach: =leaked-in=, =credential-for=, =compromised-by=;
+- provenance/evidence: =observed-on=, =observed-by=, =collected-from=,
+  =extracted-from=, =derived-from=, =downloaded-from=, =uploaded-to=,
+  =created-by=, =modified-by=, =hashes-to=, =matches-hash=, =evidence-of=,
+  =indicates=;
+- security/research: =attributed-to=, =uses=, =targets=, =exploits=,
+  =mitigates=, =c2-for=, =in-scope-of=, =out-of-scope-of=,
+  =discovered-by=, =scanned-by=, =has-finding=, =vulnerable-to=;
+- generic: =related-to=.
+
+Constructor:
+
+#+begin_src lisp
+(spec:new-relation
+ "dataset"
+ "source-id"
+ "target-id"
+ :predicate "derived-from"
+ :note "Generated by actor")
+#+end_src
+
+** ID strategies
+
+The legacy constructors mix two identity models:
+
+- *ULID*: person, relation, default document when the server normalizes a
+  missing ID.
+- *Deterministic hash*: org, domain, network, host, URL, email, user, message,
+  social post, phone, target, geo/address.
+
+Deterministic IDs support idempotent recursive actors, but the current default
+hash algorithm in =star-cl= is MD5. Treat it as a deduplication key, not a
+cryptographic integrity proof. Use SHA-256 in provenance extensions when
+integrity matters.
+
+** CouchDB fields
+
+The ingest handler:
+
+1. generates a ULID when =_id= is missing or empty;
+2. writes the JSON document;
+3. replaces/sets =_id= from CouchDB's response;
+4. adds =_rev=;
+5. republishes the enriched document as =documents.new.<dtype>=.
+
+The update handler requires =_id= and =dtype=. It fetches the current document,
+deep-merges the patch, applies the latest =_rev=, retries conflicts, and emits
+the new revision.
+
+** Actor event document
+
+Current actor-event fields:
+
+| Field | Type |
+|-------+------|
+| =_id= | ULID string |
+| =timestamp= | Unix integer |
+| =dtype= | intended =actorevent= |
+| =actorName= | string |
+| =eventType= | string |
+| =details= | string |
+| =sourceId= | string |
+
+Actor events are stored in the separate event database.
+
+** Recursive provenance convention
+
+No server component automatically adds recursive provenance. Use a stable
+extension contract across actors:
+
+#+begin_src json
+{
+  "extensions": {
+    "star_server": {
+      "trace_id": "01J...",
+      "root_id": "root-document-id",
+      "parent_id": "source-document-id",
+      "actor": "dns-resolver",
+      "actor_path": ["seed", "domain-enricher", "dns-resolver"],
+      "depth": 2,
+      "hop": 3,
+      "max_depth": 8,
+      "max_hops": 32,
+      "derivation": "dns-resolution",
+      "input_hash": "sha256:...",
+      "output_hash": "sha256:...",
+      "emitted_at": "2026-07-26T20:00:00Z"
+    }
+  }
+}
+#+end_src
+
+Also emit a relation from source to derived output. Metadata alone does not
+replace graph edges.
+
+** Migration guidance
+
+For new producers:
+
+1. emit strict 0.9 when the deployed server path validates it;
+2. keep one canonical dtype and field spelling;
+3. put actor/runtime-specific data under =extensions=;
+4. do not silently convert aliases;
+5. test round-trip preservation against every language adapter;
+6. document any legacy 0.8 bridge at the boundary.
+
+For the current server, verify downstream consumers before switching an active
+pipeline from flat 0.8 fields to nested 0.9 =data=.

--- a/docs/http-api-docs.org
+++ b/docs/http-api-docs.org
@@ -1,246 +1,296 @@
-#+title: Http docs
+#+title: StarIntel HTTP API
+#+options: toc:3
 
-* Http Api Docs
-** Search
+* HTTP API
 
-*** Search Documents
+Default base URL: =http://127.0.0.1:5000=
 
-Example usage
+The API currently has no authentication or authorization and allows every CORS
+origin. Do not expose it directly to an untrusted network.
 
-#+begin_src http
-GET http://127.0.0.1:5000/search?q=content:"hello"&limit=10&include_docs=true
-Accept: application/json
+All implemented routes are mounted at =/=; =*http-api-base-path*= is not used.
+
+** Response behavior
+
+Most successful document/query responses are raw JSON from JSOWN or CouchDB.
+Structured status responses look like:
+
+#+begin_src json
+{"msg":"OK","status":"info"}
 #+end_src
 
-earches for documents matching the specified query.
+CouchDB wrapper errors commonly map to:
 
-Parameters:
-- q: (required) The search query string
-- limit: (optional) Maximum number of results to return (default 25)
-- bookmark: (optional) A bookmark from a previous search to start from for pagination
-- sort: (optional) Field(s) to sort the results by
-- include_docs: (optional) If "true", includes the full document content in the results
+| Status | Meaning |
+|--------+---------|
+| 400 | Bad request |
+| 404 | Document/view result not found |
+| 409 | CouchDB revision conflict |
+| 500 | Unhandled server error |
+| 504 | CouchDB/socket timeout |
 
-Returns:
-A JSON array of matching documents, with the following fields:
-- id: The document ID
-- order: An array with the sort value (if specified) and relevance score
-- fields: An object with the stored field values (if include_docs is not "true")
-- doc: The full document (if include_docs is "true")
+Rabbit publish failure from document/target routes maps to 502; publish timeout
+maps to 504.
 
-The response also includes:
-- total_rows: The total number of matching documents
-- bookmark: A bookmark that can be used for pagination of subsequent requests
-** Targets
-*** Get Targets for Actor
+** Core endpoints
 
-Example usage
+*** GET /health
 
-#+begin_src http
-GET http://127.0.0.1:5000/targets/01731aa61e40224a127259541c8d71da
-Accept: application/json
+Returns process-level health:
+
+#+begin_src sh
+curl --fail http://127.0.0.1:5000/health
 #+end_src
 
-Retrieves the targets for the specified actor.
+This does not deeply verify CouchDB, RabbitMQ, or Clouseau.
 
-** Documents
+*** GET /
 
-*** Create Target
+Returns server metadata:
 
-Example usage
-
-#+begin_src http
-POST http://127.0.0.1:5000/new/target/01731aa61e40224a127259541c8d71da
-Content-Type: application/json
-
-{
-  "_id": "example_target_id",
-  "dataset": "example_dataset",
-  "dtype": "target",
-  "sources": [],
-  "version": "0.7.2",
-  "date_updated": 1621234567,
-  "date_added": 1621234567,
-  "actor": "01731aa61e40224a127259541c8d71da",
-  "target": "example_target",
-  "delay": 0,
-  "recurring": false,
-  "options": []
-}
+#+begin_src sh
+curl --fail http://127.0.0.1:5000/ | jq
 #+end_src
 
-#+RESULTS:
-: HTTP/1.1 200 OK
-: Date: Mon, 20 May 2024 09:58:43 GMT
-: Server: Hunchentoot 1.3.0
-: Transfer-Encoding: chunked
-: Content-Type: text/html; charset=utf-8
-:
-: {  "_id": "example_target_id",  "dataset": "example_dataset",  "dtype": "target",  "sources": [],  "version": "0.7.2",  "date_updated": 1621234567,  "date_added": 1621234567,  "actor": "01731aa61e40224a127259541c8d71da",  "target": "example_target",  "delay": 0,  "recurring": false,  "options": []}
+Fields include document spec version, default dataset/database, actor-event
+database, server name, and server version.
 
-Creates a new target document for the specified actor.
+*** POST /new/document/:dtype
 
-*** /new/document/<dtype>
+Publishes one JSON document to =documents.ingest.<dtype>=.
 
-Example usage
-
-#+begin_src http
-POST http://127.0.0.1:5000/new/document/person
-Content-Type: application/json
-
-
-{
-  "_id": "example_person_id",
-  "dataset": "example_dataset",
-  "dtype": "person",
-  "sources": ["manual"],
-  "version": "0.7.2",
-  "date_updated": 1621234567,
-  "date_added": 1621234567,
-  "fname": "John",
-  "mname": "Doe",
-  "lname": "Smith",
-  "bio": "Example bio",
-  "dob": "1990-01-01",
-  "race": "Example race",
-  "region": "Example region",
-  "misc": [""],
-  "etype": "person",
-  "eid": "example_eid"
-}
+#+begin_src sh
+curl --fail \
+  --header 'Content-Type: application/json' \
+  --request POST \
+  --data '{
+    "_id": "note-1",
+    "dataset": "demo",
+    "dtype": "note",
+    "sources": ["manual"],
+    "version": "0.8.0",
+    "dateAdded": 0,
+    "dateUpdated": 0,
+    "content": "hello"
+  }' \
+  http://127.0.0.1:5000/new/document/note
 #+end_src
 
-#+RESULTS:
-: HTTP/1.1 200 OK
-: Date: Mon, 20 May 2024 10:11:37 GMT
-: Server: Hunchentoot 1.3.0
-: Transfer-Encoding: chunked
-: Content-Type: text/html; charset=utf-8
-:
-: {  "_id": "example_person_id",  "dataset": "example_dataset",  "dtype": "person",  "sources": ["manual"],  "version": "0.7.2",  "date_updated": 1621234567,  "date_added": 1621234567,  "fname": "John",  "mname": "Doe",  "lname": "Smith",  "bio": "Example bio",  "dob": "1990-01-01",  "race": "Example race",  "region": "Example region",  "misc": [""],  "etype": "person",  "eid": "example_eid"}
+Important:
 
-Creates a new document speficied by dtype
+- the URL dtype selects the routing key;
+- the handler does not inject the URL dtype into the body;
+- the ingest consumer requires a non-empty body =dtype=;
+- success means publication, not completed persistence;
+- strict 0.9 validation is not called.
 
-Note: it is emitted onto the message queue from processing
+*** POST /documents/bulk
 
-*** /document
-Example usage
+Publishes an array of documents. Each element must have =dtype=.
 
-#+begin_src http
-GET http://127.0.0.1:5000/document/example_document_id
-Accept: application/json
+#+begin_src sh
+curl --fail \
+  --header 'Content-Type: application/json' \
+  --request POST \
+  --data '[
+    {"_id":"note-1","dataset":"demo","dtype":"note","content":"one"},
+    {"_id":"note-2","dataset":"demo","dtype":"note","content":"two"}
+  ]' \
+  http://127.0.0.1:5000/documents/bulk | jq
 #+end_src
-
-Retrieves the document with the specified ID.
-
-*** Messages
-**** /documents/messages-by-user
-Retrieve messages by user.
-Example usage:
-#+begin_src http
-GET http://127.0.0.1:5000/documents/messages/by-user?user=john_doe&limit=10&descending=true
-#+end_src
-
-#+RESULTS:
-: HTTP/1.1 200 OK
-: Date: Wed, 22 May 2024 00:31:04 GMT
-: Server: Hunchentoot 1.3.0
-: Transfer-Encoding: chunked
-: Content-Type: text/html; charset=utf-8
-:
-: []
-
-
-Returns messages for the specified user, sorted by the dateAdded field in descending order.
-Parameters:
-+ user (required): The user to retrieve messages for.
-+ limit (optional, default 50): The maximum number of messages to return.
-+ start_key (optional): The starting key for the range of messages to return.
-+ end_key (optional): The ending key for the range of messages to return.
-+ descending (optional, default false): Whether to return messages in descending order.
-+ skip (optional, default 0): The number of messages to skip.
-
-The start_key and end_key parameters should be valid JSON strings representing the key range.
-The response is a JSON array of message documents.
-Note: Refer to the Starintel specification for example message objects.
-**** /documents/messages/by-platform
-Retrieve messages by platform.
-#+begin_src http
-GET http://127.0.0.1:5000/documents/messages/by-platform?platform=discord&limit=10&descending=true
-#+end_src
-#+RESULTS:
-: HTTP/1.1 200 OK
-: Date: Wed, 22 May 2024 00:34:38 GMT
-: Server: Hunchentoot 1.3.0
-: Transfer-Encoding: chunked
-: Content-Type: text/html; charset=utf-8
-:
-: [{"_id":"fce27626f2e2ed302b06fea3662e825f","_rev":"1-6992719df874825ab365e43d887391d4","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906816,"dateAdded":1715906816180,"content":"they aren't configured to use the fonts","platform":"discord","user":"__gerg","isReply":[],"media":[],"messageId":"","replyTo":"","group":"Nix/NixOS (unofficial)","channel":"general","mentions":[]},{"_id":"fe7e1194359777b7e8b1dbd8b9477d04","_rev":"1-e82025832a08752c9523ffb6ffec0bf7","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906770,"dateAdded":1715906770880,"content":"I'm aware","platform":"discord","user":"amyipdev","isReply":[],"media":[],"messageId":"","replyTo":"","group":"Nix/NixOS (unofficial)","channel":"Unable to get persistence to actually keep files, cannot use system as a result","mentions":[]},{"_id":"fe209ae93b7a332d98de3c348125b972","_rev":"1-8c017c1b61d9598996e5dd7d68076978","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906654,"dateAdded":1715906654285,"content":"sleep is a scam","platform":"discord","user":"sudzsalmon","isReply":[],"media":[],"messageId":"","replyTo":"","group":"Daydream Society","channel":"general","mentions":[]},{"_id":"fc497f99907ac33142f62e2b77037f8f","_rev":"1-628005d952267d533920e0b8f7c2cddc","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906622,"dateAdded":1715906622575,"content":"Where would she have been upset? A vbulletin forum?","platform":"discord","user":"evilmofo","isReply":[],"media":[],"messageId":"","replyTo":"","group":"DEFCON","channel":"linecon","mentions":[]},{"_id":"ff7c388068fa855cc9b6a60f1b86fde7","_rev":"1-6487f93c484d147ed9692b9ae89c40f8","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906603,"dateAdded":1715906603427,"content":"sinope \u00BB one of the things I like about his channel is his earnest and respectful attitude towards the subject matter","platform":"discord","user":"/v/craft chat","isReply":[],"media":[],"messageId":"","replyTo":"","group":"s.s. /v/ minecraft","channel":"gaem-chat","mentions":[]},{"_id":"ff397ff6b42338692fba48edebc5bb82","_rev":"1-e09925814e5c5ddeb93b2c34e4ed525c","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906398,"dateAdded":1715906398133,"content":"LAYS\n\nFentanyl flavored","platform":"discord","user":"canislycora","isReply":[],"media":[],"messageId":"","replyTo":"","group":"Bluelight.org","channel":"\uD83D\uDDEF\u2502the-lounge","mentions":[]},{"_id":"ff0e7a39d43a844d106bf88eb11722e4","_rev":"1-e9364ec4a3c6b0f73d60ce600b3446d8","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906393,"dateAdded":1715906393579,"content":"my next question I guess is, is the extension list automatically updated or manually maintained?","platform":"discord","user":"ashtefere","isReply":[],"media":[],"messageId":"","replyTo":"","group":"Nix/NixOS (unofficial)","channel":"general","mentions":[]},{"_id":"fdea3948045b94c0ec4db2798d30e111","_rev":"1-706d7e642854330a4f8b3d7646d93182","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906326,"dateAdded":1715906326159,"content":"**Designated Bottomfragger** (76561198137734744) > lightbringer was wild","platform":"discord","user":"Bob's All Gamemodes","isReply":[],"media":[],"messageId":"","replyTo":"","group":"Bob's BattleBit Community","channel":"all-gamemodes-chat","mentions":[]},{"_id":"fc5802e3366cd7b6a5e318cae204b545","_rev":"1-7202ff9567315331ee6b194e14868a58","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906199,"dateAdded":1715906199246,"content":"i choose to believe the singer from Tool personally chewed me out through pirated Napster files","platform":"discord","user":"specksgalore","isReply":[],"media":[],"messageId":"","replyTo":"","group":"DEFCON","channel":"linecon","mentions":[]},{"_id":"fe0b44fcc54f1ae41ca7a0821aeee620","_rev":"1-ebb09652814a75830f290db94f555737","dataset":"starintel","dtype":"message","sources":["discordwatch"],"version":"0.7.2","dateUpdated":1715906148,"dateAdded":1715906148747,"content":"the only place that I know how to affect sound that you're playing with sunvox, is in the sunvox project.","platform":"discord","user":"polylokh_39446","isReply":[],"media":[],"messageId":"","replyTo":"","group":"Nim","channel":"gamedev","mentions":[]}]
-Returns messages for the specified platform, sorted by the dateAdded field in descending order.
-Parameters:
-
-+ platform (required): The platform to retrieve messages for.
-+ limit (optional, default 50): The maximum number of messages to return.
-+ start_key (optional): The starting key for the range of messages to return.
-+ end_key (optional): The ending key for the range of messages to return.
-+ descending (optional, default false): Whether to return messages in descending order.
-+ skip (optional, default 0): The number of messages to skip.
-
-The start_key and end_key parameters should be valid JSON strings representing the key range.
-The response is a JSON array of message documents.
-Note: Refer to the Starintel specification for example message objects.
-**** /documents/messages/by-group
-Example usage
-
-#+begin_src http
-GET http://127.0.0.1:5000/documents/messages/by-group?group=<group-name>&limit=<limit>&start_key=<start-key>&end_key=<end-key>&descending=<true|false>&skip=<skip>
-#+end_src
-
-
-Parameters:
-- group (required): The group name to filter messages by.
-- limit (optional, default: 50): The maximum number of messages to return.
-- start_key (optional): The starting key for the range of messages to return.
-- end_key (optional): The ending key for the range of messages to return.
-- descending (optional, default: false): Whether to return messages in descending order.
-- skip (optional, default: 0): The number of messages to skip from the beginning.
 
 Response:
-The response is a JSON array containing the matching message documents, sorted by the specified criteria. Each message document follows the starintel message spec format. Refer to the starintel-spec documentation for detailed information about the message document structure
-*** SocialMPosts
-**** /documents/socialmpost/by-user
-Example usage
 
-#+begin_src http
-GET http://127.0.0.1:5000/documents/socialmpost/by-user?user=<username>&limit=<limit>&start_key=<start-key>&end_key=<end-key>&descending=<true|false>&skip=<skip>
-#+end_src
-
-
-Parameters:
-- user (required): The username to filter social posts by.
-- limit (optional, default: 50): The maximum number of social posts to return.
-- start_key (optional): The starting key for the range of social posts to return.
-- end_key (optional): The ending key for the range of social posts to return.
-- descending (optional, default: false): Whether to return social posts in descending order.
-- skip (optional, default: 0): The number of social posts to skip from the beginning.
-
-Response:
-The response is a JSON array containing the matching socialmpost documents, sorted by the specified criteria. Each social post document follows the starintel social post spec format. Refer to the starintel-spec documentation for detailed information about the social post document structure.
-*** Neighbors
-**** Get Neighbors
-
-Example usage
-
-#+begin_src http
-POST http://127.0.0.1:5000/relations/neighbors
-Content-Type: application/json
-
+#+begin_src json
 {
-  "docs": ["doc_id1", "doc_id2", "doc_id3"],
-  "n": 2
+  "total": 2,
+  "succeeded": 2,
+  "failed": 0
 }
 #+end_src
 
-#+RESULTS:
+Failures are per element and can produce partial acceptance. The default maximum
+is 500 documents.
 
-Retrieves the neighbors of the specified documents up to the given level.
+*** GET /document/:id
+
+#+begin_src sh
+curl --fail http://127.0.0.1:5000/document/note-1 | jq
+#+end_src
+
+Reads from the configured main CouchDB database.
+
+*** DELETE /document/:id
+
+The server fetches the current revision then deletes the document:
+
+#+begin_src sh
+curl --fail --request DELETE \
+  http://127.0.0.1:5000/document/note-1 | jq
+#+end_src
+
+Deletion does not emit a RabbitMQ deletion event.
+
+*** POST /new/target/:actor
+
+Sets =dtype= to =target=, sets =actor= from the URL, and publishes to target
+ingest.
+
+#+begin_src sh
+curl --fail \
+  --header 'Content-Type: application/json' \
+  --request POST \
+  --data '{
+    "dataset": "demo",
+    "target": "example.org",
+    "delay": 3600,
+    "recurring": true,
+    "options": []
+  }' \
+  http://127.0.0.1:5000/new/target/domain-enricher
+#+end_src
+
+*** GET /targets/:actor
+
+Returns persisted targets from the =targets/by_actor= CouchDB view:
+
+#+begin_src sh
+curl --fail \
+  http://127.0.0.1:5000/targets/domain-enricher | jq
+#+end_src
+
+** Full-text search
+
+*** GET /search
+
+Parameters:
+
+| Parameter | Required | Default | Meaning |
+|-----------+----------+---------+---------|
+| =q= | yes in practice | none | Clouseau/Lucene query string |
+| =limit= | no | 25 | Maximum rows |
+| =bookmark= | no | none | CouchDB FTS bookmark |
+| =sort= | no | none | Sort expression accepted by CouchDB FTS |
+
+The handler always sets =include_docs=true=.
+
+#+begin_src sh
+curl --fail --get \
+  --data-urlencode 'q=content:"hello"' \
+  --data-urlencode 'limit=10' \
+  http://127.0.0.1:5000/search | jq
+#+end_src
+
+Search requires the =_design/search= FTS design document and Clouseau.
+
+** Common view query parameters
+
+Many view routes accept:
+
+| Parameter | Default | Meaning |
+|-----------+---------+---------|
+| =limit= | 50 | Row limit |
+| =start_key= | none | JSON-encoded CouchDB start key |
+| =end_key= | none | JSON-encoded CouchDB end key |
+| =descending= | false | Reverse result order |
+| =skip= | 0 | Skip rows |
+| =reduce= | route-specific | Request reduce/group behavior |
+
+=start_key= and =end_key= are parsed as JSON. Quote string keys correctly:
+
+#+begin_src sh
+curl --get \
+  --data-urlencode 'user=alice' \
+  --data-urlencode 'start_key="alice"' \
+  --data-urlencode 'limit=20' \
+  http://127.0.0.1:5000/documents/messages/by-user
+#+end_src
+
+** Message and social-post views
+
+| Method | Route | Key parameters |
+|--------+-------+----------------|
+| GET | =/documents/messages/by-user= | =user= |
+| GET | =/documents/messages/by-channel= | =group=, =channel=, optional =reduce= |
+| GET | =/documents/messages/by-groups= | legacy/duplicate channel-style query |
+| GET | =/documents/messages/by-platform= | =platform= |
+| GET | =/documents/messages/groups= | pagination parameters |
+| GET | =/documents/socialmpost/by-user= | =user= |
+
+The spelling =socialmpost= is the implemented route.
+
+** Dataset view
+
+*** GET /dataset-size
+
+The source declares this route twice. The later declaration exposes general
+view pagination/reduce parameters and can shadow the earlier simple
+=dataset=<name>= variant.
+
+Treat the current route as unstable until the duplicate definition is removed.
+
+** Host views
+
+| Route | Key |
+|-------+-----|
+| =/documents/hosts/by-ip= | =ip= |
+| =/documents/hosts/by-port= | =port= integer |
+| =/documents/hosts/by-service= | =service= |
+
+** Email views
+
+| Route | Key |
+|-------+-----|
+| =/documents/emails/by-email= | =email= |
+| =/documents/emails/by-domain= | =domain= |
+| =/documents/emails/with-password= | no key |
+
+** Domain views
+
+| Route | Key |
+|-------+-----|
+| =/documents/domains/by-record= | =record= |
+| =/documents/domains/by-resolved-address= | =ip= |
+
+** User views
+
+| Route | Key |
+|-------+-----|
+| =/documents/users/by-name= | =name= |
+| =/documents/users/by-platform= | =platform= |
+
+** Network views
+
+| Route | Key |
+|-------+-----|
+| =/documents/networks/by-asn= | =asn= integer |
+| =/documents/networks/by-org= | =org= |
+
+** URL views
+
+| Route | Key |
+|-------+-----|
+| =/documents/urls/by-url= | =url= |
+| =/documents/urls/by-domain= | =domain= |
+
+** Breach views
+
+| Route | Key |
+|-------+-----|
+| =/documents/breaches/by-size= | no explicit key; sort/paginate by size |
+
+** Stub endpoint
+
+=/new/event/:id= exists in the route source but has no implementation. Do not
+use it. Send events through =log-actor-event= locally or the =events= exchange.
+
+** HTTP operational notes
+
+- CORS is wildcard.
+- Request bodies are loaded in memory.
+- Bulk requests are sequentially published inside one HTTP request.
+- The producer is serialized through one pinned agent.
+- Default publish timeout is five seconds.
+- Hunchentoot request timeout is 300 seconds.
+- No OpenAPI document is generated.
+- No endpoint currently validates the strict StarIntel 0.9 schema.

--- a/docs/index.org
+++ b/docs/index.org
@@ -1,0 +1,44 @@
+#+title: StarIntel Server documentation
+#+options: toc:2
+
+* Documentation index
+
+This directory documents the implemented StarIntel Server runtime. It is written
+from the code in =source/starintel-gserver.asd=, not from an aspirational
+architecture.
+
+** Start here
+
+1. [[file:../README.org][README]] — install, run, submit a document, and find the main entry points.
+2. [[file:architecture.org][Architecture]] — understand startup, components, concurrency, and the repository.
+3. [[file:document-spec.org][Document specification]] — understand the data that moves through the system.
+4. [[file:actors.org][Actors]] — build local actors and connect external actor services.
+5. [[file:messaging.org][Messaging]] — understand routing, delivery, recursion, and loop control.
+6. [[file:configuration.org][Configuration]] — configure local, container, remote, and tuned deployments.
+7. [[file:http-api-docs.org][HTTP API]] — call the service.
+8. [[file:../DOCKER.md][Docker/Nix stack]] and [[file:testing.md][testing]] — operate and verify it.
+
+** Implementation status
+
+| Area | Status | Notes |
+|------+--------+-------|
+| CouchDB database initialization | Active | Creates main and actor-event databases; upserts design documents |
+| RabbitMQ document ingest | Active | =documents.ingest.#= |
+| RabbitMQ update ingest | Active | =documents.updated.#=; partial deep merge and conflict retry |
+| Target routing | Active | Local Sento actor or =actors.<name>.new.target= |
+| Actor event storage | Active | Local receiver and separate =events= exchange consumer |
+| HTTP API | Active | No authentication; CORS allows every origin |
+| Clouseau full-text search | Active in Compose | Search endpoint uses CouchDB FTS design document |
+| URL extractor pattern | Experimental | Actor starts; complete global pattern dispatcher is not evident |
+| User-finder/user-hunt actors | Present, inactive | Files are not in the ASDF component list |
+| HTTP event endpoint | Stub | =/new/event/:id= has no implementation |
+| Strict StarIntel 0.9 ingest validation | Not wired | Validators exist in =star-cl=, but HTTP/Rabbit ingest accepts raw JSON |
+
+** Source-of-truth rule
+
+When documentation and code disagree, the current code wins. Correct the docs in
+the same pull request as behavior changes.
+
+The document model itself lives in [[https://github.com/lost-rob0t/star-cl][lost-rob0t/star-cl]]. The Python adapter lives
+in [[https://github.com/lost-rob0t/starintel-doc][lost-rob0t/starintel-doc]]. This server transports and stores those documents,
+but it currently also carries legacy flat 0.8 behavior.

--- a/docs/messaging.org
+++ b/docs/messaging.org
@@ -1,0 +1,258 @@
+#+title: StarIntel messaging and recursive dataflow
+#+options: toc:3
+
+* Messaging
+
+RabbitMQ carries distributed document traffic. Sento mailboxes carry local actor
+traffic. They are separate layers and have different guarantees.
+
+** Documents exchange
+
+The main exchange is a durable RabbitMQ topic exchange named =documents=.
+
+| Flow | Queue | Binding / emitted key | Meaning |
+|------+-------+-----------------------+---------|
+| Initial ingest | =documents.ingest= | bind =documents.ingest.#= | Persist a new document |
+| Initial ingest by type | — | emit =documents.ingest.<dtype>= | Standard producer key |
+| Post-insert event | actor-specific | emit =documents.new.<dtype>= | Document now has CouchDB =_id= and =_rev= |
+| Update ingest | =documents.updates.ingest= | bind =documents.updated.#= | Persist a partial/full update |
+| Update event | same topic family | emit =documents.updated.<dtype>= | Updated document with latest =_rev= |
+| Target intake | =documents.targets= | bind =documents.new.target.#= | Route a persisted target |
+| Remote actor target | actor-defined | emit =actors.<actor>.new.target= | Deliver target to an external actor |
+
+The target wildcard currently equals =documents.new.target.#=. A normal target
+is published to =documents.ingest.target=, persisted, republished as
+=documents.new.target=, then consumed by the target router.
+
+** Events exchange
+
+Actor events can also enter through a separate exchange and queue:
+
+| Exchange | Queue | Binding |
+|----------+-------+---------|
+| =events= | =events= | =event.#= |
+
+The consumer converts the event JSON to an =actor-event= and tells the local
+actor-event receiver, which writes it to the event database.
+
+Local actors normally call =log-actor-event= directly and skip RabbitMQ.
+
+** Local actor messages
+
+*** Tell
+
+Use =sento.actor:tell= for one-way local messages:
+
+#+begin_src lisp
+(tell actor-ref message)
+#+end_src
+
+Actor lookup by operator name:
+
+#+begin_src lisp
+(let ((actor (star.actors:get-dest-actor "domain-enricher")))
+  (when actor
+    (tell actor document)))
+#+end_src
+
+*** Internal database actors
+
+The server has local actors for CouchDB insert and get operations. Their message
+formats are implementation-specific lists/plists. They are useful inside the
+server but are not a stable network protocol.
+
+*** Timers
+
+Recurring target work uses =timer-wheel=. The target's =delay= is the interval
+in seconds. A recurring target is scheduled on first delivery and later
+deliveries are sent directly without scheduling another timer.
+
+** Delivery and acknowledgement
+
+The system provides *at-least-once processing*, not exactly-once processing.
+
+- A successful handler ACKs.
+- Most errors NACK and requeue.
+- A process crash can occur after an external side effect but before ACK.
+- Multiple consumers or retries can observe the same document.
+- Initial insert conflicts are treated as a duplicate/conflict and are not
+  requeued.
+- Update handlers refetch the current CouchDB revision and retry conflicts.
+
+Every actor must therefore be idempotent.
+
+Recommended rules:
+
+1. Use deterministic IDs for deterministic findings.
+2. Treat CouchDB conflict as a duplicate unless the payload is materially
+   different.
+3. Put external side effects behind a durable outbox or their own idempotency
+   key.
+4. Never rely on message ordering across queues.
+5. Do not use Rabbit delivery count as recursion depth.
+
+** Durable versus event-only actor output
+
+*** Durable output
+
+Publish derived documents to =documents.ingest.<dtype>= when they must be
+stored:
+
+#+begin_src lisp
+(star.actors:publish
+ star.actors:*producer-agent*
+ :body (jsown:to-json derived)
+ :routing-key (format nil "documents.ingest.~a"
+                      (jsown:val derived "dtype"))
+ :properties (list (cons :type (jsown:val derived "dtype"))))
+#+end_src
+
+This path assigns =_id= when absent, writes CouchDB, attaches =_rev=, and emits
+=documents.new.<dtype>=.
+
+*** Event-only output
+
+Publish to =documents.new.<dtype>= only when the document is already durable or
+when an actor deliberately wants an event that bypasses the ingest consumer.
+
+Several experimental actors currently publish directly to =documents.new.*=.
+That does *not* persist a new document by itself.
+
+** Recursive nature of actors
+
+StarIntel recursion is a graph/dataflow property:
+
+#+begin_example
+person
+  -> username candidate actor
+     -> user documents
+        -> account verifier actor
+           -> verified user documents
+           -> relation documents
+              -> graph/query actors
+                 -> more targets
+#+end_example
+
+Each output can become another input. An actor may:
+
+- derive zero, one, or many documents;
+- attach relations between source and derived documents;
+- create a target for itself or another actor;
+- update the source document;
+- emit an actor event;
+- schedule the target again.
+
+The recursion may be local, distributed, delayed, and branching. There is no
+global recursion controller in the current server.
+
+** Loop prevention
+
+A recursive actor network can become an accidental message amplifier. Every
+actor chain should enforce a termination policy.
+
+*** Deterministic identity
+
+Use a stable ID from the source identity, actor identity, and derivation type.
+The legacy =star-cl= constructors already hash many object types. For custom
+documents:
+
+#+begin_example
+derived-id = hash(root-id, source-id, actor-name, operation, normalized-value)
+#+end_example
+
+*** Depth and hop budget
+
+The server does not add a hop counter automatically. Actors should carry a
+shared extension object:
+
+#+begin_src json
+{
+  "extensions": {
+    "star_server": {
+      "trace_id": "01J...",
+      "root_id": "root-document-id",
+      "parent_id": "source-document-id",
+      "actor_path": ["seed", "domain-enricher", "dns-resolver"],
+      "depth": 2,
+      "hop": 3,
+      "max_depth": 8,
+      "max_hops": 32
+    }
+  }
+}
+#+end_src
+
+Reject, dead-letter, or emit a terminal event when a budget is exceeded.
+
+*** Actor-path cycle check
+
+Do not invoke an actor again when its name is already present in =actor_path=
+unless the actor explicitly supports fixed-point iteration.
+
+*** Fixed-point actors
+
+An actor that refines a document repeatedly should stop when its normalized
+output hash equals the previous output hash. Store the hash in actor metadata.
+
+*** Recurring targets
+
+Recurring targets are intentional cycles. Set a positive delay, use a stable
+target ID, and make each run idempotent. A delay of zero on a recurring target
+is an operational hazard.
+
+** Recursive metadata propagation
+
+The server itself currently:
+
+- preserves fields present in a document;
+- deep-merges nested objects during updates;
+- adds CouchDB =_id= and =_rev=;
+- does not automatically append actor provenance, sources, depth, or trace data.
+
+Actor code owns recursive metadata propagation.
+
+A derived document should:
+
+1. preserve the original =dataset= unless crossing datasets intentionally;
+2. carry forward =sources= and append the actor/tool source;
+3. set =parent_id= to the input document;
+4. preserve =root_id= and =trace_id=;
+5. increment =depth= and =hop=;
+6. append the actor name to =actor_path=;
+7. create a =relation= using =derived-from=, =extracted-from=,
+   =discovered-by=, or another allowed predicate;
+8. call =log-actor-event= for important lifecycle events.
+
+** Transient messages
+
+A JSON document with =transient: true= is filtered out by the standard ingest
+and update consumers. It can still be routed to actor-specific queues.
+
+Use transient messages for high-volume intermediate work that should not enter
+CouchDB. Do not use them for evidence that must be reproducible.
+
+** External actor contract
+
+An external actor service normally:
+
+1. declares a durable queue;
+2. binds it to =documents= with one or more topic keys;
+3. parses one StarIntel JSON document per message;
+4. performs idempotent work;
+5. publishes durable outputs to =documents.ingest.<dtype>=;
+6. publishes partial updates to =documents.updated.<dtype>=;
+7. publishes actor events to =events= / =event.<actor>= when needed;
+8. ACKs only after required side effects complete.
+
+Suggested queue naming:
+
+#+begin_example
+actors.<actor-name>.targets
+actors.<actor-name>.documents.<dtype>
+#+end_example
+
+Suggested target binding:
+
+#+begin_example
+actors.<actor-name>.new.target
+#+end_example

--- a/example_configs/init.lisp
+++ b/example_configs/init.lisp
@@ -1,14 +1,63 @@
-;; Example config
+;;;; StarIntel Server init file
+;;;;
+;;;; This file is executable Common Lisp. Load it only from a trusted,
+;;;; root/operator-controlled path.
+
 (in-package :star)
-(format t "Starting starintel....")
-(setq *rabbit-address* "rabbitmq")
-(setq *couchdb-host* "bots.star.intel")
-(setq *couchdb-default-database* "starintel")
-;; You can invoke sylnk like so
-;; (start-debugger)
-;; Set log config path to logs
-(log:config :daily "logs/gserver.log"
+
+(format t "~&Starting StarIntel Server configuration...~%")
+
+;;; CouchDB -----------------------------------------------------------------
+
+(setf *couchdb-host* (or (uiop:getenv "COUCHDB_HOST") "127.0.0.1")
+      *couchdb-port* 5984
+      *couchdb-scheme* "http"
+      *couchdb-user* (or (uiop:getenv "COUCHDB_USER") "admin")
+      *couchdb-password* (or (uiop:getenv "COUCHDB_PASSWORD") "")
+      *couchdb-default-database*
+      (or (uiop:getenv "COUCHDB_DATABASE") "starintel")
+      *couchdb-event-log-database* "starintel-event-source")
+
+;;; RabbitMQ ---------------------------------------------------------------
+
+(setf *rabbit-address* (or (uiop:getenv "RABBITMQ_ADDRESS") "127.0.0.1")
+      *rabbit-port* 5672
+      *rabbit-user* (or (uiop:getenv "RABBITMQ_USER") "guest")
+      *rabbit-password* (or (uiop:getenv "RABBITMQ_PASSWORD") ""))
+
+;;; HTTP -------------------------------------------------------------------
+
+(setf *http-api-address*
+      (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") "127.0.0.1")
+      *http-api-port* 5000
+      *bulk-max-documents* 500)
+
+;;; Concurrency ------------------------------------------------------------
+
+(setf *ingest-workers* 4
+      star.actors:*publish-timeout-seconds* 5)
+
+;;; Logging ----------------------------------------------------------------
+
+(ensure-directories-exist #P"logs/")
+(log:config :daily "logs/star-server.log"
             :file2
             :sane)
 
-;;
+;;; Optional local actors --------------------------------------------------
+;;;
+;;; Actor definition files loaded here can add startup/registration functions
+;;; to STAR:*ACTORS-START-HOOK*. The hook runs after the Sento actor system,
+;;; producer agent, database actors, target timer, and target router exist.
+;;;
+;;; Example:
+;;; (load #P"/etc/starintel/actors/domain-enricher.lisp")
+
+;;; Optional SLYNK debugger ------------------------------------------------
+;;;
+;;; SLYNK is remote code execution. Use loopback/SSH forwarding only.
+;;;
+;;; (setf *slynk-port* 4009)
+;;; (start-debugger)
+
+(format t "~&StarIntel configuration loaded.~%")


### PR DESCRIPTION
## Summary

- replace the minimal README with a complete operator/developer entry point
- document the real startup sequence, concurrency model, persistence, views, repository structure, and security boundaries
- document local Sento actors and external RabbitMQ actor services
- document actor registration, targets, timers, events, durable output, retries, and testing
- document RabbitMQ exchanges, queues, routing keys, ACK/NACK behavior, and at-least-once delivery
- document recursive actor dataflow, fan-out, loop prevention, fixed-point termination, and recursive metadata propagation
- document StarIntel 0.9 validation behavior alongside the legacy flat 0.8 classes still used by the server
- inventory legacy document fields, ID strategies, relation predicates, target documents, and actor-event documents
- replace the stale HTTP API reference with the implemented routes and known quirks
- add advanced configuration examples for local development, Compose, remote services, throughput tuning, low-memory operation, custom views, SLYNK, and reverse proxies
- replace the minimal init example with a complete environment-aware template

## Important implementation facts captured

- strict StarIntel 0.9 validation exists in `star-cl` but is not wired into HTTP/Rabbit ingestion
- `documents.ingest.*` persists output; direct `documents.new.*` publication is event-only
- actor recursion is distributed dataflow, not call-stack recursion
- the server does not automatically add provenance/depth/trace metadata; actor code must propagate it
- user-finder/user-hunt source files are currently not loaded by ASDF
- the matcher/pattern system is experimental
- the HTTP API has no auth and wildcard CORS
- several existing routes/config variables are duplicated, stubbed, or currently unused

## Files

- `README.org`
- `docs/index.org`
- `docs/architecture.org`
- `docs/actors.org`
- `docs/messaging.org`
- `docs/document-spec.org`
- `docs/configuration.org`
- `docs/http-api-docs.org`
- `example_configs/init.lisp`

## Validation

- audited against the current `master` source and `star-cl` / `starintel-doc` adapters
- branch contains documentation and init-template changes only
- automated tests were not run locally; PR CI should validate repository integrity
