### PR TITLE
Lock server to canonical research-node schema

### DIFF
--- a/.github/workflows/starintel-schema-lock.yml
+++ b/.github/workflows/starintel-schema-lock.yml
@@ -1,0 +1,29 @@
+name: Canonical StarIntel schema lock
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - dev
+      - "agent/**"
+    paths:
+      - "schema/starintel-schema.lock.json"
+      - "scripts/check-starintel-schema-lock.py"
+      - ".github/workflows/starintel-schema-lock.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  research-node-schema:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Verify canonical research-node schema
+        run: python scripts/check-starintel-schema-lock.py

--- a/schema/starintel-schema.lock.json
+++ b/schema/starintel-schema.lock.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.9.0",
+  "canonical_repository": "lost-rob0t/starintel-gpt-auto-dig",
+  "canonical_commit": "ff814ff63868286d68e21502122832802cd5e361",
+  "canonical_pull_request": 46,
+  "schema_path": "schemas/starintel-doc-v0.9.0.schema.json",
+  "expansion_path": "schemas/starintel-doc-v0.9.0.expansion.json",
+  "manifest_path": "schemas/starintel-doc-v0.9.0.manifest.json",
+  "required_dtypes": [
+    "research-node"
+  ],
+  "research_node_required_fields": [
+    "objective",
+    "status"
+  ]
+}

--- a/scripts/check-starintel-schema-lock.py
+++ b/scripts/check-starintel-schema-lock.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def load_json(url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=30) as response:
+        return json.load(response)
+
+
+def canonical_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    lock_path = Path(sys.argv[1] if len(sys.argv) > 1 else "schema/starintel-schema.lock.json")
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    repository = lock["canonical_repository"]
+    commit = lock["canonical_commit"]
+    base_url = f"https://raw.githubusercontent.com/{repository}/{commit}"
+
+    schema = load_json(f"{base_url}/{lock['schema_path']}")
+    expansion = load_json(f"{base_url}/{lock['expansion_path']}")
+    manifest = load_json(f"{base_url}/{lock['manifest_path']}")
+
+    if schema.get("$id") != "https://spec.starintel.actor/schema/starintel-doc-v0.9.0.json":
+        fail("unexpected canonical schema id")
+    if manifest.get("schema_version") != lock["schema_version"]:
+        fail("manifest schema version does not match lock")
+    if expansion.get("schema_version") != lock["schema_version"]:
+        fail("expansion schema version does not match lock")
+
+    branches = schema.get("allOf", [])
+    research_branch = next(
+        (
+            branch
+            for branch in branches
+            if branch.get("if", {}).get("properties", {}).get("dtype", {}).get("const")
+            == "research-node"
+        ),
+        None,
+    )
+    if research_branch is None:
+        fail("canonical schema is missing dtype research-node")
+
+    data_schema = research_branch.get("then", {}).get("properties", {}).get("data", {})
+    if data_schema.get("additionalProperties") is not False:
+        fail("research-node data must reject undeclared fields")
+
+    required = set(data_schema.get("required", []))
+    expected_required = set(lock["research_node_required_fields"])
+    missing_required = sorted(expected_required - required)
+    if missing_required:
+        fail(f"research-node is missing required fields: {missing_required}")
+
+    expansion_fields = set(expansion.get("dtype_fields", {}).get("research-node", []))
+    missing_expansion_fields = sorted(expected_required - expansion_fields)
+    if missing_expansion_fields:
+        fail(f"research-node expansion is missing fields: {missing_expansion_fields}")
+
+    if manifest.get("dtype_count") != len(expansion.get("dtype_fields", {})):
+        fail("schema manifest dtype count does not match expansion")
+    if manifest.get("expansion_content_hash") != canonical_hash(expansion):
+        fail("schema manifest expansion hash does not match canonical expansion")
+
+    print(
+        "verified StarIntel",
+        lock["schema_version"],
+        "research-node schema at",
+        commit,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds an explicit StarIntel schema lock pointing at merged Auto Dig PR #46 / commit `ff814ff63868286d68e21502122832802cd5e361`
- records the canonical schema, expansion, and manifest paths
- verifies that `research-node` exists in the canonical v0.9 schema
- verifies strict `data` fields, required `objective` and `status`, expansion coverage, dtype count, and expansion hash
- runs the lock check in pull requests, agent branches, `dev`, and `master`

## Why

The server must not silently validate or document a different StarIntel contract than the Python, JavaScript, Common Lisp, Nim, browser, and Auto Dig repositories.

## Scope

This is a schema persistence and drift gate only. It does not revive the stale server-wide v0.9 migration PR #54 or mix unrelated ingestion/runtime changes into this PR.

## Validation

GitHub Actions runs `python scripts/check-starintel-schema-lock.py` against the exact canonical merge commit.