### PR TITLE
Fix CouchDB actor request, reply, and delete semantics

### DIFF
--- a/source/actors/couchdb-service.lisp
+++ b/source/actors/couchdb-service.lisp
@@ -1,0 +1,349 @@
+(in-package :star.actors)
+
+(defparameter +couchdb-storage-dispatcher+ :pinned
+  "Dispatcher used for blocking CouchDB actor work.")
+
+(defstruct (couchdb-get-request
+            (:constructor make-couchdb-get-request
+                (&key
+                   (database star:*couchdb-default-database*)
+                   document-id
+                   revision)))
+  database
+  document-id
+  revision)
+
+(defstruct (couchdb-insert-request
+            (:constructor make-couchdb-insert-request
+                (&key
+                   (database star:*couchdb-default-database*)
+                   document-id
+                   document)))
+  database
+  document-id
+  document)
+
+(defstruct (couchdb-delete-request
+            (:constructor make-couchdb-delete-request
+                (&key
+                   (database star:*couchdb-default-database*)
+                   document-id
+                   revision)))
+  database
+  document-id
+  revision)
+
+(defstruct (couchdb-result
+            (:constructor make-couchdb-result
+                (&key status operation database document-id revision value
+                      error-type error-message)))
+  status
+  operation
+  database
+  document-id
+  revision
+  value
+  error-type
+  error-message)
+
+(defun make-couchdb-agent (context pool
+                           &key error-fun
+                             (dispatcher-id +couchdb-storage-dispatcher+))
+  "Wrap the injected CouchDB POOL in an agent on the storage dispatcher."
+  (declare (ignore error-fun))
+  (unless pool
+    (error "MAKE-COUCHDB-AGENT requires an injected CouchDB pool."))
+  (make-agent (lambda () pool) context dispatcher-id))
+
+(defun start-couchdb-agent (system
+                            &optional
+                              (pool star.databases.couchdb:*couchdb-pool*))
+  "Start the CouchDB pool agent without creating an unused standalone client."
+  (setf *couchdb-agent* (make-couchdb-agent system pool)))
+
+(defun couchdb-agent-get (agent database document-id &optional revision)
+  (anypool:with-connection (client (couchdb-agent-client agent))
+    (if revision
+        (cl-couch:get-document client database document-id revision)
+        (cl-couch:get-document client database document-id))))
+
+(defun parse-couchdb-document (document)
+  (etypecase document
+    (string (jsown:parse document))
+    (list document)))
+
+(defun delete-couchdb-document (client database document-id
+                                 &optional revision
+                                 &key
+                                   (get-fn #'cl-couch:get-document)
+                                   (delete-fn #'cl-couch:delete-document))
+  "Delete DOCUMENT-ID using REVISION, fetching the current revision when absent."
+  (let* ((resolved-revision
+           (or revision
+               (let* ((document (funcall get-fn client database document-id))
+                      (parsed (parse-couchdb-document document)))
+                 (jsown:val-safe parsed "_rev")))))
+    (unless resolved-revision
+      (error "CouchDB document ~a/~a has no revision."
+             database document-id))
+    (values (funcall delete-fn
+                     client database document-id resolved-revision)
+            resolved-revision)))
+
+(defun couchdb-agent-delete (agent database document-id &optional revision)
+  (anypool:with-connection (client (couchdb-agent-client agent))
+    (delete-couchdb-document client database document-id revision)))
+
+(defun normalize-couchdb-get-request (message)
+  (typecase message
+    (couchdb-get-request message)
+    (string
+     (make-couchdb-get-request :document-id message))
+    (list
+     (make-couchdb-get-request
+      :database (or (getf message :database)
+                    star:*couchdb-default-database*)
+      :document-id (or (getf message :document-id)
+                       (getf message :id))
+      :revision (or (getf message :revision)
+                    (getf message :rev))))
+    (t
+     (error "Unsupported CouchDB GET request: ~s" message))))
+
+(defun normalize-couchdb-insert-request (message)
+  (typecase message
+    (couchdb-insert-request message)
+    (list
+     (make-couchdb-insert-request
+      :database (or (getf message :database)
+                    star:*couchdb-default-database*)
+      :document-id (or (getf message :document-id)
+                       (getf message :id))
+      :document (getf message :document)))
+    (t
+     (error "Unsupported CouchDB INSERT request: ~s" message))))
+
+(defun normalize-couchdb-delete-request (message)
+  (typecase message
+    (couchdb-delete-request message)
+    (list
+     (make-couchdb-delete-request
+      :database (or (getf message :database)
+                    star:*couchdb-default-database*)
+      :document-id (or (getf message :document-id)
+                       (getf message :id))
+      :revision (or (getf message :revision)
+                    (getf message :rev))))
+    (t
+     (error "Unsupported CouchDB DELETE request: ~s" message))))
+
+(defun ensure-couchdb-request-id (operation document-id)
+  (unless (and (stringp document-id) (plusp (length document-id)))
+    (error "CouchDB ~a request requires a non-empty document id."
+           operation)))
+
+(defun couchdb-error-result (operation database document-id condition)
+  (make-couchdb-result
+   :status :error
+   :operation operation
+   :database database
+   :document-id document-id
+   :error-type (string-downcase (princ-to-string (type-of condition)))
+   :error-message (princ-to-string condition)))
+
+(defun complete-couchdb-request (result)
+  "Return RESULT for ASK-S and explicitly reply only to a real async sender."
+  (when *sender*
+    (reply result *sender*))
+  result)
+
+(defun make-couchdb-get-handler (agent &key (get-fn #'couchdb-agent-get))
+  (lambda (message)
+    (let ((request nil))
+      (complete-couchdb-request
+       (handler-case
+           (progn
+             (setf request (normalize-couchdb-get-request message))
+             (ensure-couchdb-request-id
+              :get
+              (couchdb-get-request-document-id request))
+             (make-couchdb-result
+              :status :success
+              :operation :get
+              :database (couchdb-get-request-database request)
+              :document-id (couchdb-get-request-document-id request)
+              :revision (couchdb-get-request-revision request)
+              :value (funcall get-fn
+                              agent
+                              (couchdb-get-request-database request)
+                              (couchdb-get-request-document-id request)
+                              (couchdb-get-request-revision request))))
+         (dexador:http-request-not-found ()
+           (make-couchdb-result
+            :status :not-found
+            :operation :get
+            :database (and request (couchdb-get-request-database request))
+            :document-id (and request
+                              (couchdb-get-request-document-id request))))
+         (error (condition)
+           (couchdb-error-result
+            :get
+            (and request (couchdb-get-request-database request))
+            (and request (couchdb-get-request-document-id request))
+            condition)))))))
+
+(defun make-couchdb-insert-handler
+    (agent
+     &key
+       (exists-fn #'couchdb-document-exists-p)
+       (insert-fn #'couchdb-agent-insert))
+  (lambda (message)
+    (let ((request nil))
+      (complete-couchdb-request
+       (handler-case
+           (progn
+             (setf request (normalize-couchdb-insert-request message))
+             (ensure-couchdb-request-id
+              :insert
+              (couchdb-insert-request-document-id request))
+             (unless (couchdb-insert-request-document request)
+               (error "CouchDB INSERT request requires a document."))
+             (if (funcall exists-fn
+                          agent
+                          (couchdb-insert-request-database request)
+                          (couchdb-insert-request-document-id request))
+                 (make-couchdb-result
+                  :status :exists
+                  :operation :insert
+                  :database (couchdb-insert-request-database request)
+                  :document-id (couchdb-insert-request-document-id request))
+                 (make-couchdb-result
+                  :status :success
+                  :operation :insert
+                  :database (couchdb-insert-request-database request)
+                  :document-id (couchdb-insert-request-document-id request)
+                  :value (funcall insert-fn
+                                  agent
+                                  (couchdb-insert-request-database request)
+                                  (couchdb-insert-request-document request)))))
+         (dexador:http-request-conflict ()
+           (make-couchdb-result
+            :status :conflict
+            :operation :insert
+            :database (and request (couchdb-insert-request-database request))
+            :document-id (and request
+                              (couchdb-insert-request-document-id request))))
+         (error (condition)
+           (couchdb-error-result
+            :insert
+            (and request (couchdb-insert-request-database request))
+            (and request (couchdb-insert-request-document-id request))
+            condition)))))))
+
+(defun make-couchdb-delete-handler (agent &key (delete-fn #'couchdb-agent-delete))
+  (lambda (message)
+    (let ((request nil))
+      (complete-couchdb-request
+       (handler-case
+           (progn
+             (setf request (normalize-couchdb-delete-request message))
+             (ensure-couchdb-request-id
+              :delete
+              (couchdb-delete-request-document-id request))
+             (multiple-value-bind (value revision)
+                 (funcall delete-fn
+                          agent
+                          (couchdb-delete-request-database request)
+                          (couchdb-delete-request-document-id request)
+                          (couchdb-delete-request-revision request))
+               (make-couchdb-result
+                :status :success
+                :operation :delete
+                :database (couchdb-delete-request-database request)
+                :document-id (couchdb-delete-request-document-id request)
+                :revision revision
+                :value value)))
+         (dexador:http-request-not-found ()
+           (make-couchdb-result
+            :status :not-found
+            :operation :delete
+            :database (and request (couchdb-delete-request-database request))
+            :document-id (and request
+                              (couchdb-delete-request-document-id request))))
+         (dexador:http-request-conflict ()
+           (make-couchdb-result
+            :status :conflict
+            :operation :delete
+            :database (and request (couchdb-delete-request-database request))
+            :document-id (and request
+                              (couchdb-delete-request-document-id request))
+            :revision (and request
+                           (couchdb-delete-request-revision request))))
+         (error (condition)
+           (couchdb-error-result
+            :delete
+            (and request (couchdb-delete-request-database request))
+            (and request (couchdb-delete-request-document-id request))
+            condition)))))))
+
+(defun start-couchdb-gets (system)
+  (setf *couchdb-gets*
+        (actor-of system
+                  :name "*couchdb-gets*"
+                  :dispatcher +couchdb-storage-dispatcher+
+                  :receive (make-couchdb-get-handler *couchdb-agent*))))
+
+(defun start-couchdb-inserts (system)
+  (setf *couchdb-inserts*
+        (actor-of system
+                  :name "*couchdb-inserts*"
+                  :dispatcher +couchdb-storage-dispatcher+
+                  :receive (make-couchdb-insert-handler *couchdb-agent*))))
+
+(defvar *couchdb-deletes* nil
+  "Actor responsible for deterministic CouchDB delete requests.")
+
+(defun start-couchdb-deletes (system)
+  (setf *couchdb-deletes*
+        (actor-of system
+                  :name "*couchdb-deletes*"
+                  :dispatcher +couchdb-storage-dispatcher+
+                  :receive (make-couchdb-delete-handler *couchdb-agent*))))
+
+(defun start-couchdb-delete-actor-hook ()
+  (start-couchdb-deletes *sys*))
+
+(nhooks:add-hook star:*actors-start-hook* #'start-couchdb-delete-actor-hook)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (export '(couchdb-get-request
+            make-couchdb-get-request
+            couchdb-get-request-database
+            couchdb-get-request-document-id
+            couchdb-get-request-revision
+            couchdb-insert-request
+            make-couchdb-insert-request
+            couchdb-insert-request-database
+            couchdb-insert-request-document-id
+            couchdb-insert-request-document
+            couchdb-delete-request
+            make-couchdb-delete-request
+            couchdb-delete-request-database
+            couchdb-delete-request-document-id
+            couchdb-delete-request-revision
+            couchdb-result
+            couchdb-result-status
+            couchdb-result-operation
+            couchdb-result-database
+            couchdb-result-document-id
+            couchdb-result-revision
+            couchdb-result-value
+            couchdb-result-error-type
+            couchdb-result-error-message
+            make-couchdb-get-handler
+            make-couchdb-insert-handler
+            make-couchdb-delete-handler
+            delete-couchdb-document
+            *couchdb-deletes*
+            start-couchdb-deletes)
+          :star.actors))

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -18,6 +18,7 @@
                  (:file "databases/couchdb")
                  (:file "init-loader")
                  (:file "actors")
+                 (:file "actors/couchdb-service")
                  (:file "actor-systems/event-actor")
                  (:file "actor-systems/matcher-actor")
                  (:file "rabbit")
@@ -59,7 +60,6 @@
 ;;;; star-gserver. Gserver started in a org-mode notebook while i scketched things out.
 ;;;;
 ;;;;
-
 
 
 

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -5,27 +5,28 @@
   :license      "GPL v3"
   :serial t
   :depends-on   (#:starintel-gserver
-                 #:starintel-gserver-client
-                 #:star-cli
-                 #:star-ui
-                 #:star-migrations
-                 #:fiveam
-                 #:dexador
-                 #:bordeaux-threads
-                 #:jsown)
+                  #:starintel-gserver-client
+                  #:star-cli
+                  #:star-ui
+                  #:star-migrations
+                  #:fiveam
+                  #:dexador
+                  #:bordeaux-threads
+                  #:jsown)
   :components   ((:module "t"
-                  :serial t
-                  :components ((:file "package")
-                               (:file "test-runner")
-                               (:file "test-runner-test")
-                               (:file "consumers-test")
-                               (:file "init-loader-test")
-                               (:file "target-routing-test")
-                               (:file "system-load-test")
-                               (:file "run-tests"))))
+                   :serial t
+                   :components ((:file "package")
+                                (:file "test-runner")
+                                (:file "test-runner-test")
+                                (:file "consumers-test")
+                                (:file "init-loader-test")
+                                (:file "target-routing-test")
+                                (:file "system-load-test")
+                                (:file "couchdb-actor-test")
+                                (:file "run-tests"))))
   :perform (test-op (o c)
-                    (declare (ignore o c))
-                    (uiop:symbol-call :star-server-tests :run-all-gserver-tests)))
+                     (declare (ignore o c))
+                     (uiop:symbol-call :star-server-tests :run-all-gserver-tests)))
 
 ;;;; Canonical unit entry point:
 ;;;;   (asdf:test-system :starintel-gserver-tests)

--- a/t/couchdb-actor-test.lisp
+++ b/t/couchdb-actor-test.lisp
@@ -1,0 +1,236 @@
+(in-package :star-server-tests)
+
+(def-suite couchdb-actor-tests
+  :description "Hermetic CouchDB actor request, reply, and delete tests")
+
+(in-suite couchdb-actor-tests)
+
+(defun make-couchdb-test-system ()
+  (make-actor-system '(:dispatchers
+                       (:storage (:workers 2 :strategy :random))
+                       :timeout-timer
+                       (:resolution 50 :max-size 100))))
+
+(defun wait-for-future-result (future &key (attempts 200) (delay 0.01))
+  (loop repeat attempts
+        when (sento.future:complete-p future)
+          return (sento.future:fresult future)
+        do (sleep delay)
+        finally (return :not-ready)))
+
+(test couchdb-get-ask-s-with-and-without-revision
+  (let ((system (make-couchdb-test-system))
+        (calls nil))
+    (unwind-protect
+         (let* ((handler
+                  (star.actors:make-couchdb-get-handler
+                   nil
+                   :get-fn
+                   (lambda (agent database document-id revision)
+                     (declare (ignore agent))
+                     (push (list database document-id revision) calls)
+                     (format nil "~a/~a@~a"
+                             database document-id (or revision "current")))))
+                (actor
+                  (actor-of system
+                            :name "couchdb-get-ask-s-test"
+                            :dispatcher :storage
+                            :receive handler))
+                (current
+                  (sento.actor:ask-s
+                   actor
+                   (star.actors:make-couchdb-get-request
+                    :database "intel"
+                    :document-id "doc-current")
+                   :time-out 2))
+                (historical
+                  (sento.actor:ask-s
+                   actor
+                   (star.actors:make-couchdb-get-request
+                    :database "intel"
+                    :document-id "doc-historical"
+                    :revision "3-deadbeef")
+                   :time-out 2)))
+           (is (eq :success (star.actors:couchdb-result-status current)))
+           (is (string= "intel/doc-current@current"
+                        (star.actors:couchdb-result-value current)))
+           (is (eq :success (star.actors:couchdb-result-status historical)))
+           (is (string= "intel/doc-historical@3-deadbeef"
+                        (star.actors:couchdb-result-value historical)))
+           (is (member '("intel" "doc-current" nil) calls :test #'equal))
+           (is (member '("intel" "doc-historical" "3-deadbeef")
+                       calls
+                       :test #'equal)))
+      (ac:shutdown system))))
+
+(test couchdb-get-async-asks-return-to-correct-callers
+  (let ((system (make-couchdb-test-system)))
+    (unwind-protect
+         (let* ((handler
+                  (star.actors:make-couchdb-get-handler
+                   nil
+                   :get-fn
+                   (lambda (agent database document-id revision)
+                     (declare (ignore agent database revision))
+                     document-id)))
+                (actor
+                  (actor-of system
+                            :name "couchdb-get-async-test"
+                            :dispatcher :storage
+                            :receive handler))
+                (future-a
+                  (sento.actor:ask
+                   actor
+                   (star.actors:make-couchdb-get-request
+                    :document-id "caller-a")
+                   :time-out 2))
+                (future-b
+                  (sento.actor:ask
+                   actor
+                   (star.actors:make-couchdb-get-request
+                    :document-id "caller-b")
+                   :time-out 2))
+                (result-a (wait-for-future-result future-a))
+                (result-b (wait-for-future-result future-b)))
+           (is (not (eq :not-ready result-a)))
+           (is (not (eq :not-ready result-b)))
+           (is (string= "caller-a"
+                        (star.actors:couchdb-result-value result-a)))
+           (is (string= "caller-b"
+                        (star.actors:couchdb-result-value result-b))))
+      (ac:shutdown system))))
+
+(test existing-document-insert-completes-deterministically
+  (let ((system (make-couchdb-test-system)))
+    (unwind-protect
+         (let* ((handler
+                  (star.actors:make-couchdb-insert-handler
+                   nil
+                   :exists-fn
+                   (lambda (agent database document-id)
+                     (declare (ignore agent database document-id))
+                     t)
+                   :insert-fn
+                   (lambda (&rest arguments)
+                     (declare (ignore arguments))
+                     (error "Insert must not run for an existing document."))))
+                (actor
+                  (actor-of system
+                            :name "couchdb-existing-insert-test"
+                            :dispatcher :storage
+                            :receive handler))
+                (result
+                  (sento.actor:ask-s
+                   actor
+                   (star.actors:make-couchdb-insert-request
+                    :database "intel"
+                    :document-id "already-there"
+                    :document "{\"_id\":\"already-there\"}")
+                   :time-out 2)))
+           (is (eq :exists (star.actors:couchdb-result-status result)))
+           (is (string= "already-there"
+                        (star.actors:couchdb-result-document-id result))))
+      (ac:shutdown system))))
+
+(test tell-based-insert-does-not-reply-without-sender
+  (let ((system (make-couchdb-test-system))
+        (insert-count 0)
+        (lock (bt:make-lock)))
+    (unwind-protect
+         (let* ((handler
+                  (star.actors:make-couchdb-insert-handler
+                   nil
+                   :exists-fn
+                   (lambda (agent database document-id)
+                     (declare (ignore agent database document-id))
+                     (bt:with-lock-held (lock)
+                       (plusp insert-count)))
+                   :insert-fn
+                   (lambda (agent database document)
+                     (declare (ignore agent database document))
+                     (bt:with-lock-held (lock)
+                       (incf insert-count))
+                     :inserted)))
+                (actor
+                  (actor-of system
+                            :name "couchdb-tell-insert-test"
+                            :dispatcher :storage
+                            :receive handler))
+                (request
+                  (star.actors:make-couchdb-insert-request
+                   :database "events"
+                   :document-id "event-1"
+                   :document "{\"_id\":\"event-1\"}")))
+           (tell actor request)
+           (loop repeat 100
+                 until (bt:with-lock-held (lock)
+                         (= 1 insert-count))
+                 do (sleep 0.01))
+           (is (= 1 (bt:with-lock-held (lock) insert-count)))
+           (let ((result (sento.actor:ask-s actor request :time-out 2)))
+             (is (eq :exists (star.actors:couchdb-result-status result)))
+             (is (= 1 (bt:with-lock-held (lock) insert-count)))))
+      (ac:shutdown system))))
+
+(test delete-fetches-current-revision
+  (let ((get-calls 0)
+        (delete-arguments nil))
+    (multiple-value-bind (value revision)
+        (star.actors:delete-couchdb-document
+         :fake-client
+         "intel"
+         "doc-1"
+         nil
+         :get-fn
+         (lambda (client database document-id)
+           (declare (ignore client))
+           (incf get-calls)
+           (is (string= "intel" database))
+           (is (string= "doc-1" document-id))
+           "{\"_id\":\"doc-1\",\"_rev\":\"7-current\"}")
+         :delete-fn
+         (lambda (client database document-id current-revision)
+           (declare (ignore client))
+           (setf delete-arguments
+                 (list database document-id current-revision))
+           :deleted))
+      (is (eq :deleted value))
+      (is (string= "7-current" revision))
+      (is (= 1 get-calls))
+      (is (equal '("intel" "doc-1" "7-current")
+                 delete-arguments)))))
+
+(test delete-uses-provided-revision-without-fetch
+  (let ((get-called-p nil)
+        (delete-revision nil))
+    (multiple-value-bind (value revision)
+        (star.actors:delete-couchdb-document
+         :fake-client
+         "intel"
+         "doc-2"
+         "9-explicit"
+         :get-fn
+         (lambda (&rest arguments)
+           (declare (ignore arguments))
+           (setf get-called-p t)
+           (error "Revision fetch must not run."))
+         :delete-fn
+         (lambda (client database document-id current-revision)
+           (declare (ignore client database document-id))
+           (setf delete-revision current-revision)
+           :deleted))
+      (is (eq :deleted value))
+      (is (string= "9-explicit" revision))
+      (is-false get-called-p)
+      (is (string= "9-explicit" delete-revision)))))
+
+(test couchdb-agent-uses-injected-pool
+  (let ((system (make-couchdb-test-system))
+        (sentinel-pool (list :injected-pool)))
+    (unwind-protect
+         (let ((agent (star.actors::make-couchdb-agent
+                       system sentinel-pool
+                       :dispatcher-id :storage)))
+           (is (eq sentinel-pool
+                   (sento.agent:agent-get agent #'identity))))
+      (ac:shutdown system))))

--- a/t/run-tests.lisp
+++ b/t/run-tests.lisp
@@ -5,7 +5,8 @@
     consumer-tests
     init-loader-tests
     target-routing-tests
-    system-load-tests))
+    system-load-tests
+    couchdb-actor-tests))
 
 (defun run-all-gserver-tests ()
   "Run every hermetic unit suite and fail on empty, skipped, or failed tests."


### PR DESCRIPTION
## What changed

- add typed CouchDB GET, INSERT, DELETE request structures and structured result messages
- replace the GET callback reply path with actor handlers that preserve asynchronous `ask` senders and return directly for `ask-s`
- avoid calling `reply` for ordinary fire-and-forget `tell` writes
- make existing-document inserts return `:exists` instead of leaving asks unresolved
- fetch the current CouchDB revision before delete when the caller does not supply one
- return explicit success, not-found, exists, conflict, and error statuses
- inject the existing CouchDB pool into the agent instead of creating and authenticating an ignored standalone client
- run blocking database actors on the existing isolated pinned dispatcher
- add a managed delete actor while retaining the event actor's legacy plist write message

## Root cause

The previous actors mixed callback execution with actor reply context, treated one receive argument as multiple positional arguments, replied unconditionally from tell-based writes, omitted required delete revisions, and discarded the client created during startup.

## Validation

Hermetic tests cover:

- GET with and without revisions through `ask-s`
- concurrent asynchronous asks returning to the correct futures
- deterministic existing-document inserts
- tell-based inserts that remain alive without an invalid reply
- fetched versus explicit delete revisions
- injected pool ownership

Full Common Lisp execution is delegated to repository CI.

Fixes #23