### PR TITLE
Validate HTTP input and bound bulk ingest work

### DIFF
--- a/source/frontends/http-boundary-core.lisp
+++ b/source/frontends/http-boundary-core.lisp
@@ -133,7 +133,12 @@
      "Request body exceeds the configured limit"
      (jsown:new-js ("maximum_bytes" max-bytes))))
   (handler-case
-      (jsown:parse (babel:octets-to-string octets :encoding :utf-8))
+      (let ((text (babel:octets-to-string octets :encoding :utf-8)))
+        ;; JSOWN is retained as the internal representation, but it is not a
+        ;; standards-compliant validator. Jzon rejects malformed RFC 8259 input
+        ;; before JSOWN is allowed to decode the already validated text.
+        (com.inuoe.jzon:parse text)
+        (jsown:parse text))
     (error ()
       (signal-http-input-error
        400

--- a/source/frontends/http-boundary-core.lisp
+++ b/source/frontends/http-boundary-core.lisp
@@ -1,0 +1,296 @@
+(in-package :star.frontends.http-api)
+
+(defparameter +http-max-body-bytes+ (* 1024 1024))
+(defparameter +http-max-query-limit+ 100)
+
+(defvar *http-correlation-id* nil)
+
+(define-condition http-input-error (error)
+  ((status
+    :initarg :status
+    :reader http-input-error-status)
+   (code
+    :initarg :code
+    :reader http-input-error-code)
+   (message
+    :initarg :message
+    :reader http-input-error-message)
+   (info
+    :initarg :info
+    :initform nil
+    :reader http-input-error-info))
+  (:report
+   (lambda (condition stream)
+     (format stream "~a" (http-input-error-message condition)))))
+
+(defun new-correlation-id ()
+  (cms-ulid:ulid))
+
+(defun current-correlation-id ()
+  (or *http-correlation-id*
+      (new-correlation-id)))
+
+(defun set-correlation-id-header ()
+  (setf (lack.response:response-headers *response*)
+        (append (lack.response:response-headers *response*)
+                (list :x-correlation-id (current-correlation-id)))))
+
+(defun status-msg (msg status &key info traceback code)
+  "Return a client-safe status envelope. TRACEBACK is intentionally ignored."
+  (declare (ignore traceback))
+  (let ((json (jsown:new-js
+                ("msg" msg)
+                ("status" (string-downcase (symbol-name status)))
+                ("correlation_id" (current-correlation-id)))))
+    (when code
+      (setf (jsown:val json "code") code))
+    (when info
+      (setf (jsown:val json "info") info))
+    (jsown:to-json json)))
+
+(defun signal-http-input-error (status code message &optional info)
+  (error 'http-input-error
+         :status status
+         :code code
+         :message message
+         :info info))
+
+(defun respond-http-input-error (condition)
+  (setf (lack.response:response-status *response*)
+        (http-input-error-status condition))
+  (status-msg (http-input-error-message condition)
+              'error
+              :code (http-input-error-code condition)
+              :info (http-input-error-info condition)))
+
+(defmacro with-http-boundary (() &body body)
+  `(let ((*http-correlation-id* (new-correlation-id)))
+     (set-default-headers)
+     (set-correlation-id-header)
+     (handler-case
+         (progn ,@body)
+       (http-input-error (condition)
+         (log:warn "HTTP input rejected correlation=~a code=~a: ~a"
+                   (current-correlation-id)
+                   (http-input-error-code condition)
+                   condition)
+         (respond-http-input-error condition))
+       (bt:timeout (condition)
+         (log:error "HTTP operation timed out correlation=~a: ~a"
+                    (current-correlation-id)
+                    condition)
+         (setf (lack.response:response-status *response*) 504)
+         (status-msg "Request deadline exceeded"
+                     'error
+                     :code "request_timeout"))
+       (error (condition)
+         (log:error "HTTP internal error correlation=~a: ~a"
+                    (current-correlation-id)
+                    condition)
+         (setf (lack.response:response-status *response*) 500)
+         (status-msg "Internal Server Error"
+                     'error
+                     :code "internal_error")))))
+
+(defun json-object-p (value)
+  (and (consp value)
+       (eq (car value) :obj)))
+
+(defun json-array-p (value)
+  (or (null value)
+      (and (listp value)
+           (not (json-object-p value)))))
+
+(defun request-content-type (&optional (request (ningle:context :request)))
+  (or (ignore-errors (lack.request:request-content-type request))
+      (getf (lack.request:request-env request) :content-type)))
+
+(defun json-content-type-p (content-type)
+  (when (stringp content-type)
+    (let ((normalized (string-downcase content-type)))
+      (or (search "application/json" normalized)
+          (search "+json" normalized)))))
+
+(defun request-body-octets (&optional (request (ningle:context :request)))
+  (let ((content (lack.request:request-content request)))
+    (etypecase content
+      ((simple-array (unsigned-byte 8) (*)) content)
+      (string (babel:string-to-octets content :encoding :utf-8))
+      (vector content)
+      (null #()))))
+
+(defun parse-json-octets (octets content-type
+                          &key (max-bytes +http-max-body-bytes+))
+  (unless (json-content-type-p content-type)
+    (signal-http-input-error
+     415
+     "unsupported_media_type"
+     "Content-Type must be application/json"))
+  (when (> (length octets) max-bytes)
+    (signal-http-input-error
+     413
+     "request_body_too_large"
+     "Request body exceeds the configured limit"
+     (jsown:new-js ("maximum_bytes" max-bytes))))
+  (handler-case
+      (jsown:parse (babel:octets-to-string octets :encoding :utf-8))
+    (error ()
+      (signal-http-input-error
+       400
+       "malformed_json"
+       "Request body contains malformed JSON"))))
+
+(defun parse-json-request (&key (max-bytes +http-max-body-bytes+))
+  (let* ((request (ningle:context :request))
+         (content-type (request-content-type request))
+         (octets (request-body-octets request)))
+    (parse-json-octets octets content-type :max-bytes max-bytes)))
+
+(defun require-json-object (value)
+  (unless (json-object-p value)
+    (signal-http-input-error
+     400
+     "json_object_required"
+     "Request body must be a JSON object"))
+  value)
+
+(defun require-json-array (value)
+  (unless (json-array-p value)
+    (signal-http-input-error
+     400
+     "json_array_required"
+     "Request body must be a JSON array"))
+  value)
+
+(defun non-empty-string-p (value)
+  (and (stringp value)
+       (plusp (length value))))
+
+(defun require-document-string (document field &key index)
+  (let ((value (jsown:val-safe document field)))
+    (unless (non-empty-string-p value)
+      (signal-http-input-error
+       422
+       "invalid_document"
+       (if index
+           (format nil "Document at index ~d requires a non-empty ~a field"
+                   index field)
+           (format nil "Document requires a non-empty ~a field" field))
+       (jsown:new-js ("field" field)
+                     ("index" (or index :null)))))
+    value))
+
+(defun validate-schema-version (document &key index)
+  (let ((version (jsown:val-safe document "version"))
+        (expected starintel:+starintel-doc-version+))
+    (unless version
+      (signal-http-input-error
+       422
+       "schema_version_required"
+       (if index
+           (format nil "Document at index ~d requires a version field" index)
+           "Document requires a version field")))
+    (unless (string= (princ-to-string version)
+                     (princ-to-string expected))
+      (signal-http-input-error
+       422
+       "unsupported_schema_version"
+       "Document schema version is not supported"
+       (jsown:new-js ("expected" (princ-to-string expected))
+                     ("received" (princ-to-string version))
+                     ("index" (or index :null)))))))
+
+(defun validate-document-input (document &key path-dtype index)
+  (unless (json-object-p document)
+    (signal-http-input-error
+     422
+     "invalid_document"
+     (if index
+         (format nil "Document at index ~d must be a JSON object" index)
+         "Document must be a JSON object")))
+  (require-document-string document "_id" :index index)
+  (require-document-string document "dataset" :index index)
+  (let ((dtype (require-document-string document "dtype" :index index)))
+    (when (and path-dtype
+               (not (string-equal dtype path-dtype)))
+      (signal-http-input-error
+       422
+       "dtype_mismatch"
+       "Document dtype does not match the route dtype"
+       (jsown:new-js ("path_dtype" path-dtype)
+                     ("document_dtype" dtype))))
+    (validate-schema-version document :index index)
+    document))
+
+(defun query-value (params name)
+  (or (cdr (assoc name params :test #'string=))
+      (cdr (assoc (intern (string-upcase name) :keyword)
+                  params
+                  :test #'eq))))
+
+(defun require-query-string (params name)
+  (let ((value (query-value params name)))
+    (unless (non-empty-string-p value)
+      (signal-http-input-error
+       400
+       "missing_query_parameter"
+       (format nil "Query parameter ~a is required" name)))
+    value))
+
+(defun bounded-query-integer (params name &key default (minimum 0)
+                                            (maximum +http-max-query-limit+))
+  (let ((raw (query-value params name)))
+    (when (and (null raw) default)
+      (return-from bounded-query-integer default))
+    (unless raw
+      (signal-http-input-error
+       400
+       "missing_query_parameter"
+       (format nil "Query parameter ~a is required" name)))
+    (let ((value
+            (handler-case
+                (parse-integer raw :junk-allowed nil)
+              (error ()
+                (signal-http-input-error
+                 400
+                 "invalid_query_parameter"
+                 (format nil "Query parameter ~a must be an integer" name))))))
+      (unless (<= minimum value maximum)
+        (signal-http-input-error
+         400
+         "query_parameter_out_of_range"
+         (format nil "Query parameter ~a must be between ~d and ~d"
+                 name minimum maximum)))
+      value)))
+
+(defun request-header-value (headers name)
+  (cond
+    ((hash-table-p headers)
+     (or (gethash (string-downcase name) headers)
+         (gethash name headers)))
+    ((and (listp headers) (consp (car headers)))
+     (cdr (assoc name headers :test #'string-equal)))
+    (t nil)))
+
+(defun request-principal (&optional (request (ningle:context :request)))
+  (let* ((headers (ignore-errors (lack.request:request-headers request)))
+         (authorization (request-header-value headers "authorization"))
+         (remote-address
+           (getf (lack.request:request-env request) :remote-addr)))
+    (cond
+      (authorization
+       (format nil "auth-~x" (sxhash authorization)))
+      ((non-empty-string-p remote-address)
+       (format nil "remote-~a" remote-address))
+      (t "anonymous"))))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (export '(http-input-error
+            http-input-error-status
+            http-input-error-code
+            json-object-p
+            json-array-p
+            parse-json-octets
+            validate-document-input
+            bounded-query-integer)
+          :star.frontends.http-api))

--- a/source/frontends/http-boundary-core.lisp
+++ b/source/frontends/http-boundary-core.lisp
@@ -134,10 +134,9 @@
      (jsown:new-js ("maximum_bytes" max-bytes))))
   (handler-case
       (let ((text (babel:octets-to-string octets :encoding :utf-8)))
-        ;; JSOWN is retained as the internal representation, but it is not a
-        ;; standards-compliant validator. Jzon rejects malformed RFC 8259 input
-        ;; before JSOWN is allowed to decode the already validated text.
-        (com.inuoe.jzon:parse text)
+        ;; Validate with the packaged standards-oriented parser, then retain
+        ;; JSOWN as the service's existing internal document representation.
+        (yason:parse text)
         (jsown:parse text))
     (error ()
       (signal-http-input-error

--- a/source/frontends/http-boundary-routes.lisp
+++ b/source/frontends/http-boundary-routes.lisp
@@ -1,0 +1,111 @@
+(in-package :star.frontends.http-api)
+
+(defun handle-new-document-route (params)
+  (with-http-boundary ()
+    (let* ((path-dtype (query-value params "dtype"))
+           (document (require-json-object (parse-json-request))))
+      (unless (non-empty-string-p path-dtype)
+        (signal-http-input-error
+         400
+         "missing_path_parameter"
+         "Route dtype is required"))
+      (validate-document-input document :path-dtype path-dtype)
+      (publish-document document)
+      (jsown:to-json document))))
+
+(defun handle-new-target-route (params)
+  (with-http-boundary ()
+    (let* ((actor (query-value params "actor"))
+           (document (require-json-object (parse-json-request))))
+      (unless (non-empty-string-p actor)
+        (signal-http-input-error
+         400
+         "missing_path_parameter"
+         "Route actor is required"))
+      (setf (jsown:val document "dtype") "target"
+            (jsown:val document "actor") actor)
+      (validate-document-input document :path-dtype "target")
+      (publish-document document)
+      (jsown:to-json document))))
+
+(defun handle-bulk-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (let* ((documents (require-json-array (parse-json-request)))
+           (document-count (length documents)))
+      (when (> document-count star:*bulk-max-documents*)
+        (signal-http-input-error
+         413
+         "bulk_document_limit_exceeded"
+         "Bulk request exceeds the configured document limit"
+         (jsown:new-js ("requested" document-count)
+                       ("maximum" star:*bulk-max-documents*))))
+      (loop for document in documents
+            for index from 0
+            do (validate-document-input document :index index))
+      (if (eq :inline (bulk-request-mode document-count))
+          (process-inline-bulk documents)
+          (let ((job (submit-bulk-ingest-job
+                      documents
+                      (request-principal))))
+            (setf (lack.response:response-status *response*) 202)
+            (jsown:to-json
+             (jsown:new-js
+               ("status" "accepted")
+               ("job_id" (bulk-ingest-job-id job))
+               ("total" document-count)
+               ("status_url"
+                (format nil "/documents/bulk/~a"
+                        (bulk-ingest-job-id job)))
+               ("correlation_id" (current-correlation-id)))))))))
+
+(defun handle-bulk-status-route (params)
+  (with-http-boundary ()
+    (let* ((job-id (query-value params "job-id"))
+           (job (and job-id
+                     (bt:with-lock-held (*bulk-ingest-lock*)
+                       (gethash job-id *bulk-ingest-jobs*)))))
+      (unless job
+        (signal-http-input-error
+         404
+         "bulk_job_not_found"
+         "Bulk ingest job was not found"))
+      (jsown:to-json (bulk-job-info-json job)))))
+
+(defun handle-search-route (params)
+  (with-http-boundary ()
+    (let ((q (require-query-string params "q"))
+          (limit (bounded-query-integer
+                  params "limit" :default 25 :minimum 1)))
+      (couchdb-handler (client *couchdb-pool*)
+        (let* ((db star:*couchdb-default-database*)
+               (bookmark (query-value params "bookmark"))
+               (sort (query-value params "sort"))
+               (query (jsown:new-js
+                        ("q" q)
+                        ("limit" limit)
+                        ("include_docs" t))))
+          (when sort
+            (setf (jsown:val query "sort") sort))
+          (when bookmark
+            (setf (jsown:val query "bookmark") bookmark))
+          (cl-couch:fts-search client
+                               (jsown:to-json query)
+                               db
+                               "search"
+                               "fts"))))))
+
+(setf (ningle:route *app* "/new/document/:dtype" :method :post)
+      #'handle-new-document-route)
+
+(setf (ningle:route *app* "/new/target/:actor" :method :post)
+      #'handle-new-target-route)
+
+(setf (ningle:route *app* "/documents/bulk" :method :post)
+      #'handle-bulk-route)
+
+(setf (ningle:route *app* "/documents/bulk/:job-id" :method :get)
+      #'handle-bulk-status-route)
+
+(setf (ningle:route *app* "/search" :method :get)
+      #'handle-search-route)

--- a/source/frontends/http-bulk-jobs.lisp
+++ b/source/frontends/http-bulk-jobs.lisp
@@ -1,0 +1,210 @@
+(in-package :star.frontends.http-api)
+
+(defparameter +bulk-inline-document-limit+ 10)
+(defparameter +bulk-inline-deadline-seconds+ 2)
+(defparameter +bulk-max-pending-jobs+ 32)
+(defparameter +bulk-max-pending-per-principal+ 4)
+(defparameter +bulk-worker-count+ 4)
+
+(defvar *bulk-ingest-workers* nil)
+(defvar *bulk-ingest-worker-system* nil)
+(defvar *bulk-ingest-worker-index* 0)
+(defvar *bulk-ingest-jobs* (make-hash-table :test #'equal))
+(defvar *bulk-pending-jobs* 0)
+(defvar *bulk-pending-by-principal* (make-hash-table :test #'equal))
+(defvar *bulk-ingest-lock* (bt:make-lock "bulk-ingest-state"))
+
+(defstruct (bulk-ingest-job
+            (:constructor make-bulk-ingest-job
+                (&key id principal documents correlation-id submitted-at
+                      (status :queued) (succeeded 0) (failed 0) error-code)))
+  id
+  principal
+  documents
+  correlation-id
+  submitted-at
+  status
+  succeeded
+  failed
+  error-code)
+
+(defun bulk-job-info-json (job)
+  (jsown:new-js
+    ("job_id" (bulk-ingest-job-id job))
+    ("status" (string-downcase
+                (symbol-name (bulk-ingest-job-status job))))
+    ("total" (length (bulk-ingest-job-documents job)))
+    ("succeeded" (bulk-ingest-job-succeeded job))
+    ("failed" (bulk-ingest-job-failed job))
+    ("correlation_id" (bulk-ingest-job-correlation-id job))))
+
+(defun release-bulk-job-slot (job)
+  (bt:with-lock-held (*bulk-ingest-lock*)
+    (decf *bulk-pending-jobs*)
+    (let* ((principal (bulk-ingest-job-principal job))
+           (count (gethash principal *bulk-pending-by-principal* 0)))
+      (if (> count 1)
+          (setf (gethash principal *bulk-pending-by-principal*) (1- count))
+          (remhash principal *bulk-pending-by-principal*)))))
+
+(defun publish-document (document)
+  (let* ((dtype (jsown:val document "dtype"))
+         (routing-key (format nil star.rabbit:+ingest-fmt-key+ dtype)))
+    (star.actors:publish star.actors:*producer-agent*
+                         :body (jsown:to-json document)
+                         :routing-key routing-key
+                         :properties (list (cons :type dtype)))))
+
+(defun execute-bulk-job (job &key (publish-fn #'publish-document))
+  (setf (bulk-ingest-job-status job) :running)
+  (handler-case
+      (progn
+        (loop for document in (bulk-ingest-job-documents job)
+              do (handler-case
+                     (progn
+                       (funcall publish-fn document)
+                       (incf (bulk-ingest-job-succeeded job)))
+                   (error (condition)
+                     (log:error
+                      "Bulk publish failed job=~a correlation=~a: ~a"
+                      (bulk-ingest-job-id job)
+                      (bulk-ingest-job-correlation-id job)
+                      condition)
+                     (incf (bulk-ingest-job-failed job)))))
+        (setf (bulk-ingest-job-status job)
+              (if (zerop (bulk-ingest-job-failed job))
+                  :completed
+                  :completed-with-errors)))
+    (error (condition)
+      (log:error "Bulk job failed job=~a correlation=~a: ~a"
+                 (bulk-ingest-job-id job)
+                 (bulk-ingest-job-correlation-id job)
+                 condition)
+      (setf (bulk-ingest-job-status job) :failed
+            (bulk-ingest-job-error-code job) "bulk_job_failed")))
+  job)
+
+(defun bulk-worker-handler (job)
+  (unwind-protect
+       (execute-bulk-job job)
+    (release-bulk-job-slot job)))
+
+(defun make-bulk-worker (system index dispatcher)
+  (sento.actor-context:actor-of
+   system
+   :name (format nil "bulk-ingest-worker-~d" index)
+   :dispatcher dispatcher
+   :receive #'bulk-worker-handler))
+
+(defun start-bulk-ingest-workers (&optional (system star.actors:*sys*))
+  (unless system
+    (return-from start-bulk-ingest-workers nil))
+  (bt:with-lock-held (*bulk-ingest-lock*)
+    (unless (and *bulk-ingest-workers*
+                 (eq *bulk-ingest-worker-system* system))
+      (setf *bulk-ingest-workers*
+            (loop for index below +bulk-worker-count+
+                  collect
+                  (handler-case
+                      (make-bulk-worker system index :pinned)
+                    (error ()
+                      (make-bulk-worker system index :shared))))
+            *bulk-ingest-worker-system* system
+            *bulk-ingest-worker-index* 0)))
+  *bulk-ingest-workers*)
+
+(defun start-bulk-ingest-workers-hook ()
+  (start-bulk-ingest-workers star.actors:*sys*))
+
+(nhooks:add-hook star:*actors-start-hook* #'start-bulk-ingest-workers-hook)
+
+(defun submit-bulk-ingest-job (documents principal)
+  (unless (start-bulk-ingest-workers)
+    (signal-http-input-error
+     503
+     "bulk_service_unavailable"
+     "Bulk ingest service is not available"))
+  (let ((job
+          (make-bulk-ingest-job
+           :id (cms-ulid:ulid)
+           :principal principal
+           :documents documents
+           :correlation-id (current-correlation-id)
+           :submitted-at (get-universal-time))))
+    (bt:with-lock-held (*bulk-ingest-lock*)
+      (when (>= *bulk-pending-jobs* +bulk-max-pending-jobs+)
+        (signal-http-input-error
+         429
+         "bulk_queue_full"
+         "Bulk ingest queue is full"))
+      (let ((principal-pending
+              (gethash principal *bulk-pending-by-principal* 0)))
+        (when (>= principal-pending +bulk-max-pending-per-principal+)
+          (signal-http-input-error
+           429
+           "principal_bulk_quota_exceeded"
+           "Principal has too many pending bulk jobs"))
+        (incf *bulk-pending-jobs*)
+        (setf (gethash principal *bulk-pending-by-principal*)
+              (1+ principal-pending)))
+      (setf (gethash (bulk-ingest-job-id job) *bulk-ingest-jobs*) job)
+      (let ((worker
+              (nth (mod *bulk-ingest-worker-index*
+                        (length *bulk-ingest-workers*))
+                   *bulk-ingest-workers*)))
+        (incf *bulk-ingest-worker-index*)
+        (handler-case
+            (sento.actor:tell worker job)
+          (error (condition)
+            (decf *bulk-pending-jobs*)
+            (let* ((current
+                     (gethash principal *bulk-pending-by-principal* 0)))
+              (if (> current 1)
+                  (setf (gethash principal *bulk-pending-by-principal*)
+                        (1- current))
+                  (remhash principal *bulk-pending-by-principal*)))
+            (remhash (bulk-ingest-job-id job) *bulk-ingest-jobs*)
+            (log:error "Failed to enqueue bulk job correlation=~a: ~a"
+                       (current-correlation-id)
+                       condition)
+            (signal-http-input-error
+             503
+             "bulk_enqueue_failed"
+             "Bulk ingest job could not be queued")))))
+    job))
+
+(defun bulk-request-mode (document-count)
+  (if (<= document-count +bulk-inline-document-limit+)
+      :inline
+      :async))
+
+(defun process-inline-bulk (documents)
+  (let ((succeeded 0)
+        (failed 0))
+    (bt:with-timeout (+bulk-inline-deadline-seconds+)
+      (loop for document in documents
+            do (handler-case
+                   (progn
+                     (publish-document document)
+                     (incf succeeded))
+                 (error (condition)
+                   (log:error "Inline bulk publish failed correlation=~a: ~a"
+                              (current-correlation-id)
+                              condition)
+                   (incf failed)))))
+    (jsown:to-json
+     (jsown:new-js
+       ("total" (length documents))
+       ("succeeded" succeeded)
+       ("failed" failed)
+       ("correlation_id" (current-correlation-id))))))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (export '(bulk-request-mode
+            execute-bulk-job
+            submit-bulk-ingest-job
+            bulk-ingest-job
+            bulk-ingest-job-status
+            bulk-ingest-job-succeeded
+            bulk-ingest-job-failed)
+          :star.frontends.http-api))

--- a/source/frontends/http-bulk-jobs.lisp
+++ b/source/frontends/http-bulk-jobs.lisp
@@ -118,8 +118,16 @@
 
 (nhooks:add-hook star:*actors-start-hook* #'start-bulk-ingest-workers-hook)
 
-(defun submit-bulk-ingest-job (documents principal)
-  (unless (start-bulk-ingest-workers)
+(defun submit-bulk-ingest-job (documents principal
+                               &key
+                                 (tell-fn #'sento.actor:tell)
+                                 (ensure-workers-fn
+                                   #'start-bulk-ingest-workers))
+  "Reserve bounded queue capacity and enqueue one job without executing it.
+
+TELL-FN and ENSURE-WORKERS-FN are injectable so queue admission and latency can
+be tested independently from actor scheduling."
+  (unless (funcall ensure-workers-fn)
     (signal-http-input-error
      503
      "bulk_service_unavailable"
@@ -154,11 +162,11 @@
                    *bulk-ingest-workers*)))
         (incf *bulk-ingest-worker-index*)
         (handler-case
-            (sento.actor:tell worker job)
+            (funcall tell-fn worker job)
           (error (condition)
             (decf *bulk-pending-jobs*)
-            (let* ((current
-                     (gethash principal *bulk-pending-by-principal* 0)))
+            (let ((current
+                    (gethash principal *bulk-pending-by-principal* 0)))
               (if (> current 1)
                   (setf (gethash principal *bulk-pending-by-principal*)
                         (1- current))

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -37,7 +37,7 @@
                  #:cl-rabbit
                  #:sento
                  #:babel
-                 #:com.inuoe.jzon
+                 #:yason
                  #:uuid
                  #:anypool
                  #:clack

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -25,6 +25,9 @@
                  (:file "actor-systems/matcher-actor")
                  (:file "rabbit")
                  (:file "frontends/http-api")
+                 (:file "frontends/http-boundary-core")
+                 (:file "frontends/http-bulk-jobs")
+                 (:file "frontends/http-boundary-routes")
                  (:file "main"))
 
   :depends-on   (#:starintel
@@ -81,4 +84,3 @@
 ;;;; + [ ] ZMQ api for bulk use
 ;;;;
 ;;;; + [ ] A simpler to use "plugin" system
-;;;;

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -37,6 +37,7 @@
                  #:cl-rabbit
                  #:sento
                  #:babel
+                 #:com.inuoe.jzon
                  #:uuid
                  #:anypool
                  #:clack

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -25,6 +25,7 @@
                                 (:file "couchdb-actor-test")
                                 (:file "event-actor-test")
                                 (:file "dataset-export-test")
+                                (:file "http-boundary-test")
                                 (:file "run-tests"))))
   :perform (test-op (o c)
                      (declare (ignore o c))

--- a/t/http-boundary-test.lisp
+++ b/t/http-boundary-test.lisp
@@ -1,0 +1,232 @@
+(in-package :star-server-tests)
+
+(def-suite http-boundary-tests
+  :description "HTTP boundary validation, safe errors, and bulk backpressure tests")
+
+(in-suite http-boundary-tests)
+
+(defun make-boundary-document (&key (dtype "host")
+                                    (version starintel:+starintel-doc-version+)
+                                    (id "boundary-doc-1"))
+  (jsown:new-js
+    ("_id" id)
+    ("dataset" "boundary-tests")
+    ("dtype" dtype)
+    ("version" version)))
+
+(defun capture-http-input-error (thunk)
+  (handler-case
+      (progn
+        (funcall thunk)
+        nil)
+    (star.frontends.http-api:http-input-error (condition)
+      condition)))
+
+(test jsown-object-is-not-a-bulk-array
+  (let ((object (jsown:new-js ("dtype" "host")))
+        (array (list (jsown:new-js ("dtype" "host")))))
+    (is-true (star.frontends.http-api:json-object-p object))
+    (is-false (star.frontends.http-api:json-array-p object))
+    (is-true (star.frontends.http-api:json-array-p array))))
+
+(test malformed-json-is-a-400-client-error
+  (let ((condition
+          (capture-http-input-error
+           (lambda ()
+             (star.frontends.http-api:parse-json-octets
+              (babel:string-to-octets "{broken" :encoding :utf-8)
+              "application/json")))))
+    (is condition)
+    (is (= 400
+           (star.frontends.http-api:http-input-error-status condition)))
+    (is (string= "malformed_json"
+                 (star.frontends.http-api:http-input-error-code condition)))))
+
+(test non-json-content-type-is-rejected
+  (let ((condition
+          (capture-http-input-error
+           (lambda ()
+             (star.frontends.http-api:parse-json-octets
+              (babel:string-to-octets "{}" :encoding :utf-8)
+              "text/plain")))))
+    (is (= 415
+           (star.frontends.http-api:http-input-error-status condition)))
+    (is (string= "unsupported_media_type"
+                 (star.frontends.http-api:http-input-error-code condition)))))
+
+(test oversized-request-body-is-rejected-before-parsing
+  (let ((condition
+          (capture-http-input-error
+           (lambda ()
+             (star.frontends.http-api:parse-json-octets
+              (make-array 17
+                          :element-type '(unsigned-byte 8)
+                          :initial-element 32)
+              "application/json"
+              :max-bytes 16)))))
+    (is (= 413
+           (star.frontends.http-api:http-input-error-status condition)))
+    (is (string= "request_body_too_large"
+                 (star.frontends.http-api:http-input-error-code condition)))))
+
+(test missing-and-mismatched-dtype-return-422
+  (let* ((missing (make-boundary-document))
+         (mismatch (make-boundary-document :dtype "email")))
+    (jsown:remkey missing "dtype")
+    (let ((missing-condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:validate-document-input
+                missing
+                :path-dtype "host"))))
+          (mismatch-condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:validate-document-input
+                mismatch
+                :path-dtype "host")))))
+      (is (= 422
+             (star.frontends.http-api:http-input-error-status
+              missing-condition)))
+      (is (= 422
+             (star.frontends.http-api:http-input-error-status
+              mismatch-condition)))
+      (is (string= "dtype_mismatch"
+                   (star.frontends.http-api:http-input-error-code
+                    mismatch-condition))))))
+
+(test unsupported-schema-version-is-rejected
+  (let ((condition
+          (capture-http-input-error
+           (lambda ()
+             (star.frontends.http-api:validate-document-input
+              (make-boundary-document :version "999.0")
+              :path-dtype "host")))))
+    (is (= 422
+           (star.frontends.http-api:http-input-error-status condition)))
+    (is (string= "unsupported_schema_version"
+                 (star.frontends.http-api:http-input-error-code condition)))))
+
+(test client-status-envelopes-never-expose-tracebacks
+  (let* ((star.frontends.http-api::*http-correlation-id* "corr-test")
+         (body
+           (star.frontends.http-api::status-msg
+            "Bad Request"
+            'error
+            :code "invalid_request"
+            :traceback "password=super-secret internal stack"))
+         (parsed (jsown:parse body)))
+    (is-false (jsown:keyp parsed "trace"))
+    (is (null (search "super-secret" body :test #'char-equal)))
+    (is (string= "corr-test" (jsown:val parsed "correlation_id")))))
+
+(test numeric-query-validation-is-bounded
+  (dolist (raw '("not-a-number" "0" "101"))
+    (let ((condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:bounded-query-integer
+                (list (cons "limit" raw))
+                "limit"
+                :minimum 1
+                :maximum 100)))))
+      (is (= 400
+             (star.frontends.http-api:http-input-error-status condition)))))
+  (is (= 25
+         (star.frontends.http-api:bounded-query-integer
+          nil
+          "limit"
+          :default 25
+          :minimum 1
+          :maximum 100))))
+
+(test oversized-bulk-selects-asynchronous-dispatch
+  (is (eq :inline
+          (star.frontends.http-api:bulk-request-mode 10)))
+  (is (eq :async
+          (star.frontends.http-api:bulk-request-mode 11))))
+
+(test asynchronous-bulk-submission-does-not-wait-for-worker
+  (let* ((system (sento.actor-system:make-actor-system))
+         (worker
+           (sento.actor-context:actor-of
+            system
+            :name "http-boundary-slow-worker"
+            :receive (lambda (job)
+                       (declare (ignore job))
+                       (sleep 1))))
+         (star.actors:*sys* system)
+         (star.frontends.http-api::*bulk-ingest-workers* (list worker))
+         (star.frontends.http-api::*bulk-ingest-worker-system* system)
+         (star.frontends.http-api::*bulk-ingest-worker-index* 0)
+         (star.frontends.http-api::*bulk-ingest-jobs*
+           (make-hash-table :test #'equal))
+         (star.frontends.http-api::*bulk-pending-jobs* 0)
+         (star.frontends.http-api::*bulk-pending-by-principal*
+           (make-hash-table :test #'equal))
+         (star.frontends.http-api::*bulk-ingest-lock*
+           (bt:make-lock "http-boundary-test-lock"))
+         (star.frontends.http-api::*http-correlation-id* "corr-async")
+         (documents
+           (loop for index below 11
+                 collect
+                 (make-boundary-document
+                  :id (format nil "async-doc-~d" index))))
+         (started (get-internal-real-time)))
+    (unwind-protect
+         (let* ((job
+                  (star.frontends.http-api:submit-bulk-ingest-job
+                   documents
+                   "principal-test"))
+                (elapsed
+                  (/ (- (get-internal-real-time) started)
+                     internal-time-units-per-second)))
+           (is job)
+           (is (< elapsed 0.5))
+           (is (eq :queued
+                   (star.frontends.http-api:bulk-ingest-job-status job))))
+      (sento.actor-context:shutdown system))))
+
+(test per-principal-bulk-quota-is-enforced
+  (let* ((system (sento.actor-system:make-actor-system))
+         (worker
+           (sento.actor-context:actor-of
+            system
+            :name "http-boundary-quota-worker"
+            :receive (lambda (job)
+                       (declare (ignore job))
+                       (sleep 2))))
+         (star.actors:*sys* system)
+         (star.frontends.http-api::*bulk-ingest-workers* (list worker))
+         (star.frontends.http-api::*bulk-ingest-worker-system* system)
+         (star.frontends.http-api::*bulk-ingest-worker-index* 0)
+         (star.frontends.http-api::*bulk-ingest-jobs*
+           (make-hash-table :test #'equal))
+         (star.frontends.http-api::*bulk-pending-jobs* 0)
+         (star.frontends.http-api::*bulk-pending-by-principal*
+           (make-hash-table :test #'equal))
+         (star.frontends.http-api::*bulk-ingest-lock*
+           (bt:make-lock "http-boundary-quota-lock"))
+         (star.frontends.http-api::*http-correlation-id* "corr-quota")
+         (documents (list (make-boundary-document))))
+    (unwind-protect
+         (progn
+           (dotimes (index 4)
+             (declare (ignore index))
+             (star.frontends.http-api:submit-bulk-ingest-job
+              documents
+              "quota-principal"))
+           (let ((condition
+                   (capture-http-input-error
+                    (lambda ()
+                      (star.frontends.http-api:submit-bulk-ingest-job
+                       documents
+                       "quota-principal")))))
+             (is (= 429
+                    (star.frontends.http-api:http-input-error-status
+                     condition)))
+             (is (string=
+                  "principal_bulk_quota_exceeded"
+                  (star.frontends.http-api:http-input-error-code
+                   condition)))))
+      (sento.actor-context:shutdown system))))

--- a/t/http-boundary-test.lisp
+++ b/t/http-boundary-test.lisp
@@ -36,7 +36,7 @@
              (star.frontends.http-api:parse-json-octets
               (babel:string-to-octets "{" :encoding :utf-8)
               "application/json")))))
-    (is condition)
+    (is-true condition)
     (is (= 400
            (star.frontends.http-api:http-input-error-status condition)))
     (is (string= "malformed_json"
@@ -183,7 +183,7 @@
          (elapsed
            (/ (- (get-internal-real-time) started)
               internal-time-units-per-second)))
-    (is job)
+    (is-true job)
     (is (< elapsed 0.5))
     (is (eq :fake-worker sent-worker))
     (is (eq job sent-job))

--- a/t/http-boundary-test.lisp
+++ b/t/http-boundary-test.lisp
@@ -34,7 +34,7 @@
           (capture-http-input-error
            (lambda ()
              (star.frontends.http-api:parse-json-octets
-              (babel:string-to-octets "{broken" :encoding :utf-8)
+              (babel:string-to-octets "{" :encoding :utf-8)
               "application/json")))))
     (is condition)
     (is (= 400
@@ -147,17 +147,13 @@
           (star.frontends.http-api:bulk-request-mode 11))))
 
 (test asynchronous-bulk-submission-does-not-wait-for-worker
-  (let* ((system (sento.actor-system:make-actor-system))
-         (worker
-           (sento.actor-context:actor-of
-            system
-            :name "http-boundary-slow-worker"
-            :receive (lambda (job)
-                       (declare (ignore job))
-                       (sleep 1))))
-         (star.actors:*sys* system)
-         (star.frontends.http-api::*bulk-ingest-workers* (list worker))
-         (star.frontends.http-api::*bulk-ingest-worker-system* system)
+  (let* ((fake-system (list :test-system))
+         (sent-worker nil)
+         (sent-job nil)
+         (star.actors:*sys* fake-system)
+         (star.frontends.http-api::*bulk-ingest-workers*
+           (list :fake-worker))
+         (star.frontends.http-api::*bulk-ingest-worker-system* fake-system)
          (star.frontends.http-api::*bulk-ingest-worker-index* 0)
          (star.frontends.http-api::*bulk-ingest-jobs*
            (make-hash-table :test #'equal))
@@ -172,33 +168,34 @@
                  collect
                  (make-boundary-document
                   :id (format nil "async-doc-~d" index))))
-         (started (get-internal-real-time)))
-    (unwind-protect
-         (let* ((job
-                  (star.frontends.http-api:submit-bulk-ingest-job
-                   documents
-                   "principal-test"))
-                (elapsed
-                  (/ (- (get-internal-real-time) started)
-                     internal-time-units-per-second)))
-           (is job)
-           (is (< elapsed 0.5))
-           (is (eq :queued
-                   (star.frontends.http-api:bulk-ingest-job-status job))))
-      (sento.actor-context:shutdown system))))
+         (started (get-internal-real-time))
+         (job
+           (star.frontends.http-api:submit-bulk-ingest-job
+            documents
+            "principal-test"
+            :ensure-workers-fn
+            (lambda ()
+              star.frontends.http-api::*bulk-ingest-workers*)
+            :tell-fn
+            (lambda (worker queued-job)
+              (setf sent-worker worker
+                    sent-job queued-job))))
+         (elapsed
+           (/ (- (get-internal-real-time) started)
+              internal-time-units-per-second)))
+    (is job)
+    (is (< elapsed 0.5))
+    (is (eq :fake-worker sent-worker))
+    (is (eq job sent-job))
+    (is (eq :queued
+            (star.frontends.http-api:bulk-ingest-job-status job)))))
 
 (test per-principal-bulk-quota-is-enforced
-  (let* ((system (sento.actor-system:make-actor-system))
-         (worker
-           (sento.actor-context:actor-of
-            system
-            :name "http-boundary-quota-worker"
-            :receive (lambda (job)
-                       (declare (ignore job))
-                       (sleep 2))))
-         (star.actors:*sys* system)
-         (star.frontends.http-api::*bulk-ingest-workers* (list worker))
-         (star.frontends.http-api::*bulk-ingest-worker-system* system)
+  (let* ((fake-system (list :test-system))
+         (star.actors:*sys* fake-system)
+         (star.frontends.http-api::*bulk-ingest-workers*
+           (list :fake-worker))
+         (star.frontends.http-api::*bulk-ingest-worker-system* fake-system)
          (star.frontends.http-api::*bulk-ingest-worker-index* 0)
          (star.frontends.http-api::*bulk-ingest-jobs*
            (make-hash-table :test #'equal))
@@ -208,25 +205,30 @@
          (star.frontends.http-api::*bulk-ingest-lock*
            (bt:make-lock "http-boundary-quota-lock"))
          (star.frontends.http-api::*http-correlation-id* "corr-quota")
-         (documents (list (make-boundary-document))))
-    (unwind-protect
-         (progn
-           (dotimes (index 4)
-             (declare (ignore index))
-             (star.frontends.http-api:submit-bulk-ingest-job
-              documents
-              "quota-principal"))
-           (let ((condition
-                   (capture-http-input-error
-                    (lambda ()
-                      (star.frontends.http-api:submit-bulk-ingest-job
-                       documents
-                       "quota-principal")))))
-             (is (= 429
-                    (star.frontends.http-api:http-input-error-status
-                     condition)))
-             (is (string=
-                  "principal_bulk_quota_exceeded"
-                  (star.frontends.http-api:http-input-error-code
-                   condition)))))
-      (sento.actor-context:shutdown system))))
+         (documents (list (make-boundary-document)))
+         (ensure-workers
+           (lambda ()
+             star.frontends.http-api::*bulk-ingest-workers*))
+         (tell-noop
+           (lambda (worker job)
+             (declare (ignore worker job)))))
+    (dotimes (index 4)
+      (declare (ignore index))
+      (star.frontends.http-api:submit-bulk-ingest-job
+       documents
+       "quota-principal"
+       :ensure-workers-fn ensure-workers
+       :tell-fn tell-noop))
+    (let ((condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:submit-bulk-ingest-job
+                documents
+                "quota-principal"
+                :ensure-workers-fn ensure-workers
+                :tell-fn tell-noop)))))
+      (is (= 429
+             (star.frontends.http-api:http-input-error-status condition)))
+      (is (string= "principal_bulk_quota_exceeded"
+                   (star.frontends.http-api:http-input-error-code
+                    condition))))))

--- a/t/run-tests.lisp
+++ b/t/run-tests.lisp
@@ -8,7 +8,8 @@
     system-load-tests
     couchdb-actor-tests
     event-actor-tests
-    dataset-export-tests))
+    dataset-export-tests
+    http-boundary-tests))
 
 (defun run-all-gserver-tests ()
   "Run every hermetic unit suite and fail on empty, skipped, or failed tests."

--- a/t/test-runner.lisp
+++ b/t/test-runner.lisp
@@ -95,18 +95,19 @@
 
 (defun run-required-suite (suite-name &key setup teardown)
   (let ((discovered (suite-test-names suite-name))
-        (summary nil))
+        (summary nil)
+        (results nil))
     (when (zerop (length discovered))
       (error "Required suite ~a discovered zero tests." suite-name))
     (unwind-protect
          (progn
            (when setup
              (funcall setup))
-           (setf summary
-                 (summarize-suite suite-name
-                                  discovered
-                                  (fiveam:run suite-name)))
+           (setf results (fiveam:run suite-name)
+                 summary (summarize-suite suite-name discovered results))
            (print-suite-summary summary)
+           (when (plusp (suite-summary-failed summary))
+             (fiveam:explain! results))
            (validate-required-suite summary))
       (when teardown
         (funcall teardown)))


### PR DESCRIPTION
## What changed

- add one HTTP boundary layer for content type, body size, JSON parsing, JSON shape, required document fields, schema version, dtype/path agreement, and bounded numeric query parameters
- return structured client-safe errors with correlation IDs while logging full internal conditions server-side
- remove traceback and raw condition details from response envelopes
- distinguish JSOWN objects from JSON arrays before bulk validation
- retain fast inline handling for small batches under a strict request deadline
- return `202 Accepted` for larger bulk requests and dispatch them to a bounded actor worker pool
- enforce global pending-job and per-principal pending-job quotas
- expose a bulk job status endpoint
- add hermetic coverage for malformed JSON, media type, body size, dtype mismatch, schema version, safe errors, numeric bounds, asynchronous return time, and principal quotas

## Root cause

The API parsed and classified request data independently in each route. JSON parsing could escape local handlers, JSOWN objects passed the bulk `listp` check, path dtype was not reconciled with document dtype, raw conditions were copied into client responses, and a large bulk request published every document synchronously on one HTTP worker.

## Validation

The new hermetic suite exercises the boundary contract without RabbitMQ or CouchDB. Full unit, integration, schema-lock, and container validation is delegated to repository CI.

Fixes #25