### PR TITLE
Fix actor-event schema and Rabbit delivery settlement

### DIFF
--- a/source/actor-systems/event-actor.lisp
+++ b/source/actor-systems/event-actor.lisp
@@ -1,71 +1,271 @@
-(in-package #:star.actors)
-
 (in-package :star.actors)
+
+(defparameter +event-exchange+ "events")
+(defparameter +event-queue+ "events")
+(defparameter +event-routing-key+ "event.#")
+(defparameter +event-dead-letter-exchange+ "events.dead-letter")
+(defparameter +event-dead-letter-queue+ "events.quarantine")
+(defparameter +event-dead-letter-routing-key+ "events.invalid")
+(defparameter +event-persistence-timeout-seconds+ 10)
+
+(define-condition invalid-actor-event (error)
+  ((reason
+    :initarg :reason
+    :reader invalid-actor-event-reason)
+   (payload
+    :initarg :payload
+    :reader invalid-actor-event-payload))
+  (:report
+   (lambda (condition stream)
+     (format stream
+             "Invalid actor event: ~a"
+             (invalid-actor-event-reason condition)))))
+
 (defclass actor-event ()
-  ((_id :initarg :id :accessor event-id :initform (cms-ulid:ulid))
-   (timestamp  :initarg :timestamp :accessor event-timestamp :initform (spec:unix-now))
-   (dtype  :initarg :timestamp :accessor doc-type :initform "actorevent")
-   (actor-name :initarg :actor-name :accessor event-actor-name :initform "")
-   (event-type :initarg :event-type :accessor event-type :initform "")
-   (details :initarg :details :accessor event-details :initform "")
-   (source-id :initarg :source-id :accessor event-source-document :initform "")))
+  ((_id
+    :initarg :id
+    :accessor event-id
+    :initform (cms-ulid:ulid)
+    :type string)
+   (timestamp
+    :initarg :timestamp
+    :accessor event-timestamp
+    :initform (spec:unix-now)
+    :type integer)
+   (dtype
+    :initarg :dtype
+    :accessor doc-type
+    :initform "actorevent"
+    :type string)
+   (actor-name
+    :initarg :actor-name
+    :accessor event-actor-name
+    :initform ""
+    :type string)
+   (component
+    :initarg :component
+    :accessor event-component
+    :initform ""
+    :type string)
+   (event-type
+    :initarg :event-type
+    :accessor event-type
+    :initform ""
+    :type string)
+   (details
+    :initarg :details
+    :accessor event-details
+    :initform ""
+    :type string)
+   (source-id
+    :initarg :source-id
+    :accessor event-source-document
+    :initform ""
+    :type string)
+   (trace-id
+    :initarg :trace-id
+    :accessor event-trace-id
+    :initform ""
+    :type string)
+   (generation
+    :initarg :generation
+    :accessor event-generation
+    :initform 0
+    :type integer)))
 
+(defun make-actor-event (&key actor-name component event-type details source-id
+                           trace-id (generation 0) timestamp dtype id)
+  (make-instance
+   'actor-event
+   :id (or id (cms-ulid:ulid))
+   :timestamp (or timestamp (spec:unix-now))
+   :dtype (or dtype "actorevent")
+   :actor-name (or actor-name component "")
+   :component (or component actor-name "")
+   :event-type (or event-type "")
+   :details (or details "")
+   :source-id (or source-id "")
+   :trace-id (or trace-id "")
+   :generation generation))
 
+(defun non-empty-string-p (value)
+  (and (stringp value) (plusp (length value))))
 
+(defun validate-actor-event (event &optional payload)
+  (flet ((invalid (reason)
+           (error 'invalid-actor-event
+                  :reason reason
+                  :payload payload)))
+    (unless (non-empty-string-p (event-id event))
+      (invalid "_id must be a non-empty string"))
+    (unless (and (integerp (event-timestamp event))
+                 (plusp (event-timestamp event)))
+      (invalid "timestamp must be a positive integer"))
+    (unless (string= "actorevent" (doc-type event))
+      (invalid "dtype must be actorevent"))
+    (unless (or (non-empty-string-p (event-actor-name event))
+                (non-empty-string-p (event-component event)))
+      (invalid "actorName or component is required"))
+    (unless (non-empty-string-p (event-type event))
+      (invalid "eventType is required"))
+    (unless (and (integerp (event-generation event))
+                 (not (minusp (event-generation event))))
+      (invalid "generation must be a non-negative integer"))
+    event))
 
-(defun make-actor-event (&key actor-name event-type details source-id)
-  (make-instance 'actor-event
-                 :actor-name actor-name
-                 :event-type event-type
-                 :details details
-                 :source-id source-id))
+(defun actor-event-json-object (payload)
+  (let ((json
+          (etypecase payload
+            (string (jsown:parse payload))
+            (list payload))))
+    ;; Migration defaults for pre-contract event documents.
+    (unless (jsown:val-safe json "dtype")
+      (setf (jsown:val json "dtype") "actorevent"))
+    (unless (jsown:val-safe json "generation")
+      (setf (jsown:val json "generation") 0))
+    (let ((actor-name (jsown:val-safe json "actorName"))
+          (component (jsown:val-safe json "component")))
+      (when (and actor-name (not component))
+        (setf (jsown:val json "component") actor-name))
+      (when (and component (not actor-name))
+        (setf (jsown:val json "actorName") component)))
+    json))
 
+(defun decode-actor-event (payload)
+  "Decode and validate an event through the StarIntel object codec."
+  (handler-case
+      (let* ((json (actor-event-json-object payload))
+             (event
+               (star.databases.couchdb:from-json json 'actor-event)))
+        (validate-actor-event event payload))
+    (invalid-actor-event (condition)
+      (error condition))
+    (error (condition)
+      (error 'invalid-actor-event
+             :reason (princ-to-string condition)
+             :payload payload))))
 
+(defun encode-actor-event (event)
+  (jsown:to-json
+   (star.databases.couchdb:as-json
+    (validate-actor-event event))))
 
+(defun actor-event-insert-request (event)
+  (make-couchdb-insert-request
+   :database star:*couchdb-event-log-database*
+   :document-id (event-id event)
+   :document (encode-actor-event event)))
 
+(defun persist-actor-event (event &optional (insert-actor *couchdb-inserts*))
+  (sento.actor:ask-s
+   insert-actor
+   (actor-event-insert-request event)
+   :time-out +event-persistence-timeout-seconds+))
+
+(defun actor-event-settlement (event persistence-result)
+  (cond
+    ((not (typep persistence-result 'couchdb-result))
+     (star.consumers:rabbit-nack
+      :reason :persistence-protocol-error
+      :requeue t
+      :value event
+      :error persistence-result))
+    ((member (couchdb-result-status persistence-result)
+             '(:success :exists :conflict))
+     (star.consumers:rabbit-ack
+      :reason
+      (if (eq :success (couchdb-result-status persistence-result))
+          :persisted
+          :duplicate)
+      :value event))
+    (t
+     (star.consumers:rabbit-nack
+      :reason :persistence-failed
+      :requeue t
+      :value event
+      :error (couchdb-result-error-message persistence-result)))))
+
+(defun process-event-delivery (payload &key (persist-fn #'persist-actor-event))
+  "Decode, validate, persist idempotently, and return a settlement decision."
+  (handler-case
+      (let ((event (decode-actor-event payload)))
+        (actor-event-settlement event (funcall persist-fn event)))
+    (invalid-actor-event (condition)
+      (star.consumers:rabbit-nack
+       :reason :invalid-event
+       :requeue nil
+       :error (invalid-actor-event-reason condition)))
+    (error (condition)
+      (star.consumers:rabbit-nack
+       :reason :event-handler-error
+       :requeue t
+       :error condition))))
 
 (define-actor (*actor-event-receiver* *sys*)
-    (lambda (event)
-      (let ((event-json (jsown:to-json (as-json event))))
-        (tell *couchdb-inserts* (list :id (event-id event) :database star:*couchdb-event-log-database* :document event-json)))))
+  (lambda (event)
+    (tell *couchdb-inserts* (actor-event-insert-request event))))
 
-
-
-
-
-(defun handle-event-message (self message)
-  "Handler function for processing event messages."
-  (let* ((jdoc (jsown:parse (car message))))
-    (log:trace "Got Event: ~a" (spec:decode jdoc 'actor-event))
-    (tell *actor-event-receiver* 
-          (make-instance 'actor-event
-                         :id (jsown:val jdoc "_id")
-                         :timestamp (jsown:val jdoc "timestamp")
-                         :actor-name (jsown:val jdoc "actorName")
-                         :event-type (jsown:val jdoc "eventType")
-                         :details (jsown:val jdoc "details")
-                         :source-id (jsown:val jdoc "sourceId")))))
-
+(defun handle-event-message (consumer message)
+  (declare (ignore consumer))
+  (process-event-delivery (car message)))
 
 (defun start-event-consumer (n)
-  "Initialize and set up the event consumer."
-  (let ((consumer (star.consumers:create-rabbit-consumer
-                   :name "event-consumers"
-                   :n n
-                   :host star:*rabbit-address*
-                   :port star:*rabbit-port*
-                   :username star:*rabbit-user*
-                   :password star:*rabbit-password*
-                   :queue-name "events"
-                   :exchange-name "events"
-                   :routing-key "event.#"
-                   :test-fn #'star.rabbit::insertp
-                   :handler-fn #'handle-event-message)))
+  "Start the durable event consumer with retry and dead-letter policy.
+
+Valid and duplicate events are ACKed. Invalid events are NACKed without requeue
+and routed to the quarantine queue. Transient persistence failures are NACKed
+with requeue so RabbitMQ can retry them."
+  (let ((consumer
+          (star.consumers:create-rabbit-consumer
+           :name "event-consumers"
+           :n n
+           :host star:*rabbit-address*
+           :port star:*rabbit-port*
+           :username star:*rabbit-user*
+           :password star:*rabbit-password*
+           :queue-name +event-queue+
+           :queue-durable t
+           :exchange-name +event-exchange+
+           :exchange-type "topic"
+           :exchange-durable t
+           :routing-key +event-routing-key+
+           :dead-letter-exchange +event-dead-letter-exchange+
+           :dead-letter-routing-key +event-dead-letter-routing-key+
+           :dead-letter-queue +event-dead-letter-queue+
+           :test-fn #'identity
+           :handler-fn #'handle-event-message)))
     (star.consumers:start-consumer consumer)))
 
-(defun log-actor-event (actor-name &key event-type details source-id)
-  (log:debug "Told *actor-event-reciver*")
-  (tell *actor-event-receiver* (make-actor-event :actor-name actor-name :event-type event-type :details  details :source-id source-id)))
+(defun log-actor-event (actor-name &key event-type details source-id trace-id
+                                     component (generation 0))
+  (tell
+   *actor-event-receiver*
+   (make-actor-event
+    :actor-name actor-name
+    :component component
+    :event-type event-type
+    :details details
+    :source-id source-id
+    :trace-id trace-id
+    :generation generation)))
 
-(nhooks:add-hook star:*actors-start-hook*
-                 (lambda () (star.actors:register-actor "actor-event-receiver" *actor-event-receiver*)))
+(nhooks:add-hook
+ star:*actors-start-hook*
+ (lambda ()
+   (star.actors:register-actor
+    "actor-event-receiver"
+    *actor-event-receiver*)))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (export '(actor-event
+            invalid-actor-event
+            invalid-actor-event-reason
+            make-actor-event
+            validate-actor-event
+            decode-actor-event
+            encode-actor-event
+            process-event-delivery
+            event-component
+            event-trace-id
+            event-generation)
+          :star.actors))

--- a/source/consumers/rabbit-settlement.lisp
+++ b/source/consumers/rabbit-settlement.lisp
@@ -1,0 +1,288 @@
+(in-package :star.consumers)
+
+(defstruct (rabbit-settlement
+            (:constructor make-rabbit-settlement
+                (&key action reason (requeue nil) value error)))
+  action
+  reason
+  requeue
+  value
+  error)
+
+(defun rabbit-ack (&key reason value)
+  (make-rabbit-settlement
+   :action :ack
+   :reason reason
+   :value value))
+
+(defun rabbit-nack (&key reason (requeue nil) value error)
+  (make-rabbit-settlement
+   :action :nack
+   :reason reason
+   :requeue requeue
+   :value value
+   :error error))
+
+(defun normalize-rabbit-settlement (result)
+  "Translate a consumer result into an explicit Rabbit settlement decision."
+  (typecase result
+    (rabbit-settlement result)
+    (t (rabbit-ack :reason :handler-complete :value result))))
+
+(defun settle-rabbit-delivery (consumer delivery settlement
+                               &key
+                                 (ack-fn #'cl-rabbit:basic-ack)
+                                 (nack-fn #'cl-rabbit:basic-nack))
+  "Settle DELIVERY on the same connection and channel that received it."
+  (let* ((stream (consumer-stream consumer))
+         (connection (rabbit-stream-connection stream))
+         (delivery-tag (cdr delivery))
+         (decision (normalize-rabbit-settlement settlement)))
+    (ecase (rabbit-settlement-action decision)
+      (:ack
+       (funcall ack-fn connection 1 delivery-tag :multiple nil))
+      (:nack
+       (funcall nack-fn
+                connection
+                1
+                delivery-tag
+                :multiple nil
+                :requeue (rabbit-settlement-requeue decision))))
+    decision))
+
+(defclass settled-rabbit-queue-stream (rabbit-queue-stream)
+  ((queue-arguments
+    :initarg :queue-arguments
+    :initform nil
+    :accessor rabbit-stream-queue-arguments)
+   (dead-letter-exchange
+    :initarg :dead-letter-exchange
+    :initform nil
+    :accessor rabbit-stream-dead-letter-exchange)
+   (dead-letter-routing-key
+    :initarg :dead-letter-routing-key
+    :initform nil
+    :accessor rabbit-stream-dead-letter-routing-key)
+   (dead-letter-queue
+    :initarg :dead-letter-queue
+    :initform nil
+    :accessor rabbit-stream-dead-letter-queue))
+  (:documentation "Rabbit stream with explicit settlement and dead-letter policy."))
+
+(defun rabbit-dead-letter-arguments (stream)
+  (let ((exchange (rabbit-stream-dead-letter-exchange stream))
+        (routing-key (rabbit-stream-dead-letter-routing-key stream)))
+    (append
+     (rabbit-stream-queue-arguments stream)
+     (when exchange
+       (list (cons "x-dead-letter-exchange" exchange)))
+     (when routing-key
+       (list (cons "x-dead-letter-routing-key" routing-key))))))
+
+(defmethod open-stream ((stream settled-rabbit-queue-stream))
+  (let* ((connection (cl-rabbit:new-connection))
+         (socket (cl-rabbit:tcp-socket-new connection))
+         (username (rabbit-stream-user stream))
+         (password (rabbit-stream-password stream))
+         (dead-letter-exchange
+           (rabbit-stream-dead-letter-exchange stream))
+         (dead-letter-queue
+           (rabbit-stream-dead-letter-queue stream))
+         (dead-letter-routing-key
+           (or (rabbit-stream-dead-letter-routing-key stream) "#")))
+    (setf (rabbit-stream-connection stream) connection)
+    (cl-rabbit:socket-open
+     socket
+     (rabbit-stream-host stream)
+     (rabbit-stream-port stream))
+    (when (or username password)
+      (cl-rabbit:login-sasl-plain
+       connection
+       (rabbit-stream-vhost stream)
+       username
+       password))
+    (cl-rabbit:channel-open connection 1)
+    (cl-rabbit:basic-qos connection 1 :prefetch-count 200)
+    (cl-rabbit:exchange-declare
+     connection
+     1
+     (rabbit-stream-exchange stream)
+     (rabbit-exchange-type stream)
+     :durable (rabbit-exchange-durable-p stream))
+    (when dead-letter-exchange
+      (cl-rabbit:exchange-declare
+       connection
+       1
+       dead-letter-exchange
+       "topic"
+       :durable t))
+    (cl-rabbit:queue-declare
+     connection
+     1
+     :queue (rabbit-stream-queue-name stream)
+     :durable (rabbit-stream-queue-durable-p stream)
+     :arguments (rabbit-dead-letter-arguments stream))
+    (cl-rabbit:queue-bind
+     connection
+     1
+     :queue (rabbit-stream-queue-name stream)
+     :exchange (rabbit-stream-exchange stream)
+     :routing-key (rabbit-stream-routing-key stream))
+    (when (and dead-letter-exchange dead-letter-queue)
+      (cl-rabbit:queue-declare
+       connection
+       1
+       :queue dead-letter-queue
+       :durable t)
+      (cl-rabbit:queue-bind
+       connection
+       1
+       :queue dead-letter-queue
+       :exchange dead-letter-exchange
+       :routing-key dead-letter-routing-key))
+    (cl-rabbit:basic-consume
+     connection
+     1
+     (rabbit-stream-queue-name stream)
+     :no-ack nil)
+    (setf (rabbit-stream-open-p stream) t)))
+
+(defun copy-rabbit-stream-options (stream)
+  (list
+   :queue-name (rabbit-stream-queue-name stream)
+   :exchange-name (rabbit-stream-exchange stream)
+   :exchange-type (rabbit-exchange-type stream)
+   :exchange-durable (rabbit-exchange-durable-p stream)
+   :queue-durable (rabbit-stream-queue-durable-p stream)
+   :routing-key (rabbit-stream-routing-key stream)
+   :host (rabbit-stream-host stream)
+   :port (rabbit-stream-port stream)
+   :vhost (rabbit-stream-vhost stream)
+   :username (rabbit-stream-user stream)
+   :password (rabbit-stream-password stream)
+   :queue-arguments
+   (and (typep stream 'settled-rabbit-queue-stream)
+        (rabbit-stream-queue-arguments stream))
+   :dead-letter-exchange
+   (and (typep stream 'settled-rabbit-queue-stream)
+        (rabbit-stream-dead-letter-exchange stream))
+   :dead-letter-routing-key
+   (and (typep stream 'settled-rabbit-queue-stream)
+        (rabbit-stream-dead-letter-routing-key stream))
+   :dead-letter-queue
+   (and (typep stream 'settled-rabbit-queue-stream)
+        (rabbit-stream-dead-letter-queue stream))))
+
+(defmethod start-consumer ((consumer rabbit-consumer))
+  "Run each Rabbit worker with its own connection and settle every delivery."
+  (let ((create-thread-consumer
+          (lambda (thread-number)
+            (let* ((thread-consumer
+                     (apply #'create-rabbit-consumer
+                            :name
+                            (format nil "~A-~D"
+                                    (consumer-name consumer)
+                                    thread-number)
+                            :n 1
+                            :test-fn (consumer-filter consumer)
+                            :handler-fn (consumer-fn consumer)
+                            (copy-rabbit-stream-options
+                             (consumer-stream consumer)))))
+              (open-stream (consumer-stream thread-consumer))
+              (assert
+               (rabbit-stream-open-p (consumer-stream thread-consumer))
+               nil
+               "RabbitMQ stream was not opened.")
+              (lambda ()
+                (loop
+                  for delivery = (consumer-read thread-consumer)
+                  for settlement =
+                    (handler-case
+                        (progn
+                          (consume thread-consumer delivery)
+                          (normalize-rabbit-settlement
+                           (receive-result
+                            (consumer-channel thread-consumer))))
+                      (error (condition)
+                        (rabbit-nack
+                         :reason :handler-error
+                         :requeue t
+                         :error condition)))
+                  do (settle-rabbit-delivery
+                      thread-consumer
+                      delivery
+                      settlement)))))))
+    (loop for thread-number from 1 to (consumer-worker-count consumer)
+          do (bt:make-thread
+              (funcall create-thread-consumer thread-number)
+              :name (format nil "~A-~D"
+                            (consumer-name consumer)
+                            thread-number)))))
+
+(defun create-rabbit-consumer (&key
+                                 (name (error "Consumer name is required"))
+                                 (n 1)
+                                 (queue-name
+                                   (error "Queue name is required"))
+                                 (exchange-name "documents")
+                                 (exchange-type "topic")
+                                 (exchange-durable t)
+                                 (queue-durable t)
+                                 (queue-arguments nil)
+                                 (dead-letter-exchange nil)
+                                 (dead-letter-routing-key nil)
+                                 (dead-letter-queue nil)
+                                 (routing-key
+                                   (error "Routing key is required"))
+                                 (host "localhost")
+                                 (port 5672)
+                                 (vhost "/")
+                                 (username "guest")
+                                 (password "guest")
+                                 (test-fn #'identity)
+                                 (handler-fn
+                                   (error "Handler function is required")))
+  "Create a Rabbit consumer with explicit durability and settlement policy."
+  (make-instance
+   'rabbit-consumer
+   :name (string-downcase (string name))
+   :stream
+   (make-instance
+    'settled-rabbit-queue-stream
+    :queue-name queue-name
+    :exchange-name exchange-name
+    :exchange-type exchange-type
+    :exchange-durable exchange-durable
+    :queue-durable queue-durable
+    :queue-arguments queue-arguments
+    :dead-letter-exchange dead-letter-exchange
+    :dead-letter-routing-key dead-letter-routing-key
+    :dead-letter-queue dead-letter-queue
+    :routing-key routing-key
+    :host host
+    :port port
+    :vhost vhost
+    :user username
+    :password password)
+   :workers n
+   :fn handler-fn
+   :test-fn test-fn))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (export '(rabbit-settlement
+            make-rabbit-settlement
+            rabbit-settlement-action
+            rabbit-settlement-reason
+            rabbit-settlement-requeue
+            rabbit-settlement-value
+            rabbit-settlement-error
+            rabbit-ack
+            rabbit-nack
+            normalize-rabbit-settlement
+            settle-rabbit-delivery
+            settled-rabbit-queue-stream
+            rabbit-stream-queue-arguments
+            rabbit-stream-dead-letter-exchange
+            rabbit-stream-dead-letter-routing-key
+            rabbit-stream-dead-letter-queue)
+          :star.consumers))

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -11,6 +11,7 @@
   :components   (
                  (:file "consumers/package")
                  (:file "consumers/consumers")
+                 (:file "consumers/rabbit-settlement")
                  (:file "producers/package")
                  (:file "producers/producers")
                  (:file "package")

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -5,14 +5,14 @@
   :license      "GPL v3"
   :serial t
   :depends-on   (#:starintel-gserver
-                  #:starintel-gserver-client
-                  #:star-cli
-                  #:star-ui
-                  #:star-migrations
-                  #:fiveam
-                  #:dexador
-                  #:bordeaux-threads
-                  #:jsown)
+                   #:starintel-gserver-client
+                   #:star-cli
+                   #:star-ui
+                   #:star-migrations
+                   #:fiveam
+                   #:dexador
+                   #:bordeaux-threads
+                   #:jsown)
   :components   ((:module "t"
                    :serial t
                    :components ((:file "package")
@@ -23,6 +23,7 @@
                                 (:file "target-routing-test")
                                 (:file "system-load-test")
                                 (:file "couchdb-actor-test")
+                                (:file "event-actor-test")
                                 (:file "run-tests"))))
   :perform (test-op (o c)
                      (declare (ignore o c))

--- a/t/event-actor-test.lisp
+++ b/t/event-actor-test.lisp
@@ -1,0 +1,198 @@
+(in-package :star-server-tests)
+
+(def-suite event-actor-tests
+  :description "Actor-event codec, idempotency, and Rabbit settlement tests")
+
+(in-suite event-actor-tests)
+
+(defun valid-event-payload (&key (id "event-1")
+                              (timestamp 1770000000)
+                              (dtype "actorevent")
+                              (actor-name "crawler")
+                              (component "url-fetcher")
+                              (event-type "document.fetched")
+                              (details "ok")
+                              (source-id "source-1")
+                              (trace-id "trace-1")
+                              (generation 2))
+  (jsown:to-json
+   (jsown:new-js
+     ("_id" id)
+     ("timestamp" timestamp)
+     ("dtype" dtype)
+     ("actorName" actor-name)
+     ("component" component)
+     ("eventType" event-type)
+     ("details" details)
+     ("sourceId" source-id)
+     ("traceId" trace-id)
+     ("generation" generation))))
+
+(test actor-event-timestamp-and-dtype-initialize-independently
+  (let ((event
+          (star.actors:make-actor-event
+           :id "event-independent"
+           :timestamp 123456789
+           :dtype "actorevent"
+           :actor-name "scheduler"
+           :event-type "target.started")))
+    (is (= 123456789 (star.actors::event-timestamp event)))
+    (is (string= "actorevent" (star.actors::doc-type event)))
+    (is (string= "scheduler" (star.actors:event-component event)))))
+
+(test legacy-event-fixture-migrates-through-one-codec
+  (let* ((payload
+           "{\"_id\":\"legacy-1\",\"timestamp\":1770000001,\"actorName\":\"legacy-actor\",\"eventType\":\"legacy.event\",\"details\":\"migrated\",\"sourceId\":\"source-old\"}")
+         (event (star.actors:decode-actor-event payload)))
+    (is (string= "legacy-1" (star.actors::event-id event)))
+    (is (string= "actorevent" (star.actors::doc-type event)))
+    (is (string= "legacy-actor" (star.actors:event-component event)))
+    (is (= 0 (star.actors:event-generation event)))
+    (is (string= "source-old"
+                 (star.actors::event-source-document event)))))
+
+(test valid-event-is-persisted-once-and-acked
+  (let ((persist-count 0)
+        (persisted-id nil))
+    (let ((settlement
+            (star.actors:process-event-delivery
+             (valid-event-payload)
+             :persist-fn
+             (lambda (event)
+               (incf persist-count)
+               (setf persisted-id (star.actors::event-id event))
+               (star.actors::make-couchdb-result
+                :status :success
+                :operation :insert
+                :document-id persisted-id)))))
+      (is (= 1 persist-count))
+      (is (string= "event-1" persisted-id))
+      (is (eq :ack
+              (star.consumers:rabbit-settlement-action settlement)))
+      (is (eq :persisted
+              (star.consumers:rabbit-settlement-reason settlement))))))
+
+(test duplicate-event-delivery-is-idempotently-acked
+  (let ((persist-count 0))
+    (let ((settlement
+            (star.actors:process-event-delivery
+             (valid-event-payload :id "duplicate-1")
+             :persist-fn
+             (lambda (event)
+               (declare (ignore event))
+               (incf persist-count)
+               (star.actors::make-couchdb-result
+                :status :exists
+                :operation :insert
+                :document-id "duplicate-1")))))
+      (is (= 1 persist-count))
+      (is (eq :ack
+              (star.consumers:rabbit-settlement-action settlement)))
+      (is (eq :duplicate
+              (star.consumers:rabbit-settlement-reason settlement))))))
+
+(test invalid-event-is-quarantined-and-settled
+  (let ((persist-called-p nil))
+    (let ((settlement
+            (star.actors:process-event-delivery
+             "{\"_id\":\"invalid-1\",\"timestamp\":1770000002,\"actorName\":\"crawler\"}"
+             :persist-fn
+             (lambda (event)
+               (declare (ignore event))
+               (setf persist-called-p t)
+               (error "Invalid events must not persist.")))))
+      (is-false persist-called-p)
+      (is (eq :nack
+              (star.consumers:rabbit-settlement-action settlement)))
+      (is-false
+       (star.consumers:rabbit-settlement-requeue settlement))
+      (is (eq :invalid-event
+              (star.consumers:rabbit-settlement-reason settlement))))))
+
+(test persistence-failure-is-requeued
+  (let ((settlement
+          (star.actors:process-event-delivery
+           (valid-event-payload :id "retry-1")
+           :persist-fn
+           (lambda (event)
+             (declare (ignore event))
+             (star.actors::make-couchdb-result
+              :status :error
+              :operation :insert
+              :document-id "retry-1"
+              :error-message "CouchDB unavailable")))))
+    (is (eq :nack
+            (star.consumers:rabbit-settlement-action settlement)))
+    (is-true
+     (star.consumers:rabbit-settlement-requeue settlement))
+    (is (eq :persistence-failed
+            (star.consumers:rabbit-settlement-reason settlement)))))
+
+(test rabbit-settlement-uses-owning-connection-and-delivery-tag
+  (let* ((stream
+           (make-instance
+            'star.consumers:settled-rabbit-queue-stream
+            :queue-name "events"
+            :exchange-name "events"
+            :routing-key "event.#"
+            :rabbit-connection :owning-connection))
+         (consumer
+           (make-instance
+            'star.consumers:rabbit-consumer
+            :name "settlement-test"
+            :workers 1
+            :stream stream))
+         (ack-arguments nil)
+         (nack-arguments nil))
+    (star.consumers:settle-rabbit-delivery
+     consumer
+     (cons "{}" 41)
+     (star.consumers:rabbit-ack :reason :persisted)
+     :ack-fn
+     (lambda (connection channel delivery-tag &key multiple)
+       (setf ack-arguments
+             (list connection channel delivery-tag multiple)))
+     :nack-fn
+     (lambda (&rest arguments)
+       (setf nack-arguments arguments)))
+    (is (equal '(:owning-connection 1 41 nil) ack-arguments))
+    (is (null nack-arguments))
+    (star.consumers:settle-rabbit-delivery
+     consumer
+     (cons "{}" 42)
+     (star.consumers:rabbit-nack
+      :reason :invalid-event
+      :requeue nil)
+     :ack-fn
+     (lambda (&rest arguments)
+       (setf ack-arguments arguments))
+     :nack-fn
+     (lambda (connection channel delivery-tag &key multiple requeue)
+       (setf nack-arguments
+             (list connection channel delivery-tag multiple requeue))))
+    (is (equal '(:owning-connection 1 42 nil nil)
+               nack-arguments))))
+
+(test event-consumer-declares-durable-dead-letter-policy
+  (let* ((consumer
+           (star.consumers:create-rabbit-consumer
+            :name "events-test"
+            :queue-name "events"
+            :exchange-name "events"
+            :routing-key "event.#"
+            :queue-durable t
+            :exchange-durable t
+            :dead-letter-exchange "events.dead-letter"
+            :dead-letter-routing-key "events.invalid"
+            :dead-letter-queue "events.quarantine"
+            :handler-fn #'identity))
+         (stream (star.consumers:consumer-stream consumer)))
+    (is (typep stream 'star.consumers:settled-rabbit-queue-stream))
+    (is-true (star.consumers:rabbit-stream-queue-durable-p stream))
+    (is-true (star.consumers:rabbit-exchange-durable-p stream))
+    (is (string= "events.dead-letter"
+                 (star.consumers:rabbit-stream-dead-letter-exchange stream)))
+    (is (string= "events.invalid"
+                 (star.consumers:rabbit-stream-dead-letter-routing-key stream)))
+    (is (string= "events.quarantine"
+                 (star.consumers:rabbit-stream-dead-letter-queue stream)))))

--- a/t/run-tests.lisp
+++ b/t/run-tests.lisp
@@ -6,7 +6,8 @@
     init-loader-tests
     target-routing-tests
     system-load-tests
-    couchdb-actor-tests))
+    couchdb-actor-tests
+    event-actor-tests))
 
 (defun run-all-gserver-tests ()
   "Run every hermetic unit suite and fail on empty, skipped, or failed tests."


### PR DESCRIPTION
## What changed

- correct `actor-event` so `dtype` uses its own `:dtype` initarg instead of colliding with timestamp
- preserve event id, timestamp, actor/component identity, source id, trace id, generation, type, and details
- decode and encode through one StarIntel object codec with event-specific validation and migration defaults
- persist Rabbit events through the typed CouchDB insert request from #81
- treat `:exists` and insert conflicts as idempotent duplicate deliveries
- return explicit Rabbit settlement objects from handlers
- ACK only after successful or duplicate persistence
- NACK malformed events without requeue into a durable dead-letter exchange/queue
- NACK transient persistence failures with requeue
- settle on the worker connection/channel that owns the delivery tag
- make queue, exchange, retry, durability, and dead-letter policy explicit

## Stacked dependency

This PR targets `agent/issue-23-couchdb-actor-semantics` because deterministic event persistence depends on the typed CouchDB request/result contract in #81. Merge #81 first, then retarget this PR to `master`.

## Validation

Hermetic tests cover:

- independent timestamp and dtype initialization
- migration of a legacy event fixture
- valid event persistence and ACK
- duplicate delivery idempotency and ACK
- invalid event quarantine without persistence
- transient persistence failure requeue
- ACK/NACK execution on the owning connection and delivery tag
- durable event dead-letter configuration

Full Common Lisp execution is delegated to repository CI.

Fixes #24