### PR TITLE
Implement authenticated request context and API-key lifecycle

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,8 +23,17 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
-      - name: Run image, health, FTS, and persistence tests
+      - name: Run image, health, authentication, FTS, and persistence tests
         run: ./scripts/stack-test.sh
+
+      - name: Upload sanitized stack diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stack-test-diagnostics
+          path: stack-test-artifacts/
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Publish images
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,9 +99,16 @@ services:
       RABBITMQ_USER: ${RABBITMQ_USER:-starintel}
       RABBITMQ_PASSWORD_FILE: /run/secrets/rabbitmq_password
       HTTP_API_LISTEN_ADDRESS: 0.0.0.0
+      STAR_AUTH_MODE: api-key
+      STAR_AUTH_DATABASE: ${STAR_AUTH_DATABASE:-starintel-gserver-auth}
+      STAR_AUTH_PEPPER_FILE: /run/secrets/auth_pepper
+      STAR_AUTH_BOOTSTRAP_SECRET_FILE: /run/secrets/auth_bootstrap_secret
+      STAR_AUTH_ALLOWED_ORIGINS: ${STAR_AUTH_ALLOWED_ORIGINS:-}
     secrets:
       - couchdb_password
       - rabbitmq_password
+      - auth_pepper
+      - auth_bootstrap_secret
     ports:
       - "${STAR_SERVER_BIND_ADDRESS:-127.0.0.1}:${STAR_SERVER_PORT:-5000}:5000"
     networks:
@@ -127,6 +134,10 @@ secrets:
     file: ${CREDENTIALS_DIR:-./secrets}/erlang_cookie
   rabbitmq_password:
     file: ${CREDENTIALS_DIR:-./secrets}/rabbitmq_password
+  auth_pepper:
+    file: ${CREDENTIALS_DIR:-./secrets}/auth_pepper
+  auth_bootstrap_secret:
+    file: ${CREDENTIALS_DIR:-./secrets}/auth_bootstrap_secret
 
 volumes:
   clouseau_index:

--- a/docker/star-server-entrypoint.sh
+++ b/docker/star-server-entrypoint.sh
@@ -7,13 +7,23 @@ load_secret() {
   eval "file=\${$file_variable:-}"
 
   if [ -n "$file" ]; then
+    if [ ! -r "$file" ]; then
+      printf '%s\n' "Secret file for ${name} is not readable: ${file}" >&2
+      exit 1
+    fi
     value="$(cat "$file")"
+    if [ -z "$value" ]; then
+      printf '%s\n' "Secret file for ${name} is empty: ${file}" >&2
+      exit 1
+    fi
     export "$name=$value"
   fi
 }
 
 load_secret COUCHDB_PASSWORD
 load_secret RABBITMQ_PASSWORD
+load_secret STAR_AUTH_PEPPER
+load_secret STAR_AUTH_BOOTSTRAP_SECRET
 
 exec su-exec 65532:65532 \
   /bin/star-server start -i /etc/starintel/init.lisp

--- a/docker/star-server-init.lisp
+++ b/docker/star-server-init.lisp
@@ -1,14 +1,47 @@
 (in-package :star)
 
-(setf *couchdb-host* (or (uiop:getenv "COUCHDB_HOST") *couchdb-host*)
+(setf *couchdb-host*
+      (or (uiop:getenv "COUCHDB_HOST") *couchdb-host*)
       *couchdb-default-database*
       (or (uiop:getenv "COUCHDB_DATABASE") *couchdb-default-database*)
-      *couchdb-user* (or (uiop:getenv "COUCHDB_USER") *couchdb-user*)
+      *couchdb-auth-database*
+      (or (uiop:getenv "STAR_AUTH_DATABASE") *couchdb-auth-database*)
+      *couchdb-user*
+      (or (uiop:getenv "COUCHDB_USER") *couchdb-user*)
       *couchdb-password*
       (or (uiop:getenv "COUCHDB_PASSWORD") *couchdb-password*)
-      *rabbit-address* (or (uiop:getenv "RABBITMQ_ADDRESS") *rabbit-address*)
-      *rabbit-user* (or (uiop:getenv "RABBITMQ_USER") *rabbit-user*)
+      *rabbit-address*
+      (or (uiop:getenv "RABBITMQ_ADDRESS") *rabbit-address*)
+      *rabbit-user*
+      (or (uiop:getenv "RABBITMQ_USER") *rabbit-user*)
       *rabbit-password*
       (or (uiop:getenv "RABBITMQ_PASSWORD") *rabbit-password*)
       *http-api-address*
-      (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") *http-api-address*))
+      (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") *http-api-address*)
+      *http-cors-allowed-origins*
+      (or (split-comma-setting (uiop:getenv "STAR_AUTH_ALLOWED_ORIGINS"))
+          *http-cors-allowed-origins*)
+      *auth-mode*
+      (or (uiop:getenv "STAR_AUTH_MODE") *auth-mode*)
+      *auth-pepper*
+      (or (uiop:getenv "STAR_AUTH_PEPPER") *auth-pepper*)
+      *auth-bootstrap-secret*
+      (or (uiop:getenv "STAR_AUTH_BOOTSTRAP_SECRET")
+          *auth-bootstrap-secret*)
+      *auth-dev-bypass*
+      (not (null
+            (environment-boolean
+             "STAR_AUTH_DEV_BYPASS"
+             *auth-dev-bypass*)))
+      *auth-rotation-overlap-max-seconds*
+      (environment-integer
+       "STAR_AUTH_MAX_ROTATION_OVERLAP_SECONDS"
+       *auth-rotation-overlap-max-seconds*)
+      *auth-default-request-timeout-ms*
+      (environment-integer
+       "STAR_AUTH_DEFAULT_REQUEST_TIMEOUT_MS"
+       *auth-default-request-timeout-ms*)
+      *auth-max-request-timeout-ms*
+      (environment-integer
+       "STAR_AUTH_MAX_REQUEST_TIMEOUT_MS"
+       *auth-max-request-timeout-ms*))

--- a/docs/http-authentication-runtime.org
+++ b/docs/http-authentication-runtime.org
@@ -1,0 +1,362 @@
+#+title: HTTP API-key authentication runtime
+#+options: toc:3
+
+* Status
+
+StarIntel Server protects every HTTP route by default except:
+
+- =GET /health=;
+- =GET /=;
+- =POST /auth/bootstrap=.
+
+The runtime uses opaque API keys, an immutable request security context, a
+separate CouchDB authentication database, exact-origin CORS configuration, and
+uniform authentication failures.
+
+The broader security model is defined in:
+
+- [[file:http-auth-threat-model.org][HTTP authentication threat model]];
+- [[file:http-principal-capability-contract.org][principal and capability contract]];
+- [[file:http-auth-kv-lease-boundary.org][KV lease authentication boundary]].
+
+This implementation establishes identity and administrator lifecycle controls.
+Fine-grained route capability and resource-scope enforcement remains follow-on
+work. Until that enforcement lands, any valid non-administrator key can reach
+ordinary protected routes; lifecycle mutation routes require an administrator
+principal or =admin= scope.
+
+* Credential format
+
+The v0.1 API key has this shape:
+
+#+begin_example
+star_sk_v1_<credential-id>_<secret>
+#+end_example
+
+- =credential-id= is a non-secret ULID used for record lookup;
+- =secret= is 32 random bytes represented as 64 hexadecimal characters;
+- the full key is bearer material and must be protected like a password;
+- unsupported prefixes, versions, malformed fields, unknown identifiers, and
+  incorrect secrets all return the same external authentication failure.
+
+The server stores no recoverable API-key secret. A credential record contains:
+
+- credential identifier;
+- owner and principal type;
+- scope strings;
+- status;
+- random salt;
+- salted and peppered verifier;
+- creation and optional expiry timestamps;
+- disable and revocation timestamps;
+- rotation parent, successor, and overlap expiration metadata;
+- CouchDB revision metadata.
+
+Credential records live in =STAR_AUTH_DATABASE=, not in the intelligence
+document database. General document, search, export, and graph routes do not read
+the authentication database.
+
+* Hashing and comparison
+
+The verifier is derived from:
+
+#+begin_example
+SHA-256(server-pepper || credential-salt || random-secret)
+#+end_example
+
+The implementation uses a constant-time comparison function at the verifier
+boundary. The server pepper is loaded separately from CouchDB and is never stored
+in a credential record.
+
+This SHA-256 construction is the implemented v0.1 verifier, not the final
+memory-hard Argon2id design described by the threat model. Migrating verifier
+algorithms requires a versioned credential-record format and rehash/rotation
+path.
+
+* Request authentication
+
+Send the key as a bearer token:
+
+#+begin_example
+Authorization: Bearer star_sk_v1_<credential-id>_<secret>
+#+end_example
+
+A valid request creates one immutable security context containing:
+
+- principal identifier;
+- principal type;
+- non-secret credential identifier;
+- scope strings;
+- correlation identifier;
+- request deadline;
+- authentication timestamp.
+
+The context is propagated into asynchronous bulk jobs. RabbitMQ publication
+receives only non-secret provenance fields: principal identifier and type,
+credential identifier, scopes, correlation identifier, and deadline. Raw bearer
+material, verifier data, salts, and the server pepper are never propagated.
+
+Clients may provide a bounded =X-Correlation-ID=. The server generates one when
+it is missing or invalid.
+
+Clients may provide =X-Request-Timeout-Ms=. Values outside the configured bound
+fall back to the server default rather than creating an unbounded deadline.
+
+* Uniform authentication failure
+
+Every missing, malformed, unknown, incorrect, expired, disabled, revoked, or
+rotation-expired credential returns:
+
+#+begin_src json
+{
+  "status": "error",
+  "code": "invalid_credential",
+  "msg": "Authentication failed",
+  "correlation_id": "..."
+}
+#+end_src
+
+The status is =401=. The response includes =WWW-Authenticate= and
+=Cache-Control: no-store=. It does not reveal whether the credential identifier
+exists or which internal check failed.
+
+* Bootstrap
+
+Bootstrap creates the first administrator credential and is allowed only while
+the authentication store is empty.
+
+Request:
+
+#+begin_example
+POST /auth/bootstrap
+Content-Type: application/json
+X-Star-Bootstrap-Secret: <one-time deployment secret>
+
+{"owner":"initial-administrator"}
+#+end_example
+
+The bootstrap secret is configured through =STAR_AUTH_BOOTSTRAP_SECRET= or
+=STAR_AUTH_BOOTSTRAP_SECRET_FILE=. A constant-time digest comparison checks the
+presented value.
+
+A successful response has status =201= and returns the API key exactly once:
+
+#+begin_src json
+{
+  "api_key": "star_sk_v1_...",
+  "credential": {
+    "credential_id": "...",
+    "owner": "initial-administrator",
+    "principal_type": "administrator",
+    "scopes": ["admin"],
+    "status": "active"
+  },
+  "correlation_id": "..."
+}
+#+end_src
+
+The response is marked =Cache-Control: no-store= and =Pragma: no-cache=.
+
+A second bootstrap attempt returns =409 bootstrap_complete=. An invalid
+bootstrap secret returns =403 bootstrap_denied=. Neither response returns secret
+or verifier material.
+
+* Credential lifecycle routes
+
+All lifecycle routes below require an authenticated administrator principal or a
+credential with =admin= scope.
+
+** Create
+
+#+begin_example
+POST /auth/credentials
+Authorization: Bearer <administrator-key>
+Content-Type: application/json
+
+{
+  "owner": "quasar-production",
+  "principal_type": "api_client",
+  "scopes": ["documents:read", "documents:write", "search:read"],
+  "expires_in_seconds": 2592000
+}
+#+end_example
+
+The successful =201= response returns the new API key exactly once and includes
+redacted metadata.
+
+** List metadata
+
+#+begin_example
+GET /auth/credentials
+Authorization: Bearer <administrator-key>
+#+end_example
+
+The response contains metadata only. It never contains raw keys, verifier bytes,
+salts, or the pepper.
+
+** Rotate
+
+#+begin_example
+POST /auth/credentials/<credential-id>/rotate
+Authorization: Bearer <administrator-key>
+Content-Type: application/json
+
+{"overlap_seconds":300}
+#+end_example
+
+Rotation creates a distinct credential and returns its secret exactly once. The
+old credential remains valid until the overlap expiration, then fails with the
+same uniform =401 invalid_credential= response. The maximum overlap is bounded by
+=STAR_AUTH_MAX_ROTATION_OVERLAP_SECONDS=.
+
+An overlap of zero invalidates the old credential immediately after the rotation
+record is committed.
+
+** Revoke
+
+#+begin_example
+POST /auth/credentials/<credential-id>/revoke
+Authorization: Bearer <administrator-key>
+#+end_example
+
+Revocation is permanent for the credential identifier.
+
+** Disable
+
+#+begin_example
+POST /auth/credentials/<credential-id>/disable
+Authorization: Bearer <administrator-key>
+#+end_example
+
+Disabled credentials cannot authenticate. Re-enable is intentionally not
+implemented in this lifecycle surface.
+
+** Inspect current context
+
+#+begin_example
+GET /auth/context
+Authorization: Bearer <api-key>
+#+end_example
+
+The response returns the current non-secret principal, credential, scopes,
+correlation identifier, and deadline. It is intended for client verification and
+diagnostics.
+
+* Revocation cache bound
+
+The v0.1 implementation has no successful-credential or authorization cache.
+Every authenticated request reads the current credential record from the
+configured store.
+
+Therefore the documented cache bound is:
+
+#+begin_example
+0 seconds
+#+end_example
+
+Once a revocation or disable update commits, the next verifier lookup observes
+it. An already-running request that authenticated before the update retains its
+immutable request context for that request only. Concurrent tests verify that
+requests released after the revocation commit are rejected.
+
+Adding a cache later is a security-contract change. It requires a bounded TTL,
+immediate invalidation, concurrency tests, and an updated documented revocation
+bound.
+
+* Bulk jobs and service calls
+
+Large bulk requests capture the authenticated service context when the job is
+accepted. Worker execution uses that captured context rather than ambient
+unauthenticated state.
+
+Bulk-job status is visible only to:
+
+- the principal that submitted the job; or
+- an administrator.
+
+Other principals receive =404 bulk_job_not_found= so job existence is not
+exposed.
+
+The repository does not yet contain a KV lease adapter. The same service-call
+context is the required input projection for future target-lease operations; a
+future adapter must not infer authority from process location or a missing
+context.
+
+* CORS
+
+Wildcard CORS is removed. Configure exact browser origins with a comma-separated
+list:
+
+#+begin_example
+STAR_AUTH_ALLOWED_ORIGINS=https://quasar.example,https://admin.example
+#+end_example
+
+For an allowed origin, the server returns that exact origin and =Vary: Origin=.
+Credential-bearing wildcard origins are never emitted.
+
+A preflight from an unconfigured origin returns =403 cors_origin_denied=. Requests
+without an =Origin= header, such as normal CLI or service clients, are unaffected
+by browser CORS policy and still require authentication.
+
+* Configuration
+
+| Environment variable | Default | Purpose |
+|----------------------+---------+---------|
+| =STAR_AUTH_MODE= | =api-key= | Authentication mode. Supported: =api-key= and constrained development =disabled=. |
+| =STAR_AUTH_DATABASE= | =starintel-gserver-auth= | Separate CouchDB credential database. |
+| =STAR_AUTH_PEPPER= | none | Server-side verifier pepper. |
+| =STAR_AUTH_PEPPER_FILE= | none | File containing the verifier pepper. |
+| =STAR_AUTH_BOOTSTRAP_SECRET= | none | One-time bootstrap secret. |
+| =STAR_AUTH_BOOTSTRAP_SECRET_FILE= | none | File containing the bootstrap secret. |
+| =STAR_AUTH_ALLOWED_ORIGINS= | empty | Comma-separated exact browser origins. |
+| =STAR_AUTH_DEV_BYPASS= | false | Explicit development bypass flag. |
+| =STAR_AUTH_MAX_ROTATION_OVERLAP_SECONDS= | =86400= | Maximum old/new key overlap. |
+| =STAR_AUTH_DEFAULT_REQUEST_TIMEOUT_MS= | =30000= | Default propagated request deadline. |
+| =STAR_AUTH_MAX_REQUEST_TIMEOUT_MS= | =600000= | Maximum accepted client timeout. |
+| =COUCHDB_PASSWORD_FILE= | none | Runtime-readable CouchDB password file. |
+| =RABBITMQ_PASSWORD_FILE= | none | Runtime-readable RabbitMQ password file. |
+
+Production =api-key= mode refuses to initialize without a non-empty pepper.
+Unknown modes refuse startup.
+
+Authentication may be disabled only when all implemented checks pass:
+
+- =STAR_AUTH_MODE=disabled=;
+- =STAR_AUTH_DEV_BYPASS=true=;
+- the HTTP listener is loopback (=localhost=, =127.0.0.1=, or =::1=).
+
+A disabled-auth configuration on =0.0.0.0= fails startup.
+
+* Container deployment
+
+The Compose stack mounts these additional secrets into the server:
+
+- =auth_pepper=;
+- =auth_bootstrap_secret=.
+
+The stack test proves:
+
+- public health remains available;
+- unauthenticated protected access returns =401=;
+- bootstrap returns one administrator key;
+- bootstrap cannot run twice;
+- authenticated context resolves the expected administrator;
+- authenticated full-text search works;
+- the intelligence document persists across restart;
+- the administrator credential persists in the separate auth database and still
+  authenticates after restart.
+
+* Operational rules
+
+- Never commit, log, paste into issue comments, or store complete API keys in
+  StarIntel documents.
+- Capture the one-time key response into a secret manager immediately.
+- Use distinct principals and credentials per service and environment.
+- Prefer narrow scopes even though fine-grained route authorization is not yet
+  enforced; the stored grants are the migration basis for that enforcement.
+- Rotate a suspected credential, use the shortest safe overlap, then revoke the
+  old identifier.
+- Treat a lost key as unrecoverable; create or rotate instead of attempting to
+  read the secret from storage.
+- Protect CouchDB and the auth database from direct untrusted network access.
+- Protect the server pepper independently from CouchDB backups.

--- a/docs/index.org
+++ b/docs/index.org
@@ -19,27 +19,30 @@ the corresponding controls are implemented.
 5. [[file:messaging.org][Messaging]] — understand routing, delivery, recursion, and loop control.
 6. [[file:configuration.org][Configuration]] — configure local, container, remote, and tuned deployments.
 7. [[file:http-api-docs.org][HTTP API]] — call the service.
-8. [[file:../DOCKER.md][Docker/Nix stack]] and [[file:testing.md][testing]] — operate and verify it.
-9. [[file:http-auth-threat-model.org][HTTP authentication threat model]] — protected assets, attackers, boundaries, controls, failures, and residual risks. Design only.
-10. [[file:http-auth-kv-lease-boundary.org][KV lease authentication boundary]] — target-lease assets, atomic ownership, fencing, replay controls, and the KV trust boundary. Normative threat-model section; design only.
-11. [[file:http-principal-capability-contract.org][HTTP principal and capability contract]] — principal classes, credentials, capabilities, scopes, decisions, and route mapping. Design only.
+8. [[file:http-authentication-runtime.org][HTTP authentication runtime]] — bootstrap, API-key lifecycle, CORS, request context, revocation behavior, and deployment.
+9. [[file:../DOCKER.md][Docker/Nix stack]] and [[file:testing.md][testing]] — operate and verify it.
+10. [[file:http-auth-threat-model.org][HTTP authentication threat model]] — protected assets, attackers, boundaries, controls, failures, and residual risks. Design contract.
+11. [[file:http-auth-kv-lease-boundary.org][KV lease authentication boundary]] — target-lease assets, atomic ownership, fencing, replay controls, and the KV trust boundary. Normative design contract.
+12. [[file:http-principal-capability-contract.org][HTTP principal and capability contract]] — principal classes, credentials, capabilities, scopes, decisions, and route mapping. Design contract.
 
 ** Implementation status
 
 | Area | Status | Notes |
 |------+--------+-------|
-| CouchDB database initialization | Active | Creates main and actor-event databases; upserts design documents |
+| CouchDB database initialization | Active | Creates main, actor-event, and separate authentication databases; upserts required design documents |
 | RabbitMQ document ingest | Active | =documents.ingest.#= |
 | RabbitMQ update ingest | Active | =documents.updated.#=; partial deep merge and conflict retry |
 | Target routing | Active | Local Sento actor or =actors.<name>.new.target= |
 | Actor event storage | Active | Local receiver and separate =events= exchange consumer |
-| HTTP API | Active | No authentication; CORS allows every origin |
-| HTTP authentication threat model | Design | Contract, principal/capability model, and KV lease boundary are checked in; runtime enforcement is not implemented |
-| Clouseau full-text search | Active in Compose | Search endpoint uses CouchDB FTS design document |
+| HTTP API-key authentication | Active | Default-deny bearer authentication, immutable request context, lifecycle routes, exact-origin CORS, and separate credential storage |
+| Fine-grained route authorization | Not implemented | Stored scopes exist, but ordinary protected routes do not yet enforce capability/resource policy beyond administrator lifecycle routes and bulk-job ownership |
+| Authentication revocation cache | Active | No credential cache; committed revoke/disable is visible to the next verifier lookup |
+| KV target leases | Design only | No KV lease adapter exists; authenticated service context is propagated for future integration |
+| Clouseau full-text search | Active in Compose | Search endpoint uses CouchDB FTS design document and now requires authentication |
 | URL extractor pattern | Experimental | Actor starts; complete global pattern dispatcher is not evident |
 | User-finder/user-hunt actors | Present, inactive | Files are not in the ASDF component list |
 | HTTP event endpoint | Stub | =/new/event/:id= has no implementation |
-| Strict StarIntel 0.9 ingest validation | Not wired | Validators exist in =star-cl=, but HTTP/Rabbit ingest accepts raw JSON |
+| Strict StarIntel 0.9 ingest validation | Partially wired | HTTP boundary validates required envelope fields and schema version; Rabbit ingest remains a separate boundary |
 
 ** Source-of-truth rule
 

--- a/scripts/stack-test.sh
+++ b/scripts/stack-test.sh
@@ -3,8 +3,12 @@ set -Eeuo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 credentials_dir="$(mktemp -d)"
+artifact_dir="${repo_root}/stack-test-artifacts"
 project_name="starintel-auth-stack-$$"
 port_base=$((20000 + $$ % 20000))
+stage="initialize"
+failure_line=""
+failure_status="0"
 
 export CREDENTIALS_DIR="$credentials_dir"
 export COMPOSE_PROJECT_NAME="$project_name"
@@ -13,16 +17,50 @@ export COUCHDB_PORT="$((port_base + 1))"
 export RABBITMQ_PORT="$((port_base + 2))"
 export RABBITMQ_MANAGEMENT_PORT="$((port_base + 3))"
 
-couchdb_password="stack-couchdb-$$"
-rabbitmq_password="stack-rabbitmq-$$"
-auth_pepper="stack-auth-pepper-$$-$(date +%s%N)"
-auth_bootstrap_secret="stack-bootstrap-$$-$(date +%s%N)"
+mkdir -p "$artifact_dir"
+rm -f "$artifact_dir"/*
+
+set_stage() {
+  stage="$1"
+  printf 'stage=%s\nstatus=running\n' "$stage" > "$artifact_dir/status.txt"
+  printf '==> %s\n' "$stage"
+}
+
+record_error() {
+  failure_status="$?"
+  failure_line="$1"
+  return "$failure_status"
+}
+trap 'record_error "$LINENO"' ERR
+
+capture_diagnostics() {
+  {
+    printf 'stage=%s\n' "$stage"
+    printf 'status=failed\n'
+    printf 'exit_status=%s\n' "$failure_status"
+    printf 'line=%s\n' "$failure_line"
+  } > "$artifact_dir/status.txt"
+
+  docker compose --project-directory "$repo_root" ps --all \
+    > "$artifact_dir/compose-ps.txt" 2>&1 || true
+  docker compose --project-directory "$repo_root" logs --no-color star-server \
+    > "$artifact_dir/star-server.log" 2>&1 || true
+  docker compose --project-directory "$repo_root" logs --no-color couchdb \
+    > "$artifact_dir/couchdb.log" 2>&1 || true
+}
 
 cleanup() {
   status=$?
   if ((status != 0)); then
-    docker compose --project-directory "$repo_root" ps || true
-    docker compose --project-directory "$repo_root" logs --no-color || true
+    if ((failure_status == 0)); then
+      failure_status="$status"
+    fi
+    capture_diagnostics
+    cat "$artifact_dir/status.txt" >&2 || true
+    cat "$artifact_dir/compose-ps.txt" >&2 || true
+    tail -n 200 "$artifact_dir/star-server.log" >&2 || true
+  else
+    printf 'stage=complete\nstatus=passed\n' > "$artifact_dir/status.txt"
   fi
   docker compose --project-directory "$repo_root" down \
     --volumes --remove-orphans >/dev/null 2>&1 || true
@@ -31,6 +69,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
+couchdb_password="stack-couchdb-$$"
+rabbitmq_password="stack-rabbitmq-$$"
+auth_pepper="stack-auth-pepper-$$-$(date +%s%N)"
+auth_bootstrap_secret="stack-bootstrap-$$-$(date +%s%N)"
+
+set_stage "write-secrets"
 printf '%s\n' "$couchdb_password" > "$credentials_dir/couchdb_password"
 printf '%s\n' "stack-couchdb-secret-$$" > "$credentials_dir/couchdb_secret"
 printf '%s\n' "STACKERLANGCOOKIE$$" > "$credentials_dir/erlang_cookie"
@@ -41,8 +85,13 @@ chmod 0600 "$credentials_dir"/*
 
 cd "$repo_root"
 
+set_stage "load-images"
 nix run .#load-images
+
+set_stage "validate-compose"
 docker compose config --quiet
+
+set_stage "start-stack"
 docker compose up --detach --wait --wait-timeout 300
 
 fixture_id="auth-stack-fixture"
@@ -50,6 +99,7 @@ fixture_term="authstacksearchfixture"
 couchdb_url="http://127.0.0.1:${COUCHDB_PORT}"
 server_url="http://127.0.0.1:${STAR_SERVER_PORT}"
 
+set_stage "bootstrap-administrator"
 bootstrap_response="$(
   curl --fail --silent --show-error \
     --request POST \
@@ -62,6 +112,7 @@ api_key="$(jq --exit-status --raw-output '.api_key' <<<"$bootstrap_response")"
 [[ "$api_key" == star_sk_v1_* ]]
 auth_header="Authorization: Bearer ${api_key}"
 
+set_stage "verify-unauthenticated-denial"
 unauthenticated_status="$(
   curl --silent --output /dev/null --write-out '%{http_code}' \
     --get --data-urlencode "q=content:${fixture_term}" \
@@ -69,6 +120,7 @@ unauthenticated_status="$(
 )"
 [[ "$unauthenticated_status" == "401" ]]
 
+set_stage "verify-one-time-bootstrap"
 second_bootstrap_status="$(
   curl --silent --output /dev/null --write-out '%{http_code}' \
     --request POST \
@@ -79,6 +131,7 @@ second_bootstrap_status="$(
 )"
 [[ "$second_bootstrap_status" == "409" ]]
 
+set_stage "verify-authenticated-context"
 curl --fail --silent --show-error \
   --header "$auth_header" \
   "${server_url}/auth/context" |
@@ -86,6 +139,7 @@ curl --fail --silent --show-error \
     '.principal_id == "stack-administrator" and .principal_type == "administrator"' \
     >/dev/null
 
+set_stage "insert-search-fixture"
 curl --fail --silent --show-error \
   --user "${COUCHDB_USER:-admin}:${couchdb_password}" \
   --request PUT \
@@ -141,21 +195,28 @@ wait_for_healthy_stack() {
   return 1
 }
 
+set_stage "verify-authenticated-search"
 wait_for_search
 
+set_stage "restart-stack"
 docker compose restart
+
+set_stage "wait-after-restart"
 wait_for_healthy_stack
 
+set_stage "verify-document-persistence"
 curl --fail --silent --show-error \
   --user "${COUCHDB_USER:-admin}:${couchdb_password}" \
   "${couchdb_url}/${COUCHDB_DATABASE:-starintel}/${fixture_id}" |
   jq --exit-status --arg term "$fixture_term" '.content == $term' >/dev/null
 
+set_stage "verify-credential-persistence"
 curl --fail --silent --show-error \
   --header "$auth_header" \
   "${server_url}/auth/context" |
   jq --exit-status '.principal_id == "stack-administrator"' >/dev/null
 
+set_stage "verify-search-after-restart"
 wait_for_search
 
 printf 'Authenticated Nix-built stack passed bootstrap, denial, FTS, and restart persistence checks.\n'

--- a/scripts/stack-test.sh
+++ b/scripts/stack-test.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 credentials_dir="$(mktemp -d)"
-project_name="starintel-issue55-$$"
+project_name="starintel-auth-stack-$$"
 port_base=$((20000 + $$ % 20000))
 
 export CREDENTIALS_DIR="$credentials_dir"
@@ -13,8 +13,10 @@ export COUCHDB_PORT="$((port_base + 1))"
 export RABBITMQ_PORT="$((port_base + 2))"
 export RABBITMQ_MANAGEMENT_PORT="$((port_base + 3))"
 
-couchdb_password="issue55-couchdb-$$"
-rabbitmq_password="issue55-rabbitmq-$$"
+couchdb_password="stack-couchdb-$$"
+rabbitmq_password="stack-rabbitmq-$$"
+auth_pepper="stack-auth-pepper-$$-$(date +%s%N)"
+auth_bootstrap_secret="stack-bootstrap-$$-$(date +%s%N)"
 
 cleanup() {
   status=$?
@@ -30,9 +32,11 @@ cleanup() {
 trap cleanup EXIT
 
 printf '%s\n' "$couchdb_password" > "$credentials_dir/couchdb_password"
-printf '%s\n' "issue55-couchdb-secret-$$" > "$credentials_dir/couchdb_secret"
-printf '%s\n' "ISSUE55ERLANGCOOKIE$$" > "$credentials_dir/erlang_cookie"
+printf '%s\n' "stack-couchdb-secret-$$" > "$credentials_dir/couchdb_secret"
+printf '%s\n' "STACKERLANGCOOKIE$$" > "$credentials_dir/erlang_cookie"
 printf '%s\n' "$rabbitmq_password" > "$credentials_dir/rabbitmq_password"
+printf '%s\n' "$auth_pepper" > "$credentials_dir/auth_pepper"
+printf '%s\n' "$auth_bootstrap_secret" > "$credentials_dir/auth_bootstrap_secret"
 chmod 0600 "$credentials_dir"/*
 
 cd "$repo_root"
@@ -41,10 +45,46 @@ nix run .#load-images
 docker compose config --quiet
 docker compose up --detach --wait --wait-timeout 300
 
-fixture_id="issue-55-fixture"
-fixture_term="issue55searchfixture"
+fixture_id="auth-stack-fixture"
+fixture_term="authstacksearchfixture"
 couchdb_url="http://127.0.0.1:${COUCHDB_PORT}"
 server_url="http://127.0.0.1:${STAR_SERVER_PORT}"
+
+bootstrap_response="$(
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --header "X-Star-Bootstrap-Secret: ${auth_bootstrap_secret}" \
+    --data '{"owner":"stack-administrator"}' \
+    "${server_url}/auth/bootstrap"
+)"
+api_key="$(jq --exit-status --raw-output '.api_key' <<<"$bootstrap_response")"
+[[ "$api_key" == star_sk_v1_* ]]
+auth_header="Authorization: Bearer ${api_key}"
+
+unauthenticated_status="$(
+  curl --silent --output /dev/null --write-out '%{http_code}' \
+    --get --data-urlencode "q=content:${fixture_term}" \
+    "${server_url}/search"
+)"
+[[ "$unauthenticated_status" == "401" ]]
+
+second_bootstrap_status="$(
+  curl --silent --output /dev/null --write-out '%{http_code}' \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --header "X-Star-Bootstrap-Secret: ${auth_bootstrap_secret}" \
+    --data '{"owner":"second-administrator"}' \
+    "${server_url}/auth/bootstrap"
+)"
+[[ "$second_bootstrap_status" == "409" ]]
+
+curl --fail --silent --show-error \
+  --header "$auth_header" \
+  "${server_url}/auth/context" |
+  jq --exit-status \
+    '.principal_id == "stack-administrator" and .principal_type == "administrator"' \
+    >/dev/null
 
 curl --fail --silent --show-error \
   --user "${COUCHDB_USER:-admin}:${couchdb_password}" \
@@ -58,6 +98,7 @@ wait_for_search() {
   for _ in $(seq 1 60); do
     response="$(
       curl --fail --silent --show-error \
+        --header "$auth_header" \
         --get --data-urlencode "q=content:${fixture_term}" \
         "${server_url}/search" || true
     )"
@@ -67,7 +108,7 @@ wait_for_search() {
     fi
     sleep 2
   done
-  printf 'fixture did not appear in full-text search\n' >&2
+  printf 'fixture did not appear in authenticated full-text search\n' >&2
   return 1
 }
 
@@ -110,6 +151,11 @@ curl --fail --silent --show-error \
   "${couchdb_url}/${COUCHDB_DATABASE:-starintel}/${fixture_id}" |
   jq --exit-status --arg term "$fixture_term" '.content == $term' >/dev/null
 
+curl --fail --silent --show-error \
+  --header "$auth_header" \
+  "${server_url}/auth/context" |
+  jq --exit-status '.principal_id == "stack-administrator"' >/dev/null
+
 wait_for_search
 
-printf 'Nix-built Compose stack passed health, FTS, and restart persistence checks.\n'
+printf 'Authenticated Nix-built stack passed bootstrap, denial, FTS, and restart persistence checks.\n'

--- a/source/auth/core.lisp
+++ b/source/auth/core.lisp
@@ -1,0 +1,469 @@
+(in-package :star.auth)
+
+(defparameter +api-key-prefix+ "star_sk_v1_")
+(defparameter +api-key-version+ "v1")
+(defparameter +credential-kind+ "api-key")
+
+(define-condition authentication-error (error)
+  ((code
+    :initarg :code
+    :initform "invalid_credential"
+    :reader authentication-error-code)
+   (message
+    :initarg :message
+    :initform "Authentication failed"
+    :reader authentication-error-message))
+  (:report
+   (lambda (condition stream)
+     (format stream "~a" (authentication-error-message condition)))))
+
+(define-condition credential-lifecycle-error (error)
+  ((code
+    :initarg :code
+    :reader credential-lifecycle-error-code)
+   (message
+    :initarg :message
+    :reader credential-lifecycle-error-message))
+  (:report
+   (lambda (condition stream)
+     (format stream "~a" (credential-lifecycle-error-message condition)))))
+
+(defstruct (request-principal
+            (:constructor %make-request-principal)
+            (:copier nil))
+  (id nil :read-only t)
+  (type nil :read-only t)
+  (scopes nil :read-only t)
+  (credential-id nil :read-only t))
+
+(defstruct (request-security-context
+            (:constructor %make-request-security-context)
+            (:copier nil))
+  (principal nil :read-only t)
+  (correlation-id nil :read-only t)
+  (deadline nil :read-only t)
+  (authenticated-at nil :read-only t))
+
+(defstruct (service-call-context
+            (:constructor %make-service-call-context)
+            (:copier nil))
+  (principal-id nil :read-only t)
+  (principal-type nil :read-only t)
+  (credential-id nil :read-only t)
+  (scopes nil :read-only t)
+  (correlation-id nil :read-only t)
+  (deadline nil :read-only t))
+
+(defstruct api-key-record
+  id
+  owner
+  principal-type
+  scopes
+  status
+  salt
+  verifier
+  created-at
+  expires-at
+  disabled-at
+  revoked-at
+  rotation-parent-id
+  superseded-by
+  overlap-expires-at
+  revision)
+
+(defclass credential-store () ())
+
+(defgeneric credential-store-get (store credential-id))
+(defgeneric credential-store-put (store record))
+(defgeneric credential-store-update (store record))
+(defgeneric credential-store-list (store))
+(defgeneric credential-store-count (store))
+
+(defvar *credential-store* nil)
+(defvar *request-security-context* nil)
+(defvar *auth-clock* #'get-universal-time)
+
+(defun auth-now ()
+  (funcall *auth-clock*))
+
+(defun signal-authentication-failure ()
+  (error 'authentication-error
+         :code "invalid_credential"
+         :message "Authentication failed"))
+
+(defun signal-lifecycle-error (code message)
+  (error 'credential-lifecycle-error
+         :code code
+         :message message))
+
+(defun string-octets (value)
+  (babel:string-to-octets value :encoding :utf-8))
+
+(defun concatenate-octet-vectors (&rest vectors)
+  (let* ((length (reduce #'+ vectors :key #'length :initial-value 0))
+         (result (make-array length :element-type '(unsigned-byte 8)))
+         (offset 0))
+    (dolist (vector vectors result)
+      (replace result vector :start1 offset)
+      (incf offset (length vector)))))
+
+(defun constant-time-octets= (left right)
+  "Compare octet vectors without data-dependent early return.
+Verifier inputs are fixed-length SHA-256 values at the authentication boundary."
+  (let* ((left-length (length left))
+         (right-length (length right))
+         (maximum (max left-length right-length))
+         (difference (logxor left-length right-length)))
+    (dotimes (index maximum (zerop difference))
+      (setf difference
+            (logior difference
+                    (logxor (if (< index left-length)
+                                (aref left index)
+                                0)
+                            (if (< index right-length)
+                                (aref right index)
+                                0)))))))
+
+(defvar *verifier-compare-function* #'constant-time-octets=)
+
+(defun sha256 (&rest vectors)
+  (ironclad:digest-sequence
+   :sha256
+   (apply #'concatenate-octet-vectors vectors)))
+
+(defun random-hex (octet-count)
+  (ironclad:byte-array-to-hex-string
+   (ironclad:random-data octet-count)))
+
+(defun decode-hex (value)
+  (ironclad:hex-string-to-byte-array value))
+
+(defun derive-verifier (secret-octets salt-hex pepper)
+  (sha256 (string-octets pepper)
+          (decode-hex salt-hex)
+          secret-octets))
+
+(defun verifier-hex (secret-octets salt-hex pepper)
+  (ironclad:byte-array-to-hex-string
+   (derive-verifier secret-octets salt-hex pepper)))
+
+(defun fixed-secret-digest (value)
+  (sha256 (string-octets (or value ""))))
+
+(defun constant-time-secret= (left right)
+  (funcall *verifier-compare-function*
+           (fixed-secret-digest left)
+           (fixed-secret-digest right)))
+
+(defun split-on-character (string character)
+  (loop with start = 0
+        for position = (position character string :start start)
+        collect (subseq string start position)
+        while position
+        do (setf start (1+ position))))
+
+(defun valid-hex-string-p (value expected-length)
+  (and (stringp value)
+       (= (length value) expected-length)
+       (every (lambda (character)
+                (not (null (digit-char-p character 16))))
+              value)))
+
+(defun parse-api-key (api-key)
+  "Return credential id and decoded secret. Signal one uniform failure otherwise."
+  (handler-case
+      (let ((parts (and (stringp api-key)
+                        (split-on-character api-key #\_))))
+        (unless (and (= (length parts) 5)
+                     (string= (first parts) "star")
+                     (string= (second parts) "sk")
+                     (string= (third parts) +api-key-version+)
+                     (plusp (length (fourth parts)))
+                     (valid-hex-string-p
+                      (fifth parts)
+                      (* 2 star:*auth-key-secret-bytes*)))
+          (signal-authentication-failure))
+        (values (fourth parts)
+                (decode-hex (fifth parts))))
+    (authentication-error (condition)
+      (error condition))
+    (error ()
+      (signal-authentication-failure))))
+
+(defun bearer-token (authorization-header)
+  (unless (and (stringp authorization-header)
+               (> (length authorization-header) 7)
+               (string-equal "Bearer " authorization-header :end2 7))
+    (signal-authentication-failure))
+  (let ((token (subseq authorization-header 7)))
+    (when (or (zerop (length token))
+              (find #\Space token)
+              (find #\Tab token))
+      (signal-authentication-failure))
+    token))
+
+(defun normalize-principal-type (value)
+  (string-downcase
+   (etypecase value
+     (string value)
+     (symbol (symbol-name value)))))
+
+(defun normalize-scopes (scopes)
+  (unless (and (listp scopes)
+               (every (lambda (scope)
+                        (and (stringp scope)
+                             (plusp (length scope))))
+                      scopes))
+    (signal-lifecycle-error
+     "invalid_scopes"
+     "Scopes must be a list of non-empty strings"))
+  (remove-duplicates (copy-list scopes) :test #'string=))
+
+(defun active-record-p (record now)
+  (and record
+       (eq :active (api-key-record-status record))
+       (or (null (api-key-record-expires-at record))
+           (> (api-key-record-expires-at record) now))
+       (or (null (api-key-record-superseded-by record))
+           (and (api-key-record-overlap-expires-at record)
+                (> (api-key-record-overlap-expires-at record) now)))))
+
+(defun record-principal (record)
+  (%make-request-principal
+   :id (api-key-record-owner record)
+   :type (api-key-record-principal-type record)
+   :scopes (copy-list (api-key-record-scopes record))
+   :credential-id (api-key-record-id record)))
+
+(defun authenticate-api-key (api-key correlation-id deadline
+                              &key (store *credential-store*))
+  (unless store
+    (signal-authentication-failure))
+  (multiple-value-bind (credential-id secret-octets)
+      (parse-api-key api-key)
+    (let* ((record (credential-store-get store credential-id))
+           (now (auth-now)))
+      (unless (active-record-p record now)
+        (signal-authentication-failure))
+      (let ((expected (decode-hex (api-key-record-verifier record)))
+            (actual (derive-verifier
+                     secret-octets
+                     (api-key-record-salt record)
+                     star:*auth-pepper*)))
+        (unless (funcall *verifier-compare-function* expected actual)
+          (signal-authentication-failure)))
+      (%make-request-security-context
+       :principal (record-principal record)
+       :correlation-id correlation-id
+       :deadline deadline
+       :authenticated-at now))))
+
+(defun authenticate-authorization-header (authorization-header correlation-id deadline
+                                          &key (store *credential-store*))
+  (authenticate-api-key
+   (bearer-token authorization-header)
+   correlation-id
+   deadline
+   :store store))
+
+(defun current-request-principal ()
+  (and *request-security-context*
+       (request-security-context-principal *request-security-context*)))
+
+(defun current-principal-id ()
+  (let ((principal (current-request-principal)))
+    (and principal (request-principal-id principal))))
+
+(defun current-service-call-context ()
+  (let ((context *request-security-context*))
+    (when context
+      (let ((principal (request-security-context-principal context)))
+        (%make-service-call-context
+         :principal-id (request-principal-id principal)
+         :principal-type (request-principal-type principal)
+         :credential-id (request-principal-credential-id principal)
+         :scopes (copy-list (request-principal-scopes principal))
+         :correlation-id (request-security-context-correlation-id context)
+         :deadline (request-security-context-deadline context))))))
+
+(defun scope-granted-p (scope &optional (principal (current-request-principal)))
+  (and principal
+       (or (member "admin" (request-principal-scopes principal) :test #'string=)
+           (member scope (request-principal-scopes principal) :test #'string=))))
+
+(defun administrator-principal-p (&optional (principal (current-request-principal)))
+  (and principal
+       (or (string= "administrator" (request-principal-type principal))
+           (scope-granted-p "admin" principal))))
+
+(defun make-api-key-material (owner principal-type scopes
+                              &key expires-at rotation-parent-id)
+  (let* ((credential-id (cms-ulid:ulid))
+         (secret-hex (random-hex star:*auth-key-secret-bytes*))
+         (secret-octets (decode-hex secret-hex))
+         (salt-hex (random-hex star:*auth-salt-bytes*))
+         (record
+           (make-api-key-record
+            :id credential-id
+            :owner owner
+            :principal-type (normalize-principal-type principal-type)
+            :scopes (normalize-scopes scopes)
+            :status :active
+            :salt salt-hex
+            :verifier (verifier-hex secret-octets salt-hex star:*auth-pepper*)
+            :created-at (auth-now)
+            :expires-at expires-at
+            :rotation-parent-id rotation-parent-id)))
+    (values record
+            (format nil "~a~a_~a"
+                    +api-key-prefix+
+                    credential-id
+                    secret-hex))))
+
+(defun validate-expiry (expires-in-seconds)
+  (cond
+    ((null expires-in-seconds) nil)
+    ((and (integerp expires-in-seconds)
+          (plusp expires-in-seconds))
+     (+ (auth-now) expires-in-seconds))
+    (t
+     (signal-lifecycle-error
+      "invalid_expiry"
+      "Expiration must be a positive number of seconds"))))
+
+(defun create-api-key (owner principal-type scopes
+                       &key expires-in-seconds rotation-parent-id
+                         (store *credential-store*))
+  (unless (and (stringp owner) (plusp (length owner)))
+    (signal-lifecycle-error
+     "invalid_owner"
+     "Credential owner must be a non-empty string"))
+  (unless store
+    (signal-lifecycle-error
+     "auth_store_unavailable"
+     "Credential store is unavailable"))
+  (multiple-value-bind (record raw-key)
+      (make-api-key-material
+       owner
+       principal-type
+       scopes
+       :expires-at (validate-expiry expires-in-seconds)
+       :rotation-parent-id rotation-parent-id)
+    (credential-store-put store record)
+    (values record raw-key)))
+
+(defun bootstrap-api-key (presented-secret owner
+                          &key (store *credential-store*))
+  (unless store
+    (signal-lifecycle-error
+     "auth_store_unavailable"
+     "Credential store is unavailable"))
+  (unless (and star:*auth-bootstrap-secret*
+               (constant-time-secret=
+                presented-secret
+                star:*auth-bootstrap-secret*))
+    (signal-lifecycle-error
+     "bootstrap_denied"
+     "Bootstrap denied"))
+  (unless (zerop (credential-store-count store))
+    (signal-lifecycle-error
+     "bootstrap_complete"
+     "Bootstrap has already been completed"))
+  (create-api-key owner
+                  "administrator"
+                  (list "admin")
+                  :store store))
+
+(defun validate-overlap-seconds (overlap-seconds)
+  (unless (and (integerp overlap-seconds)
+               (<= 0 overlap-seconds star:*auth-rotation-overlap-max-seconds*))
+    (signal-lifecycle-error
+     "invalid_overlap"
+     "Rotation overlap is outside the configured bound"))
+  overlap-seconds)
+
+(defun rotate-api-key (credential-id overlap-seconds
+                       &key (store *credential-store*))
+  (let* ((overlap (validate-overlap-seconds overlap-seconds))
+         (record (and store
+                      (credential-store-get store credential-id))))
+    (unless record
+      (signal-lifecycle-error
+       "credential_not_found"
+       "Credential was not found"))
+    (unless (eq :active (api-key-record-status record))
+      (signal-lifecycle-error
+       "credential_not_active"
+       "Credential is not active"))
+    (multiple-value-bind (replacement raw-key)
+        (make-api-key-material
+         (api-key-record-owner record)
+         (api-key-record-principal-type record)
+         (api-key-record-scopes record)
+         :expires-at (api-key-record-expires-at record)
+         :rotation-parent-id credential-id)
+      (credential-store-put store replacement)
+      (setf (api-key-record-superseded-by record)
+            (api-key-record-id replacement)
+            (api-key-record-overlap-expires-at record)
+            (+ (auth-now) overlap))
+      (handler-case
+          (credential-store-update store record)
+        (error (condition)
+          (setf (api-key-record-status replacement) :revoked
+                (api-key-record-revoked-at replacement) (auth-now))
+          (ignore-errors
+            (credential-store-update store replacement))
+          (error condition)))
+      (values replacement raw-key))))
+
+(defun revoke-api-key (credential-id &key (store *credential-store*))
+  (let ((record (and store
+                     (credential-store-get store credential-id))))
+    (unless record
+      (signal-lifecycle-error
+       "credential_not_found"
+       "Credential was not found"))
+    (setf (api-key-record-status record) :revoked
+          (api-key-record-revoked-at record) (auth-now))
+    (credential-store-update store record)))
+
+(defun disable-api-key (credential-id &key (store *credential-store*))
+  (let ((record (and store
+                     (credential-store-get store credential-id))))
+    (unless record
+      (signal-lifecycle-error
+       "credential_not_found"
+       "Credential was not found"))
+    (setf (api-key-record-status record) :disabled
+          (api-key-record-disabled-at record) (auth-now))
+    (credential-store-update store record)))
+
+(defun nullable-json-value (value)
+  (or value :null))
+
+(defun api-key-metadata-json (record)
+  (jsown:new-js
+    ("credential_id" (api-key-record-id record))
+    ("owner" (api-key-record-owner record))
+    ("principal_type" (api-key-record-principal-type record))
+    ("scopes" (copy-list (api-key-record-scopes record)))
+    ("status" (string-downcase
+               (symbol-name (api-key-record-status record))))
+    ("created_at" (api-key-record-created-at record))
+    ("expires_at" (nullable-json-value
+                   (api-key-record-expires-at record)))
+    ("disabled_at" (nullable-json-value
+                    (api-key-record-disabled-at record)))
+    ("revoked_at" (nullable-json-value
+                   (api-key-record-revoked-at record)))
+    ("rotation_parent_id" (nullable-json-value
+                           (api-key-record-rotation-parent-id record)))
+    ("superseded_by" (nullable-json-value
+                      (api-key-record-superseded-by record)))
+    ("overlap_expires_at" (nullable-json-value
+                           (api-key-record-overlap-expires-at record)))))
+
+(defun list-api-key-metadata (&key (store *credential-store*))
+  (mapcar #'api-key-metadata-json
+          (credential-store-list store)))

--- a/source/auth/immutability.lisp
+++ b/source/auth/immutability.lisp
@@ -1,0 +1,87 @@
+(in-package :star.auth)
+
+(defparameter *raw-request-principal-id-reader*
+  (symbol-function 'request-principal-id))
+(defparameter *raw-request-principal-type-reader*
+  (symbol-function 'request-principal-type))
+(defparameter *raw-request-principal-scopes-reader*
+  (symbol-function 'request-principal-scopes))
+(defparameter *raw-request-principal-credential-id-reader*
+  (symbol-function 'request-principal-credential-id))
+(defparameter *raw-request-security-context-correlation-id-reader*
+  (symbol-function 'request-security-context-correlation-id))
+(defparameter *raw-service-call-context-principal-id-reader*
+  (symbol-function 'service-call-context-principal-id))
+(defparameter *raw-service-call-context-principal-type-reader*
+  (symbol-function 'service-call-context-principal-type))
+(defparameter *raw-service-call-context-credential-id-reader*
+  (symbol-function 'service-call-context-credential-id))
+(defparameter *raw-service-call-context-scopes-reader*
+  (symbol-function 'service-call-context-scopes))
+(defparameter *raw-service-call-context-correlation-id-reader*
+  (symbol-function 'service-call-context-correlation-id))
+
+(defun copy-string-or-nil (value)
+  (and value (copy-seq value)))
+
+(defun defensive-request-principal-id (principal)
+  (copy-string-or-nil
+   (funcall *raw-request-principal-id-reader* principal)))
+
+(defun defensive-request-principal-type (principal)
+  (copy-string-or-nil
+   (funcall *raw-request-principal-type-reader* principal)))
+
+(defun defensive-request-principal-scopes (principal)
+  (mapcar #'copy-string-or-nil
+          (funcall *raw-request-principal-scopes-reader* principal)))
+
+(defun defensive-request-principal-credential-id (principal)
+  (copy-string-or-nil
+   (funcall *raw-request-principal-credential-id-reader* principal)))
+
+(defun defensive-request-security-context-correlation-id (context)
+  (copy-string-or-nil
+   (funcall *raw-request-security-context-correlation-id-reader* context)))
+
+(defun defensive-service-call-context-principal-id (context)
+  (copy-string-or-nil
+   (funcall *raw-service-call-context-principal-id-reader* context)))
+
+(defun defensive-service-call-context-principal-type (context)
+  (copy-string-or-nil
+   (funcall *raw-service-call-context-principal-type-reader* context)))
+
+(defun defensive-service-call-context-credential-id (context)
+  (copy-string-or-nil
+   (funcall *raw-service-call-context-credential-id-reader* context)))
+
+(defun defensive-service-call-context-scopes (context)
+  (mapcar #'copy-string-or-nil
+          (funcall *raw-service-call-context-scopes-reader* context)))
+
+(defun defensive-service-call-context-correlation-id (context)
+  (copy-string-or-nil
+   (funcall *raw-service-call-context-correlation-id-reader* context)))
+
+(eval-when (:load-toplevel :execute)
+  (setf (symbol-function 'request-principal-id)
+        #'defensive-request-principal-id
+        (symbol-function 'request-principal-type)
+        #'defensive-request-principal-type
+        (symbol-function 'request-principal-scopes)
+        #'defensive-request-principal-scopes
+        (symbol-function 'request-principal-credential-id)
+        #'defensive-request-principal-credential-id
+        (symbol-function 'request-security-context-correlation-id)
+        #'defensive-request-security-context-correlation-id
+        (symbol-function 'service-call-context-principal-id)
+        #'defensive-service-call-context-principal-id
+        (symbol-function 'service-call-context-principal-type)
+        #'defensive-service-call-context-principal-type
+        (symbol-function 'service-call-context-credential-id)
+        #'defensive-service-call-context-credential-id
+        (symbol-function 'service-call-context-scopes)
+        #'defensive-service-call-context-scopes
+        (symbol-function 'service-call-context-correlation-id)
+        #'defensive-service-call-context-correlation-id))

--- a/source/auth/store.lisp
+++ b/source/auth/store.lisp
@@ -1,0 +1,293 @@
+(in-package :star.auth)
+
+(defclass memory-credential-store (credential-store)
+  ((records
+    :initform (make-hash-table :test #'equal)
+    :reader memory-store-records)
+   (lock
+    :initform (bt:make-lock "memory-credential-store")
+    :reader memory-store-lock)))
+
+(defun make-memory-credential-store ()
+  (make-instance 'memory-credential-store))
+
+(defun copy-record-or-nil (record)
+  (and record (copy-api-key-record record)))
+
+(defmethod credential-store-get ((store memory-credential-store) credential-id)
+  (bt:with-lock-held ((memory-store-lock store))
+    (copy-record-or-nil
+     (gethash credential-id (memory-store-records store)))))
+
+(defmethod credential-store-put ((store memory-credential-store) record)
+  (bt:with-lock-held ((memory-store-lock store))
+    (when (gethash (api-key-record-id record)
+                   (memory-store-records store))
+      (signal-lifecycle-error
+       "credential_conflict"
+       "Credential identifier already exists"))
+    (setf (gethash (api-key-record-id record)
+                   (memory-store-records store))
+          (copy-api-key-record record)))
+  (copy-api-key-record record))
+
+(defmethod credential-store-update ((store memory-credential-store) record)
+  (bt:with-lock-held ((memory-store-lock store))
+    (unless (gethash (api-key-record-id record)
+                     (memory-store-records store))
+      (signal-lifecycle-error
+       "credential_not_found"
+       "Credential was not found"))
+    (setf (gethash (api-key-record-id record)
+                   (memory-store-records store))
+          (copy-api-key-record record)))
+  (copy-api-key-record record))
+
+(defmethod credential-store-list ((store memory-credential-store))
+  (bt:with-lock-held ((memory-store-lock store))
+    (sort
+     (loop for record being the hash-values of (memory-store-records store)
+           collect (copy-api-key-record record))
+     #'<
+     :key #'api-key-record-created-at)))
+
+(defmethod credential-store-count ((store memory-credential-store))
+  (bt:with-lock-held ((memory-store-lock store))
+    (hash-table-count (memory-store-records store))))
+
+(defclass couchdb-credential-store (credential-store)
+  ((pool
+    :initarg :pool
+    :reader couchdb-store-pool)
+   (database
+    :initarg :database
+    :reader couchdb-store-database)))
+
+(defun make-auth-couchdb-pool ()
+  (anypool:make-pool
+   :name "starintel-auth-couchdb-connections"
+   :connector
+   (lambda ()
+     (let ((client
+             (cl-couch:new-couchdb
+              star:*couchdb-host*
+              star:*couchdb-port*
+              :scheme star:*couchdb-scheme*)))
+       (cl-couch:password-auth
+        client
+        star:*couchdb-user*
+        star:*couchdb-password*)
+       client))
+   :disconnector
+   (lambda (client)
+     (setf (cl-couch:couchdb-headers client) nil))
+   :max-open-count 10
+   :max-idle-count 5))
+
+(defun make-couchdb-credential-store ()
+  (make-instance
+   'couchdb-credential-store
+   :pool (make-auth-couchdb-pool)
+   :database star:*couchdb-auth-database*))
+
+(defun status-string (status)
+  (string-downcase (symbol-name status)))
+
+(defun parse-status (status)
+  (intern (string-upcase status) :keyword))
+
+(defun api-key-record-to-json (record)
+  (let ((document
+          (jsown:new-js
+            ("_id" (api-key-record-id record))
+            ("kind" +credential-kind+)
+            ("owner" (api-key-record-owner record))
+            ("principal_type" (api-key-record-principal-type record))
+            ("scopes" (copy-list (api-key-record-scopes record)))
+            ("status" (status-string (api-key-record-status record)))
+            ("salt" (api-key-record-salt record))
+            ("verifier" (api-key-record-verifier record))
+            ("created_at" (api-key-record-created-at record))
+            ("expires_at" (nullable-json-value
+                           (api-key-record-expires-at record)))
+            ("disabled_at" (nullable-json-value
+                            (api-key-record-disabled-at record)))
+            ("revoked_at" (nullable-json-value
+                           (api-key-record-revoked-at record)))
+            ("rotation_parent_id" (nullable-json-value
+                                   (api-key-record-rotation-parent-id record)))
+            ("superseded_by" (nullable-json-value
+                              (api-key-record-superseded-by record)))
+            ("overlap_expires_at" (nullable-json-value
+                                   (api-key-record-overlap-expires-at record))))))
+    (when (api-key-record-revision record)
+      (setf (jsown:val document "_rev")
+            (api-key-record-revision record)))
+    document))
+
+(defun null-json-value-p (value)
+  (or (null value) (eq value :null)))
+
+(defun json-value-or-nil (document key)
+  (let ((value (jsown:val-safe document key)))
+    (unless (null-json-value-p value)
+      value)))
+
+(defun json-to-api-key-record (value)
+  (let ((document (if (stringp value)
+                      (jsown:parse value)
+                      value)))
+    (make-api-key-record
+     :id (jsown:val document "_id")
+     :owner (jsown:val document "owner")
+     :principal-type (jsown:val document "principal_type")
+     :scopes (copy-list (or (jsown:val-safe document "scopes") nil))
+     :status (parse-status (jsown:val document "status"))
+     :salt (jsown:val document "salt")
+     :verifier (jsown:val document "verifier")
+     :created-at (jsown:val document "created_at")
+     :expires-at (json-value-or-nil document "expires_at")
+     :disabled-at (json-value-or-nil document "disabled_at")
+     :revoked-at (json-value-or-nil document "revoked_at")
+     :rotation-parent-id
+     (json-value-or-nil document "rotation_parent_id")
+     :superseded-by (json-value-or-nil document "superseded_by")
+     :overlap-expires-at
+     (json-value-or-nil document "overlap_expires_at")
+     :revision (jsown:val-safe document "_rev"))))
+
+(defun update-record-revision-from-response (record response)
+  (let ((parsed (ignore-errors (jsown:parse response))))
+    (when parsed
+      (setf (api-key-record-revision record)
+            (jsown:val-safe parsed "rev"))))
+  record)
+
+(defmethod credential-store-get ((store couchdb-credential-store) credential-id)
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (handler-case
+        (json-to-api-key-record
+         (cl-couch:get-document
+          client
+          (couchdb-store-database store)
+          credential-id))
+      (dex:http-request-not-found () nil))))
+
+(defmethod credential-store-put ((store couchdb-credential-store) record)
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (handler-case
+        (update-record-revision-from-response
+         record
+         (cl-couch:create-document
+          client
+          (couchdb-store-database store)
+          (jsown:to-json (api-key-record-to-json record))))
+      (dex:http-request-conflict ()
+        (signal-lifecycle-error
+         "credential_conflict"
+         "Credential identifier already exists")))))
+
+(defmethod credential-store-update ((store couchdb-credential-store) record)
+  (unless (api-key-record-revision record)
+    (let ((current
+            (credential-store-get store (api-key-record-id record))))
+      (unless current
+        (signal-lifecycle-error
+         "credential_not_found"
+         "Credential was not found"))
+      (setf (api-key-record-revision record)
+            (api-key-record-revision current))))
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (handler-case
+        (update-record-revision-from-response
+         record
+         (cl-couch:create-document
+          client
+          (couchdb-store-database store)
+          (jsown:to-json (api-key-record-to-json record))))
+      (dex:http-request-conflict ()
+        (signal-lifecycle-error
+         "credential_conflict"
+         "Credential update conflicted")))))
+
+(defmethod credential-store-list ((store couchdb-credential-store))
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (let* ((view
+             (star.databases.couchdb:query-view
+              client
+              (couchdb-store-database store)
+              "auth"
+              "credentials"
+              :include-docs t
+              :limit 10000
+              :reduce nil))
+           (rows (or (jsown:val-safe view "rows") nil)))
+      (loop for row in rows
+            for document = (jsown:val row "doc")
+            collect (json-to-api-key-record document)))))
+
+(defmethod credential-store-count ((store couchdb-credential-store))
+  (length (credential-store-list store)))
+
+(defun auth-design-document ()
+  (jsown:new-js
+    ("_id" "_design/auth")
+    ("views"
+     (jsown:new-js
+       ("credentials"
+        (jsown:new-js
+          ("map"
+           "function(doc){if(doc.kind==='api-key'){emit(doc.created_at,null);}}")))))))
+
+(defun ensure-auth-database (store)
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (handler-case
+        (cl-couch:get-database client (couchdb-store-database store))
+      (dex:http-request-not-found ()
+        (cl-couch:create-database client (couchdb-store-database store))))))
+
+(defun ensure-auth-design-document (store)
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (let* ((database (couchdb-store-database store))
+           (document (auth-design-document)))
+      (handler-case
+          (let* ((existing
+                   (jsown:parse
+                    (cl-couch:get-document
+                     client database "_design/auth")))
+                 (revision (jsown:val existing "_rev")))
+            (setf (jsown:val document "_rev") revision)
+            (cl-couch:create-document
+             client database (jsown:to-json document)))
+        (dex:http-request-not-found ()
+          (cl-couch:create-document
+           client database (jsown:to-json document)))))))
+
+(defun loopback-address-p (address)
+  (member (string-downcase address)
+          '("localhost" "127.0.0.1" "::1")
+          :test #'string=))
+
+(defun validate-auth-configuration ()
+  (let ((mode (string-downcase star:*auth-mode*)))
+    (cond
+      ((string= mode "api-key")
+       (unless (and (stringp star:*auth-pepper*)
+                    (plusp (length star:*auth-pepper*)))
+         (error "STAR_AUTH_PEPPER or STAR_AUTH_PEPPER_FILE is required")))
+      ((string= mode "disabled")
+       (unless (and star:*auth-dev-bypass*
+                    (loopback-address-p star:*http-api-address*))
+         (error "Disabled authentication requires explicit loopback development bypass")))
+      (t
+       (error "Unsupported STAR_AUTH_MODE: ~a" star:*auth-mode*))))
+  t)
+
+(defun initialize-auth-store (&key force)
+  (validate-auth-configuration)
+  (when (or force (null *credential-store*))
+    (setf *credential-store* (make-couchdb-credential-store)))
+  (when (typep *credential-store* 'couchdb-credential-store)
+    (ensure-auth-database *credential-store*)
+    (ensure-auth-design-document *credential-store*))
+  *credential-store*)

--- a/source/auth/verification-hardening.lisp
+++ b/source/auth/verification-hardening.lisp
@@ -1,0 +1,49 @@
+(in-package :star.auth)
+
+(defparameter +dummy-verifier-salt+
+  "00000000000000000000000000000000")
+
+(defparameter +dummy-verifier+
+  "0000000000000000000000000000000000000000000000000000000000000000")
+
+(defun credential-verifier-material (record)
+  "Return verifier bytes and salt without exposing record existence through work.
+Malformed stored material fails closed through the same dummy verifier path."
+  (handler-case
+      (if record
+          (values (decode-hex (api-key-record-verifier record))
+                  (api-key-record-salt record))
+          (values (decode-hex +dummy-verifier+)
+                  +dummy-verifier-salt+))
+    (error ()
+      (values (decode-hex +dummy-verifier+)
+              +dummy-verifier-salt+))))
+
+(defun authenticate-api-key (api-key correlation-id deadline
+                              &key (store *credential-store*))
+  "Authenticate through one verifier-comparison path for known and unknown ids."
+  (unless store
+    (signal-authentication-failure))
+  (multiple-value-bind (credential-id secret-octets)
+      (parse-api-key api-key)
+    (let* ((record (credential-store-get store credential-id))
+           (now (auth-now)))
+      (multiple-value-bind (expected salt)
+          (credential-verifier-material record)
+        (let* ((actual
+                 (handler-case
+                     (derive-verifier secret-octets salt star:*auth-pepper*)
+                   (error ()
+                     (derive-verifier
+                      secret-octets
+                      +dummy-verifier-salt+
+                      (or star:*auth-pepper* "")))))
+               (verified
+                 (funcall *verifier-compare-function* expected actual)))
+          (unless (and verified (active-record-p record now))
+            (signal-authentication-failure))))
+      (%make-request-security-context
+       :principal (record-principal record)
+       :correlation-id correlation-id
+       :deadline deadline
+       :authenticated-at now))))

--- a/source/auth/verification-hardening.lisp
+++ b/source/auth/verification-hardening.lisp
@@ -19,8 +19,8 @@ Malformed stored material fails closed through the same dummy verifier path."
       (values (decode-hex +dummy-verifier+)
               +dummy-verifier-salt+))))
 
-(defun authenticate-api-key (api-key correlation-id deadline
-                              &key (store *credential-store*))
+(defun hardened-authenticate-api-key (api-key correlation-id deadline
+                                      &key (store *credential-store*))
   "Authenticate through one verifier-comparison path for known and unknown ids."
   (unless store
     (signal-authentication-failure))
@@ -47,3 +47,7 @@ Malformed stored material fails closed through the same dummy verifier path."
        :correlation-id correlation-id
        :deadline deadline
        :authenticated-at now))))
+
+(eval-when (:load-toplevel :execute)
+  (setf (symbol-function 'authenticate-api-key)
+        #'hardened-authenticate-api-key))

--- a/source/frontends/http-auth-job-routes.lisp
+++ b/source/frontends/http-auth-job-routes.lisp
@@ -1,0 +1,22 @@
+(in-package :star.frontends.http-api)
+
+(defun handle-authenticated-bulk-status-route (params)
+  (with-http-boundary ()
+    (let* ((job-id (query-value params "job-id"))
+           (job
+             (and job-id
+                  (bt:with-lock-held (*bulk-ingest-lock*)
+                    (gethash job-id *bulk-ingest-jobs*))))
+           (principal-id (star.auth:current-principal-id)))
+      (unless (and job
+                   (or (star.auth:administrator-principal-p)
+                       (string= principal-id
+                                (bulk-ingest-job-principal job))))
+        (signal-http-input-error
+         404
+         "bulk_job_not_found"
+         "Bulk ingest job was not found"))
+      (jsown:to-json (bulk-job-info-json job)))))
+
+(setf (ningle:route *app* "/documents/bulk/:job-id" :method :get)
+      #'handle-authenticated-bulk-status-route)

--- a/source/frontends/http-auth-routes.lisp
+++ b/source/frontends/http-auth-routes.lisp
@@ -1,0 +1,217 @@
+(in-package :star.frontends.http-api)
+
+(defun lifecycle-error-status (code)
+  (cond
+    ((member code
+             '("invalid_owner" "invalid_scopes" "invalid_expiry"
+               "invalid_overlap")
+             :test #'string=)
+     422)
+    ((string= code "credential_not_found") 404)
+    ((member code
+             '("credential_conflict" "credential_not_active"
+               "bootstrap_complete")
+             :test #'string=)
+     409)
+    ((string= code "bootstrap_denied") 403)
+    ((string= code "auth_store_unavailable") 503)
+    (t 400)))
+
+(defmacro with-credential-lifecycle-errors (&body body)
+  `(handler-case
+       (progn ,@body)
+     (star.auth:credential-lifecycle-error (condition)
+       (signal-http-input-error
+        (lifecycle-error-status
+         (star.auth:credential-lifecycle-error-code condition))
+        (star.auth:credential-lifecycle-error-code condition)
+        (star.auth:credential-lifecycle-error-message condition)))))
+
+(defun require-auth-string (document field)
+  (let ((value (jsown:val-safe document field)))
+    (unless (and (stringp value) (plusp (length value)))
+      (signal-http-input-error
+       422
+       "invalid_auth_request"
+       (format nil "Field ~a must be a non-empty string" field)))
+    value))
+
+(defun optional-positive-integer (document field)
+  (let ((value (jsown:val-safe document field)))
+    (cond
+      ((or (null value) (eq value :null)) nil)
+      ((and (integerp value) (plusp value)) value)
+      (t
+       (signal-http-input-error
+        422
+        "invalid_auth_request"
+        (format nil "Field ~a must be a positive integer" field))))))
+
+(defun require-scope-array (document)
+  (let ((scopes (jsown:val-safe document "scopes")))
+    (unless (and (json-array-p scopes)
+                 (every (lambda (scope)
+                          (and (stringp scope)
+                               (plusp (length scope))))
+                        scopes))
+      (signal-http-input-error
+       422
+       "invalid_auth_request"
+       "Field scopes must be an array of non-empty strings"))
+    scopes))
+
+(defun add-no-store-header ()
+  (setf (lack.response:response-headers *response*)
+        (append (lack.response:response-headers *response*)
+                (list :cache-control "no-store"
+                      :pragma "no-cache"))))
+
+(defun credential-secret-response (record raw-key)
+  (add-no-store-header)
+  (jsown:to-json
+   (jsown:new-js
+     ("api_key" raw-key)
+     ("credential" (star.auth:api-key-metadata-json record))
+     ("correlation_id" (current-correlation-id)))))
+
+(defun handle-auth-bootstrap-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (with-credential-lifecycle-errors
+      (let* ((request (ningle:context :request))
+             (headers (lack.request:request-headers request))
+             (presented-secret
+               (request-header-value headers "X-Star-Bootstrap-Secret"))
+             (body (require-json-object (parse-json-request)))
+             (owner (or (jsown:val-safe body "owner")
+                        "bootstrap-administrator")))
+        (unless (and (stringp owner) (plusp (length owner)))
+          (signal-http-input-error
+           422
+           "invalid_auth_request"
+           "Field owner must be a non-empty string"))
+        (multiple-value-bind (record raw-key)
+            (star.auth:bootstrap-api-key presented-secret owner)
+          (setf (lack.response:response-status *response*) 201)
+          (credential-secret-response record raw-key))))))
+
+(defun handle-auth-create-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (let* ((body (require-json-object (parse-json-request)))
+             (owner (require-auth-string body "owner"))
+             (principal-type
+               (require-auth-string body "principal_type"))
+             (scopes (require-scope-array body))
+             (expires-in-seconds
+               (optional-positive-integer body "expires_in_seconds")))
+        (multiple-value-bind (record raw-key)
+            (star.auth:create-api-key
+             owner
+             principal-type
+             scopes
+             :expires-in-seconds expires-in-seconds)
+          (setf (lack.response:response-status *response*) 201)
+          (credential-secret-response record raw-key))))))
+
+(defun handle-auth-list-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (jsown:to-json
+       (star.auth:list-api-key-metadata)))))
+
+(defun credential-id-param (params)
+  (let ((credential-id (query-value params "credential-id")))
+    (unless (and (stringp credential-id)
+                 (plusp (length credential-id)))
+      (signal-http-input-error
+       400
+       "missing_path_parameter"
+       "Credential identifier is required"))
+    credential-id))
+
+(defun handle-auth-rotate-route (params)
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (let* ((credential-id (credential-id-param params))
+             (body (require-json-object (parse-json-request)))
+             (overlap-seconds
+               (or (jsown:val-safe body "overlap_seconds") 0)))
+        (unless (and (integerp overlap-seconds)
+                     (not (minusp overlap-seconds)))
+          (signal-http-input-error
+           422
+           "invalid_auth_request"
+           "Field overlap_seconds must be a non-negative integer"))
+        (multiple-value-bind (record raw-key)
+            (star.auth:rotate-api-key credential-id overlap-seconds)
+          (setf (lack.response:response-status *response*) 201)
+          (credential-secret-response record raw-key))))))
+
+(defun lifecycle-status-response (record message)
+  (jsown:to-json
+   (jsown:new-js
+     ("status" "ok")
+     ("msg" message)
+     ("credential" (star.auth:api-key-metadata-json record))
+     ("correlation_id" (current-correlation-id)))))
+
+(defun handle-auth-revoke-route (params)
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (lifecycle-status-response
+       (star.auth:revoke-api-key (credential-id-param params))
+       "Credential revoked"))))
+
+(defun handle-auth-disable-route (params)
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (lifecycle-status-response
+       (star.auth:disable-api-key (credential-id-param params))
+       "Credential disabled"))))
+
+(defun handle-auth-context-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (let* ((context star.auth:*request-security-context*)
+           (principal
+             (star.auth:request-security-context-principal context)))
+      (jsown:to-json
+       (jsown:new-js
+         ("principal_id" (star.auth:request-principal-id principal))
+         ("principal_type" (star.auth:request-principal-type principal))
+         ("credential_id"
+          (star.auth:request-principal-credential-id principal))
+         ("scopes" (star.auth:request-principal-scopes principal))
+         ("correlation_id"
+          (star.auth:request-security-context-correlation-id context))
+         ("deadline"
+          (star.auth:request-security-context-deadline context)))))))
+
+(setf (ningle:route *app* "/auth/bootstrap" :method :post)
+      #'handle-auth-bootstrap-route)
+
+(setf (ningle:route *app* "/auth/credentials" :method :post)
+      #'handle-auth-create-route)
+
+(setf (ningle:route *app* "/auth/credentials" :method :get)
+      #'handle-auth-list-route)
+
+(setf (ningle:route *app* "/auth/credentials/:credential-id/rotate" :method :post)
+      #'handle-auth-rotate-route)
+
+(setf (ningle:route *app* "/auth/credentials/:credential-id/revoke" :method :post)
+      #'handle-auth-revoke-route)
+
+(setf (ningle:route *app* "/auth/credentials/:credential-id/disable" :method :post)
+      #'handle-auth-disable-route)
+
+(setf (ningle:route *app* "/auth/context" :method :get)
+      #'handle-auth-context-route)

--- a/source/frontends/http-auth.lisp
+++ b/source/frontends/http-auth.lisp
@@ -1,0 +1,207 @@
+(in-package :star.frontends.http-api)
+
+(defun env-header-key (name)
+  (intern
+   (format nil "HTTP-~a"
+           (string-upcase name))
+   :keyword))
+
+(defun env-header-value (env name)
+  (or (getf env (env-header-key name))
+      (let ((headers (getf env :headers)))
+        (cond
+          ((hash-table-p headers)
+           (or (gethash (string-downcase name) headers)
+               (gethash name headers)))
+          ((and (listp headers)
+                (consp (first headers)))
+           (cdr (assoc name headers :test #'string-equal)))
+          (t nil)))))
+
+(defun bounded-correlation-id-p (value)
+  (and (stringp value)
+       (<= 1 (length value) 128)
+       (every (lambda (character)
+                (or (alphanumericp character)
+                    (find character "-_.:")))
+              value)))
+
+(defun request-correlation-id-from-env (env)
+  (let ((provided (env-header-value env "X-Correlation-ID")))
+    (if (bounded-correlation-id-p provided)
+        provided
+        (new-correlation-id))))
+
+(defun parse-request-timeout-ms (env)
+  (let ((raw (env-header-value env "X-Request-Timeout-Ms")))
+    (if raw
+        (handler-case
+            (let ((value (parse-integer raw :junk-allowed nil)))
+              (if (<= 1 value star:*auth-max-request-timeout-ms*)
+                  value
+                  star:*auth-default-request-timeout-ms*))
+          (error () star:*auth-default-request-timeout-ms*))
+        star:*auth-default-request-timeout-ms*)))
+
+(defun request-deadline-from-env (env)
+  (+ (get-universal-time)
+     (ceiling (parse-request-timeout-ms env) 1000)))
+
+(defun public-auth-path-p (path)
+  (member path star:*auth-public-paths* :test #'string=))
+
+(defun development-security-context (correlation-id deadline)
+  (star.auth::%make-request-security-context
+   :principal
+   (star.auth::%make-request-principal
+    :id "development-bypass"
+    :type "administrator"
+    :scopes (list "admin")
+    :credential-id "development-bypass")
+   :correlation-id correlation-id
+   :deadline deadline
+   :authenticated-at (get-universal-time)))
+
+(defun authenticate-request-env (env correlation-id deadline)
+  (let ((mode (string-downcase star:*auth-mode*)))
+    (cond
+      ((string= mode "api-key")
+       (star.auth:authenticate-authorization-header
+        (env-header-value env "Authorization")
+        correlation-id
+        deadline))
+      ((and (string= mode "disabled")
+            star:*auth-dev-bypass*)
+       (development-security-context correlation-id deadline))
+      (t
+       (star.auth:signal-authentication-failure)))))
+
+(defun authentication-error-response (correlation-id)
+  (list
+   401
+   (list :content-type "application/json"
+         :cache-control "no-store"
+         :x-correlation-id correlation-id
+         :www-authenticate "Bearer realm=\"starintel\"")
+   (list
+    (jsown:to-json
+     (jsown:new-js
+       ("status" "error")
+       ("code" "invalid_credential")
+       ("msg" "Authentication failed")
+       ("correlation_id" correlation-id))))))
+
+(defun append-response-headers (response headers)
+  (if (and response (listp response) (second response))
+      (list (first response)
+            (append (second response) headers)
+            (third response))
+      response))
+
+(defun authentication-middleware (app)
+  (lambda (env)
+    (let* ((path (or (getf env :path-info) "/"))
+           (method (getf env :request-method))
+           (correlation-id (request-correlation-id-from-env env))
+           (deadline (request-deadline-from-env env)))
+      (handler-case
+          (let* ((context
+                   (unless (or (eq method :options)
+                               (public-auth-path-p path))
+                     (authenticate-request-env
+                      env correlation-id deadline)))
+                 (star.auth:*request-security-context* context)
+                 (*http-correlation-id* correlation-id)
+                 (response (lack.component:call app env)))
+            (append-response-headers
+             response
+             (list :x-correlation-id correlation-id)))
+        (star.auth:authentication-error ()
+          (authentication-error-response correlation-id))))))
+
+(defun configured-origin-allowed-p (origin)
+  (and (stringp origin)
+       (member origin
+               star:*http-cors-allowed-origins*
+               :test #'string=)))
+
+(defun cors-headers-for-origin (origin)
+  (when (configured-origin-allowed-p origin)
+    (list :access-control-allow-origin origin
+          :access-control-allow-methods star:*http-cors-allowed-methods*
+          :access-control-allow-headers star:*http-cors-allowed-headers*
+          :access-control-max-age "600"
+          :vary "Origin")))
+
+(defun cors-middleware (app)
+  "Apply configured credential-safe CORS. Wildcard origins are never emitted."
+  (lambda (env)
+    (let* ((method (getf env :request-method))
+           (origin (env-header-value env "Origin"))
+           (headers (cors-headers-for-origin origin)))
+      (if (eq method :options)
+          (if headers
+              (list 204
+                    (append (list :content-type "text/plain") headers)
+                    (list ""))
+              (list 403
+                    (list :content-type "application/json")
+                    (list
+                     (jsown:to-json
+                      (jsown:new-js
+                        ("status" "error")
+                        ("code" "cors_origin_denied")
+                        ("msg" "Origin is not allowed"))))))
+          (append-response-headers
+           (lack.component:call app env)
+           headers)))))
+
+(defmacro with-http-boundary (() &body body)
+  `(let ((*http-correlation-id*
+           (or *http-correlation-id* (new-correlation-id))))
+     (set-default-headers)
+     (set-correlation-id-header)
+     (handler-case
+         (progn ,@body)
+       (http-input-error (condition)
+         (log:warn "HTTP input rejected correlation=~a code=~a: ~a"
+                   (current-correlation-id)
+                   (http-input-error-code condition)
+                   condition)
+         (respond-http-input-error condition))
+       (bt:timeout (condition)
+         (log:error "HTTP operation timed out correlation=~a: ~a"
+                    (current-correlation-id)
+                    condition)
+         (setf (lack.response:response-status *response*) 504)
+         (status-msg "Request deadline exceeded"
+                     'error
+                     :code "request_timeout"))
+       (error (condition)
+         (log:error "HTTP internal error correlation=~a: ~a"
+                    (current-correlation-id)
+                    condition)
+         (setf (lack.response:response-status *response*) 500)
+         (status-msg "Internal Server Error"
+                     'error
+                     :code "internal_error")))))
+
+(defun request-principal (&optional request)
+  (declare (ignore request))
+  (or (star.auth:current-principal-id)
+      "anonymous"))
+
+(defun require-administrator-context ()
+  (unless (star.auth:administrator-principal-p)
+    (signal-http-input-error
+     403
+     "access_denied"
+     "Access denied"))
+  star.auth:*request-security-context*)
+
+(setf *cors-headers* nil)
+(setf *server*
+      (lack:builder
+       :accesslog
+       (cors-middleware
+        (authentication-middleware *app*))))

--- a/source/frontends/http-bulk-jobs.lisp
+++ b/source/frontends/http-bulk-jobs.lisp
@@ -13,15 +13,18 @@
 (defvar *bulk-pending-jobs* 0)
 (defvar *bulk-pending-by-principal* (make-hash-table :test #'equal))
 (defvar *bulk-ingest-lock* (bt:make-lock "bulk-ingest-state"))
+(defvar *service-call-context* nil)
 
 (defstruct (bulk-ingest-job
             (:constructor make-bulk-ingest-job
-                (&key id principal documents correlation-id submitted-at
-                      (status :queued) (succeeded 0) (failed 0) error-code)))
+                (&key id principal documents correlation-id service-context
+                      submitted-at (status :queued) (succeeded 0) (failed 0)
+                      error-code)))
   id
   principal
   documents
   correlation-id
+  service-context
   submitted-at
   status
   succeeded
@@ -44,44 +47,79 @@
     (let* ((principal (bulk-ingest-job-principal job))
            (count (gethash principal *bulk-pending-by-principal* 0)))
       (if (> count 1)
-          (setf (gethash principal *bulk-pending-by-principal*) (1- count))
+          (setf (gethash principal *bulk-pending-by-principal*)
+                (1- count))
           (remhash principal *bulk-pending-by-principal*)))))
+
+(defun comma-separated-scopes (scopes)
+  (format nil "~{~a~^,~}" scopes))
+
+(defun service-context-properties (dtype context)
+  (let ((properties (list (cons :type dtype))))
+    (when context
+      (push (cons :correlation-id
+                  (star.auth:service-call-context-correlation-id context))
+            properties)
+      (push
+       (cons :headers
+             (list
+              (cons "x-star-principal-id"
+                    (star.auth:service-call-context-principal-id context))
+              (cons "x-star-principal-type"
+                    (star.auth:service-call-context-principal-type context))
+              (cons "x-star-credential-id"
+                    (star.auth:service-call-context-credential-id context))
+              (cons "x-star-scopes"
+                    (comma-separated-scopes
+                     (star.auth:service-call-context-scopes context)))
+              (cons "x-star-deadline"
+                    (princ-to-string
+                     (star.auth:service-call-context-deadline context)))))
+       properties))
+    (nreverse properties)))
+
+(defun current-publish-service-context ()
+  (or *service-call-context*
+      (star.auth:current-service-call-context)))
 
 (defun publish-document (document)
   (let* ((dtype (jsown:val document "dtype"))
-         (routing-key (format nil star.rabbit:+ingest-fmt-key+ dtype)))
-    (star.actors:publish star.actors:*producer-agent*
-                         :body (jsown:to-json document)
-                         :routing-key routing-key
-                         :properties (list (cons :type dtype)))))
+         (routing-key (format nil star.rabbit:+ingest-fmt-key+ dtype))
+         (context (current-publish-service-context)))
+    (star.actors:publish
+     star.actors:*producer-agent*
+     :body (jsown:to-json document)
+     :routing-key routing-key
+     :properties (service-context-properties dtype context))))
 
 (defun execute-bulk-job (job &key (publish-fn #'publish-document))
   (setf (bulk-ingest-job-status job) :running)
-  (handler-case
-      (progn
-        (loop for document in (bulk-ingest-job-documents job)
-              do (handler-case
-                     (progn
-                       (funcall publish-fn document)
-                       (incf (bulk-ingest-job-succeeded job)))
-                   (error (condition)
-                     (log:error
-                      "Bulk publish failed job=~a correlation=~a: ~a"
-                      (bulk-ingest-job-id job)
-                      (bulk-ingest-job-correlation-id job)
-                      condition)
-                     (incf (bulk-ingest-job-failed job)))))
-        (setf (bulk-ingest-job-status job)
-              (if (zerop (bulk-ingest-job-failed job))
-                  :completed
-                  :completed-with-errors)))
-    (error (condition)
-      (log:error "Bulk job failed job=~a correlation=~a: ~a"
-                 (bulk-ingest-job-id job)
-                 (bulk-ingest-job-correlation-id job)
-                 condition)
-      (setf (bulk-ingest-job-status job) :failed
-            (bulk-ingest-job-error-code job) "bulk_job_failed")))
+  (let ((*service-call-context* (bulk-ingest-job-service-context job)))
+    (handler-case
+        (progn
+          (loop for document in (bulk-ingest-job-documents job)
+                do (handler-case
+                       (progn
+                         (funcall publish-fn document)
+                         (incf (bulk-ingest-job-succeeded job)))
+                     (error (condition)
+                       (log:error
+                        "Bulk publish failed job=~a correlation=~a: ~a"
+                        (bulk-ingest-job-id job)
+                        (bulk-ingest-job-correlation-id job)
+                        condition)
+                       (incf (bulk-ingest-job-failed job)))))
+          (setf (bulk-ingest-job-status job)
+                (if (zerop (bulk-ingest-job-failed job))
+                    :completed
+                    :completed-with-errors)))
+      (error (condition)
+        (log:error "Bulk job failed job=~a correlation=~a: ~a"
+                   (bulk-ingest-job-id job)
+                   (bulk-ingest-job-correlation-id job)
+                   condition)
+        (setf (bulk-ingest-job-status job) :failed
+              (bulk-ingest-job-error-code job) "bulk_job_failed"))))
   job)
 
 (defun bulk-worker-handler (job)
@@ -123,10 +161,7 @@
                                  (tell-fn #'sento.actor:tell)
                                  (ensure-workers-fn
                                    #'start-bulk-ingest-workers))
-  "Reserve bounded queue capacity and enqueue one job without executing it.
-
-TELL-FN and ENSURE-WORKERS-FN are injectable so queue admission and latency can
-be tested independently from actor scheduling."
+  "Reserve bounded queue capacity and enqueue one authenticated job."
   (unless (funcall ensure-workers-fn)
     (signal-http-input-error
      503
@@ -138,6 +173,7 @@ be tested independently from actor scheduling."
            :principal principal
            :documents documents
            :correlation-id (current-correlation-id)
+           :service-context (star.auth:current-service-call-context)
            :submitted-at (get-universal-time))))
     (bt:with-lock-held (*bulk-ingest-lock*)
       (when (>= *bulk-pending-jobs* +bulk-max-pending-jobs+)
@@ -212,7 +248,10 @@ be tested independently from actor scheduling."
             execute-bulk-job
             submit-bulk-ingest-job
             bulk-ingest-job
+            bulk-ingest-job-principal
+            bulk-ingest-job-service-context
             bulk-ingest-job-status
             bulk-ingest-job-succeeded
-            bulk-ingest-job-failed)
+            bulk-ingest-job-failed
+            service-context-properties)
           :star.frontends.http-api))

--- a/source/gserver-settings.lisp
+++ b/source/gserver-settings.lisp
@@ -1,49 +1,126 @@
 (in-package :star)
-;;;  Version info
+
+(defun read-secret-file (path)
+  (when (and path (probe-file path))
+    (string-trim '(#\Space #\Tab #\Newline #\Return)
+                 (uiop:read-file-string path))))
+
+(defun environment-secret (value-variable file-variable)
+  (or (uiop:getenv value-variable)
+      (read-secret-file (uiop:getenv file-variable))))
+
+(defun environment-boolean (name &optional default)
+  (let ((value (uiop:getenv name)))
+    (if value
+        (member (string-downcase value)
+                '("1" "true" "yes" "on")
+                :test #'string=)
+        default)))
+
+(defun environment-integer (name default)
+  (let ((value (uiop:getenv name)))
+    (if value
+        (parse-integer value :junk-allowed nil)
+        default)))
+
+(defun split-comma-setting (value)
+  (when value
+    (loop with start = 0
+          for position = (position #\, value :start start)
+          for item = (string-trim '(#\Space #\Tab)
+                                  (subseq value start position))
+          when (plusp (length item))
+            collect item
+          while position
+          do (setf start (1+ position)))))
+
+;;; Version info
 (defparameter *star-server-version* "0.0.1")
-;;;; ** Gserver Settings
-;;;; *** Couchdb
-(defparameter *couchdb-host* (or (uiop:getenv "COUCHDB_HOST") "127.0.0.1") "The Couchdb host to use.
-Defaults to using ENV var $COUCHDB_HOST if set, or localhost ")
-(defparameter *couchdb-port* 5984 "The Couchdb port to use. Defaults to 5984")
-(defparameter *couchdb-default-database* (or (uiop:getenv "COUCHDB_DATABASE") "starintel") "the default database name to use.")
 
-(defparameter *couchdb-auth-database* "starintel-gserver-auth")
-(defparameter *couchdb-scheme* "http" "what http scheme to use. set to http or https")
-(defparameter *couchdb-user* (or (uiop:getenv "COUCHDB_USER") "admin") "couchdb user")
-(defparameter *couchdb-password* (uiop:getenv "COUCHDB_PASSWORD") "couchdb user password")
-;;;; By Default the views in starintel-gserver/views will be installed, but you can append your own to this setting to have it created at startup.
-(defparameter *couchdb-views* (let ((files (uiop:directory-files (uiop:merge-pathnames* "views/" (asdf:system-source-directory :starintel-gserver)))))
-                                (loop for file in files
-                                      collect (with-open-file (str file)
-                                                (let ((content (make-string (file-length str))))
-                                                  (read-sequence content str)
-                                                  content))))
-  "List of views to install into couchdb.")
+;;;; CouchDB
+(defparameter *couchdb-host*
+  (or (uiop:getenv "COUCHDB_HOST") "127.0.0.1"))
+(defparameter *couchdb-port*
+  (environment-integer "COUCHDB_PORT" 5984))
+(defparameter *couchdb-default-database*
+  (or (uiop:getenv "COUCHDB_DATABASE") "starintel"))
+(defparameter *couchdb-auth-database*
+  (or (uiop:getenv "STAR_AUTH_DATABASE") "starintel-gserver-auth"))
+(defparameter *couchdb-scheme*
+  (or (uiop:getenv "COUCHDB_SCHEME") "http"))
+(defparameter *couchdb-user*
+  (or (uiop:getenv "COUCHDB_USER") "admin"))
+(defparameter *couchdb-password*
+  (environment-secret "COUCHDB_PASSWORD" "COUCHDB_PASSWORD_FILE"))
 
-;;;; *** HTTP API
-(defparameter *http-api-address* (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") "localhost") "the listen address")
-(defparameter *http-api-port* 5000  "the port the api server listen on")
-(defparameter *http-api-base-path* "/api" "the base url to use for the api endpoint")
-(defparameter *http-cert-file* nil "path to the http api cert providing https")
-(defparameter *http-key-file* nil "path to the http cert providing https")
-(defparameter *http-scheme* 'http "use https or not.")
+(defparameter *couchdb-views*
+  (let ((files
+          (uiop:directory-files
+           (uiop:merge-pathnames*
+            "views/"
+            (asdf:system-source-directory :starintel-gserver)))))
+    (loop for file in files
+          collect
+          (with-open-file (stream file)
+            (let ((content (make-string (file-length stream))))
+              (read-sequence content stream)
+              content))))
+  "View documents installed into the intelligence database at startup.")
 
-;;;; *** RabbitMQ
-(defparameter *rabbit-address* (or (uiop:getenv "RABBITMQ_ADDRESS") "localhost") "The address rabbitmq is running on.")
-(defparameter *rabbit-port* 5672 "The port that rabbitmq is listening on.")
-(defparameter *rabbit-user* (or (uiop:getenv "RABBITMQ_USER") "guest") "the username for rabbitmq")
-(defparameter *rabbit-password* (uiop:getenv "RABBITMQ_PASSWORD") "the password for the rabbitmq user.")
-(defparameter *slynk-port* 4009 "Port to use for SLYNK remote debugging")
+;;;; HTTP API
+(defparameter *http-api-address*
+  (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") "localhost"))
+(defparameter *http-api-port*
+  (environment-integer "HTTP_API_PORT" 5000))
+(defparameter *http-api-base-path* "/api")
+(defparameter *http-cert-file* nil)
+(defparameter *http-key-file* nil)
+(defparameter *http-scheme* 'http)
+(defparameter *http-cors-allowed-origins*
+  (split-comma-setting (uiop:getenv "STAR_AUTH_ALLOWED_ORIGINS")))
+(defparameter *http-cors-allowed-methods*
+  "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+(defparameter *http-cors-allowed-headers*
+  "Content-Type, Authorization, X-Correlation-ID, X-Request-Timeout-Ms, X-Star-Bootstrap-Secret")
 
-;;;; *** Actors
-;;;; Hooks are implemented Via nhooks you can read documentation here for how to add hooks. https://github.com/atlas-engineer/nhooks
-(defparameter *actors-start-hook* (make-instance 'nhooks:hook-void) "Actor startup hook.")
-;;;; *** Patterns
-;;;; Patterns are
-(defparameter *document-patterns* () "A List of document patterns created by defpattern")
-(defparameter *ingest-workers* 4 "Number of workers for handling documents, set to 4 by default.")
-;;;; *** actor event log
-(defparameter *couchdb-event-log-database* "starintel-event-source" "The name of the database to be used for event logs.")
-;;;; *** Bulk operations
-(defparameter *bulk-max-documents* 500 "Maximum number of documents allowed in a single bulk operation.")
+;;;; HTTP authentication
+(defparameter *auth-mode*
+  (or (uiop:getenv "STAR_AUTH_MODE") "api-key"))
+(defparameter *auth-pepper*
+  (environment-secret "STAR_AUTH_PEPPER" "STAR_AUTH_PEPPER_FILE"))
+(defparameter *auth-bootstrap-secret*
+  (environment-secret
+   "STAR_AUTH_BOOTSTRAP_SECRET"
+   "STAR_AUTH_BOOTSTRAP_SECRET_FILE"))
+(defparameter *auth-dev-bypass*
+  (not (null (environment-boolean "STAR_AUTH_DEV_BYPASS" nil))))
+(defparameter *auth-key-secret-bytes* 32)
+(defparameter *auth-salt-bytes* 16)
+(defparameter *auth-rotation-overlap-max-seconds*
+  (environment-integer "STAR_AUTH_MAX_ROTATION_OVERLAP_SECONDS" 86400))
+(defparameter *auth-default-request-timeout-ms*
+  (environment-integer "STAR_AUTH_DEFAULT_REQUEST_TIMEOUT_MS" 30000))
+(defparameter *auth-max-request-timeout-ms*
+  (environment-integer "STAR_AUTH_MAX_REQUEST_TIMEOUT_MS" 600000))
+(defparameter *auth-public-paths*
+  '("/health" "/" "/auth/bootstrap"))
+
+;;;; RabbitMQ
+(defparameter *rabbit-address*
+  (or (uiop:getenv "RABBITMQ_ADDRESS") "localhost"))
+(defparameter *rabbit-port*
+  (environment-integer "RABBITMQ_PORT" 5672))
+(defparameter *rabbit-user*
+  (or (uiop:getenv "RABBITMQ_USER") "guest"))
+(defparameter *rabbit-password*
+  (environment-secret "RABBITMQ_PASSWORD" "RABBITMQ_PASSWORD_FILE"))
+(defparameter *slynk-port* 4009)
+
+;;;; Actors and patterns
+(defparameter *actors-start-hook* (make-instance 'nhooks:hook-void))
+(defparameter *document-patterns* nil)
+(defparameter *ingest-workers* 4)
+
+;;;; Event log and bulk operations
+(defparameter *couchdb-event-log-database* "starintel-event-source")
+(defparameter *bulk-max-documents* 500)

--- a/source/main.lisp
+++ b/source/main.lisp
@@ -1,6 +1,5 @@
 (in-package :starintel-gserver)
 
-
 (defun server/options ()
   (list
    (clingon:make-option
@@ -12,84 +11,61 @@
     :env-vars '("STAR_SERVER_INIT_FILE")
     :key :init-value)))
 
+(defun initialize-runtime (init-file)
+  (safe-load-init init-file)
+  (log:info "Creating ~a worker threads" star:*ingest-workers*)
+  (setf lparallel:*kernel*
+        (lparallel:make-kernel star:*ingest-workers*))
+  (star.databases.couchdb:init-db)
+  (star.auth:initialize-auth-store)
+  (star.actors:start-actors
+   :rabbit-host *rabbit-address*
+   :rabbit-vhost "/"
+   :rabbit-port *rabbit-port*
+   :rabbit-user *rabbit-user*
+   :rabbit-password *rabbit-password*)
+  (star.frontends.http-api::start-http-api)
+  (star.rabbit:start-consumers)
+  (star.actors:start-event-consumer 2))
 
-(defun server/handler (cmd)
-  (let ((debugger (clingon:getopt cmd :debugger))
-        (init-file (clingon:getopt cmd :init-value)))
-
-    (safe-load-init init-file)
-    
-    (log:info (format nil "Creating ~a worker threads" star:*ingest-workers*))
-    (setf lparallel:*kernel* (lparallel:make-kernel star:*ingest-workers*))
-    (star.databases.couchdb:init-db)
-    (star.actors:start-actors :rabbit-host *rabbit-address*
-                              :rabbit-vhost "/"
-                              :rabbit-port *rabbit-port*
-                              :rabbit-user *rabbit-user*
-                              :rabbit-password *rabbit-password*)
-    (star.frontends.http-api::start-http-api)
-    (star.rabbit:start-consumers)
-    (star.actors:start-event-consumer 2))
-
+(defun server/handler (command)
+  (initialize-runtime (clingon:getopt command :init-value))
   (loop for thread in (bt:all-threads)
-        if (not (equal thread (bt:current-thread)))
+        unless (equal thread (bt:current-thread))
           do (bt:join-thread thread)))
 
-
-
 (defun server/command ()
-  "Start server"
   (clingon:make-command
    :name "start"
-   :description "start the server"
+   :description "Start the server"
    :authors '("nsaspy <nsaspy@airmail.cc>")
    :license "GPL v3"
    :options (server/options)
    :handler #'server/handler))
 
-
 (defun main/commands ()
-  (list
-   (server/command)))
+  (list (server/command)))
 
-(defun main/handler (cmd)
-  "Print usage/exit"
-  (clingon:print-usage-and-exit cmd t))
-
+(defun main/handler (command)
+  (clingon:print-usage-and-exit command t))
 
 (defun main/command ()
-  (clingon:make-command :name "star-server"
-                        :version *star-server-version*
-                        :description "Starintel unified API and document consuming service."
-                        :authors '("nsaspy <nsaspy@airmail.cc>")
-                        :license "GPL v3"
-                        :handler #'main/handler
-                        :sub-commands (main/commands)))
+  (clingon:make-command
+   :name "star-server"
+   :version *star-server-version*
+   :description "StarIntel unified API and document-consuming service."
+   :authors '("nsaspy <nsaspy@airmail.cc>")
+   :license "GPL v3"
+   :handler #'main/handler
+   :sub-commands (main/commands)))
 
 (defun start-debugger ()
   (format t "Creating slynk server on port: ~a" star:*slynk-port*)
   (slynk:create-server :port star:*slynk-port*))
 
-
-
 (defun main ()
-  (let ((app (main/command)))
-    (clingon:run app)))
-
+  (clingon:run (main/command)))
 
 (defun repl/main (init-file)
-  "Load the server from the repl"
-  
-  (safe-load-init init-file)
-  (log:info (format nil "Creating ~a worker threads" star:*ingest-workers*))
-  (setf lparallel:*kernel* (lparallel:make-kernel star:*ingest-workers*))
-  (star.databases.couchdb:init-db)
-  (star.actors:start-actors :rabbit-host *rabbit-address*
-                            :rabbit-vhost "/"
-                            :rabbit-port *rabbit-port*
-                            :rabbit-user *rabbit-user*
-                            :rabbit-password *rabbit-password*)
-  (star.frontends.http-api::start-http-api)
-  (star.rabbit:start-consumers)
-  (star.actors:start-event-consumer 2))
-
+  "Load and start the server from the REPL."
+  (initialize-runtime init-file))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -1,7 +1,7 @@
 ;; [[file:../source.org::*Namespace setup][Namespace setup:2]]
-(uiop:define-package   :starintel-gserver
+(uiop:define-package :starintel-gserver
   (:nicknames :star)
-  (:use       :cl)
+  (:use :cl)
   (:export
    #:*rabbit-password*
    #:*rabbit-user*
@@ -13,12 +13,26 @@
    #:*http-api-base-path*
    #:*http-api-port*
    #:*http-api-address*
+   #:*http-cors-allowed-origins*
+   #:*http-cors-allowed-methods*
+   #:*http-cors-allowed-headers*
    #:*couchdb-default-database*
+   #:*couchdb-auth-database*
    #:*couchdb-host*
    #:*couchdb-port*
    #:*couchdb-user*
    #:*couchdb-password*
    #:*couchdb-scheme*
+   #:*auth-mode*
+   #:*auth-pepper*
+   #:*auth-bootstrap-secret*
+   #:*auth-dev-bypass*
+   #:*auth-key-secret-bytes*
+   #:*auth-salt-bytes*
+   #:*auth-rotation-overlap-max-seconds*
+   #:*auth-default-request-timeout-ms*
+   #:*auth-max-request-timeout-ms*
+   #:*auth-public-paths*
    #:main
    #:reload
    #:start-debugger
@@ -35,71 +49,151 @@
    #:*bulk-max-documents*
    #:repl/main))
 
-
-(uiop:define-package   :star.databases.couchdb
-  (:use       :cl-couch :cl :star #:lparallel)
-  (:export :init-db
-   :init-views
-           :init-event-db
-   :get-targets*
-           :get-view-docs
-   :query-view
-           :map-view-results
-   :get-neighbors
-           :search-fts
-   :sort-docs-by-date
-           :messages-by-user
-   :messages-by-platform
-           :messages-by-group
-   :social-posts-by-user
-           :social-posts-by-group
-   :by-channel
-           :export-by-dataset*
-   :count-by-dtype
-           :dataset-size
-   :total-documents-since
-           :orgs-by-country
-   :orgs-by-name
-           :persons-by-name
-   :persons-by-region
-           :relations-edges
-   :relations-incoming-count
-           :relations-outgoing-count
-   :targets-actor-counts
-           :targets-by-actor
-   :targets-target-count
-           :users-by-platform
-   :users-by-name
-           :as-json
-   :format-key
-           :from-json
-   :*couchdb-pool*
-           :groups
-   :lazy
-           :events-by-actor
-   :document-events
-           :target-events
-   :hosts-by-ip
-           :hosts-by-port
-   :hosts-by-service
-           :emails-by-email
-   :emails-by-domain
-           :emails-with-password
-   :domains-by-record
-           :domains-by-resolved-address
-   :networks-by-asn
-           :networks-by-org
-   :breaches-by-size
-           :urls-by-url
-   :urls-by-path
-           :urls-by-domain)
-  (:documentation "doc"))
+(uiop:define-package :star.databases.couchdb
+  (:use :cl-couch :cl :star #:lparallel)
+  (:export
+   #:init-db
+   #:init-views
+   #:init-event-db
+   #:get-targets*
+   #:get-view-docs
+   #:query-view
+   #:map-view-results
+   #:get-neighbors
+   #:search-fts
+   #:sort-docs-by-date
+   #:messages-by-user
+   #:messages-by-platform
+   #:messages-by-group
+   #:social-posts-by-user
+   #:social-posts-by-group
+   #:by-channel
+   #:export-by-dataset*
+   #:count-by-dtype
+   #:dataset-size
+   #:total-documents-since
+   #:orgs-by-country
+   #:orgs-by-name
+   #:persons-by-name
+   #:persons-by-region
+   #:relations-edges
+   #:relations-incoming-count
+   #:relations-outgoing-count
+   #:targets-actor-counts
+   #:targets-by-actor
+   #:targets-target-count
+   #:users-by-platform
+   #:users-by-name
+   #:as-json
+   #:format-key
+   #:from-json
+   #:*couchdb-pool*
+   #:groups
+   #:lazy
+   #:events-by-actor
+   #:document-events
+   #:target-events
+   #:hosts-by-ip
+   #:hosts-by-port
+   #:hosts-by-service
+   #:emails-by-email
+   #:emails-by-domain
+   #:emails-with-password
+   #:domains-by-record
+   #:domains-by-resolved-address
+   #:networks-by-asn
+   #:networks-by-org
+   #:breaches-by-size
+   #:urls-by-url
+   #:urls-by-path
+   #:urls-by-domain)
+  (:documentation "CouchDB persistence and query helpers."))
 ;; Namespace setup:2 ends here
 
+(uiop:define-package :star.auth
+  (:use :cl)
+  (:export
+   #:+api-key-prefix+
+   #:authentication-error
+   #:authentication-error-code
+   #:authentication-error-message
+   #:credential-lifecycle-error
+   #:credential-lifecycle-error-code
+   #:credential-lifecycle-error-message
+   #:request-principal
+   #:request-principal-id
+   #:request-principal-type
+   #:request-principal-scopes
+   #:request-principal-credential-id
+   #:request-security-context
+   #:request-security-context-principal
+   #:request-security-context-correlation-id
+   #:request-security-context-deadline
+   #:request-security-context-authenticated-at
+   #:service-call-context
+   #:service-call-context-principal-id
+   #:service-call-context-principal-type
+   #:service-call-context-credential-id
+   #:service-call-context-scopes
+   #:service-call-context-correlation-id
+   #:service-call-context-deadline
+   #:api-key-record
+   #:api-key-record-id
+   #:api-key-record-owner
+   #:api-key-record-principal-type
+   #:api-key-record-scopes
+   #:api-key-record-status
+   #:api-key-record-salt
+   #:api-key-record-verifier
+   #:api-key-record-created-at
+   #:api-key-record-expires-at
+   #:api-key-record-disabled-at
+   #:api-key-record-revoked-at
+   #:api-key-record-rotation-parent-id
+   #:api-key-record-superseded-by
+   #:api-key-record-overlap-expires-at
+   #:api-key-record-revision
+   #:credential-store
+   #:memory-credential-store
+   #:couchdb-credential-store
+   #:make-memory-credential-store
+   #:make-couchdb-credential-store
+   #:credential-store-get
+   #:credential-store-put
+   #:credential-store-update
+   #:credential-store-list
+   #:credential-store-count
+   #:*credential-store*
+   #:*request-security-context*
+   #:*auth-clock*
+   #:*verifier-compare-function*
+   #:auth-now
+   #:constant-time-octets=
+   #:constant-time-secret=
+   #:parse-api-key
+   #:bearer-token
+   #:signal-authentication-failure
+   #:authenticate-api-key
+   #:authenticate-authorization-header
+   #:current-request-principal
+   #:current-principal-id
+   #:current-service-call-context
+   #:scope-granted-p
+   #:administrator-principal-p
+   #:create-api-key
+   #:bootstrap-api-key
+   #:rotate-api-key
+   #:revoke-api-key
+   #:disable-api-key
+   #:api-key-metadata-json
+   #:list-api-key-metadata
+   #:validate-auth-configuration
+   #:initialize-auth-store))
+
 ;; [[file:../source.org::*Namespace setup][Namespace setup:3]]
-(uiop:define-package   :star.rabbit
-  (:use       :cl :star.consumers  :sento.actor)
-  (:documentation "Rabitmq namespace")
+(uiop:define-package :star.rabbit
+  (:use :cl :star.consumers :sento.actor)
+  (:documentation "RabbitMQ namespace")
   (:export
    #:with-rabbit-send
    #:with-rabbit-recv
@@ -127,9 +221,10 @@
    #:+updates-topic-key+))
 ;; Namespace setup:3 ends here
 
-(uiop:define-package   :star.actors
-  (:use       :cl :star.databases.couchdb :sento.agent :sento.actor :sento.actor-system :sento.actor-context)
-  (:documentation "doc")
+(uiop:define-package :star.actors
+  (:use :cl :star.databases.couchdb :sento.agent :sento.actor
+        :sento.actor-system :sento.actor-context)
+  (:documentation "Actor runtime namespace")
   (:export
    #:register-actor
    #:*targets*
@@ -160,12 +255,12 @@
    #:event-source-document
    #:event-id))
 
-
 ;; [[file:../source.org::*Namespace setup][Namespace setup:4]]
-(uiop:define-package   :starintel-gserver-http-api
+(uiop:define-package :starintel-gserver-http-api
   (:nicknames :star.frontends.http-api)
-  (:use       :cl :ningle :anypool :star.databases.couchdb :star)
-  (:documentation "simple http api.")
+  (:use :cl :ningle :anypool :star.databases.couchdb :star)
+  (:documentation "StarIntel HTTP API.")
   (:export
+   #:*app*
    #:*default-headers*))
 ;; Namespace setup:4 ends here

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -19,6 +19,7 @@
    (:file "databases/couchdb")
    (:file "databases/export")
    (:file "auth/core")
+   (:file "auth/verification-hardening")
    (:file "auth/store")
    (:file "init-loader")
    (:file "actors")

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -20,6 +20,7 @@
    (:file "databases/export")
    (:file "auth/core")
    (:file "auth/verification-hardening")
+   (:file "auth/immutability")
    (:file "auth/store")
    (:file "init-loader")
    (:file "actors")

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -1,87 +1,63 @@
 (asdf:defsystem :starintel-gserver
-  :version      "0.1.0"
-  :description  "hackable/moddable starintel acess api."
-  :author       "nsaspy@airmail.cc"
-  :license      "GPL v3"
+  :version "0.1.0"
+  :description "Hackable StarIntel document and actor service."
+  :author "nsaspy@airmail.cc"
+  :license "GPL v3"
   :serial t
   :build-operation program-op
-  :build-pathname "star-server" ;; shell name
-  :entry-point "star::main"     ;; thunk
+  :build-pathname "star-server"
+  :entry-point "star::main"
   :in-order-to ((test-op (test-op "starintel-gserver-tests")))
-  :components   (
-                 (:file "consumers/package")
-                 (:file "consumers/consumers")
-                 (:file "consumers/rabbit-settlement")
-                 (:file "producers/package")
-                 (:file "producers/producers")
-                 (:file "package")
-                 (:file "gserver-settings")
-                 (:file "databases/couchdb")
-                 (:file "databases/export")
-                 (:file "init-loader")
-                 (:file "actors")
-                 (:file "actors/couchdb-service")
-                 (:file "actor-systems/event-actor")
-                 (:file "actor-systems/matcher-actor")
-                 (:file "rabbit")
-                 (:file "frontends/http-api")
-                 (:file "frontends/http-boundary-core")
-                 (:file "frontends/http-bulk-jobs")
-                 (:file "frontends/http-boundary-routes")
-                 (:file "main"))
+  :components
+  ((:file "consumers/package")
+   (:file "consumers/consumers")
+   (:file "consumers/rabbit-settlement")
+   (:file "producers/package")
+   (:file "producers/producers")
+   (:file "package")
+   (:file "gserver-settings")
+   (:file "databases/couchdb")
+   (:file "databases/export")
+   (:file "auth/core")
+   (:file "auth/store")
+   (:file "init-loader")
+   (:file "actors")
+   (:file "actors/couchdb-service")
+   (:file "actor-systems/event-actor")
+   (:file "actor-systems/matcher-actor")
+   (:file "rabbit")
+   (:file "frontends/http-api")
+   (:file "frontends/http-boundary-core")
+   (:file "frontends/http-auth")
+   (:file "frontends/http-bulk-jobs")
+   (:file "frontends/http-boundary-routes")
+   (:file "frontends/http-auth-routes")
+   (:file "main"))
+  :depends-on
+  (#:starintel
+   #:cl-couch
+   #:serapeum
+   #:alexandria
+   #:cl-rabbit
+   #:sento
+   #:babel
+   #:yason
+   #:ironclad
+   #:dexador
+   #:uuid
+   #:anypool
+   #:clack
+   #:lack/middleware/accesslog
+   #:clack-handler-hunchentoot
+   #:ningle
+   #:clingon
+   #:slynk
+   #:nhooks
+   #:lparallel
+   #:cl-stream
+   #:cl-ppcre
+   #:cms-ulid
+   #:bordeaux-threads))
 
-  :depends-on   (#:starintel
-                 #:cl-couch
-                 #:serapeum
-                 #:alexandria
-                 #:cl-rabbit
-                 #:sento
-                 #:babel
-                 #:yason
-                 #:uuid
-                 #:anypool
-                 #:clack
-                 #:lack/middleware/accesslog
-                 #:clack-handler-hunchentoot
-                 #:ningle
-                 #:clingon
-                 #:slynk
-                 #:nhooks
-                 #:lparallel
-                 #:cl-stream
-                 #:cl-ppcre
-                 #:cms-ulid
-                 #:bordeaux-threads))
-;;;; * Starintel Gserver
-;;;;@include "gserver-settings.lisp"
-;;;; * Warning
-;;;;  Please do not use starintel-gserver in production! it is a PROTYPE, or really any star-* thing. they are subject to change as i correct or find better ideas.
-;;;;  Somethings are fairly fine but its not optmized, its a working notepad as of now.
-;;;; * About StarIntel Gserver
-;;;; Starintel-gserver is a processing framework for starintel documents.
-;;;; it was created after a need that a mess of random scripts, bots and a database wasnt enough.
-;;;; I needed something to allow multiple bots to communicate, store, query and handle new targets.
-;;;; As of <2024-09-04 Wed> This is the second iteration of the starintel service.
-;;;; This version improves on starRouter with actors instead of what i called actors, are really just consumers in
-;;;; star-gserver. Gserver started in a org-mode notebook while i scketched things out.
-;;;;
-;;;;
-
-
-
-;;;;** What in the box
-;;;; Actors, provided by cl-gserver, not written by me. i named it gserver becuase this was the "gserver" version of starRouter, which no longer used ZMQ.
-;;;; Recurring Targets (NO GUARENTEE!)
-;;;; Database actor
-;;;; Extensibility provided by simple init file and hooks.
-;;;; simple http api
-;;;; rabbitmq consumers (akin to starRouter actors)
-;;;; producers
-;;;;
-;;;;** Todo
-;;;;
-;;;; + [ ] Durable target scheduling
-;;;;
-;;;; + [ ] ZMQ api for bulk use
-;;;;
-;;;; + [ ] A simpler to use "plugin" system
+;;;; StarIntel Gserver is a processing framework for StarIntel documents.
+;;;; Runtime documentation lives in ../docs and must track behavior changes.

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -32,6 +32,7 @@
    (:file "frontends/http-bulk-jobs")
    (:file "frontends/http-boundary-routes")
    (:file "frontends/http-auth-routes")
+   (:file "frontends/http-auth-job-routes")
    (:file "main"))
   :depends-on
   (#:starintel

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -1,38 +1,44 @@
 (asdf:defsystem :starintel-gserver-tests
-  :version      "0.1.0"
-  :description  "Hermetic unit test suite for starintel-gserver"
-  :author       "nsaspy@airmail.cc"
-  :license      "GPL v3"
+  :version "0.1.0"
+  :description "Hermetic unit test suite for starintel-gserver"
+  :author "nsaspy@airmail.cc"
+  :license "GPL v3"
   :serial t
-  :depends-on   (#:starintel-gserver
-                   #:starintel-gserver-client
-                   #:star-cli
-                   #:star-ui
-                   #:star-migrations
-                   #:fiveam
-                   #:dexador
-                   #:bordeaux-threads
-                   #:jsown)
-  :components   ((:module "t"
-                   :serial t
-                   :components ((:file "package")
-                                (:file "test-runner")
-                                (:file "test-runner-test")
-                                (:file "consumers-test")
-                                (:file "init-loader-test")
-                                (:file "target-routing-test")
-                                (:file "system-load-test")
-                                (:file "couchdb-actor-test")
-                                (:file "event-actor-test")
-                                (:file "dataset-export-test")
-                                (:file "http-boundary-test")
-                                (:file "run-tests"))))
-  :perform (test-op (o c)
-                     (declare (ignore o c))
-                     (uiop:symbol-call :star-server-tests :run-all-gserver-tests)))
+  :depends-on
+  (#:starintel-gserver
+   #:starintel-gserver-client
+   #:star-cli
+   #:star-ui
+   #:star-migrations
+   #:fiveam
+   #:dexador
+   #:bordeaux-threads
+   #:jsown)
+  :components
+  ((:module "t"
+    :serial t
+    :components
+    ((:file "package")
+     (:file "test-runner")
+     (:file "test-runner-test")
+     (:file "consumers-test")
+     (:file "init-loader-test")
+     (:file "target-routing-test")
+     (:file "system-load-test")
+     (:file "couchdb-actor-test")
+     (:file "event-actor-test")
+     (:file "dataset-export-test")
+     (:file "http-boundary-test")
+     (:file "http-auth-test")
+     (:file "run-tests"))))
+  :perform
+  (test-op (operation component)
+    (declare (ignore operation component))
+    (uiop:symbol-call
+     :star-server-tests
+     :run-all-gserver-tests)))
 
 ;;;; Canonical unit entry point:
 ;;;;   (asdf:test-system :starintel-gserver-tests)
-;;;;
-;;;; Service-backed coverage is intentionally isolated in
+;;;; Service-backed coverage is isolated in
 ;;;; :starintel-gserver-integration-tests.

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -30,6 +30,7 @@
      (:file "dataset-export-test")
      (:file "http-boundary-test")
      (:file "http-auth-test")
+     (:file "http-auth-oracle-test")
      (:file "run-tests"))))
   :perform
   (test-op (operation component)

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -31,6 +31,7 @@
      (:file "http-boundary-test")
      (:file "http-auth-test")
      (:file "http-auth-oracle-test")
+     (:file "http-auth-immutability-test")
      (:file "run-tests"))))
   :perform
   (test-op (operation component)

--- a/t/http-auth-immutability-test.lisp
+++ b/t/http-auth-immutability-test.lisp
@@ -1,0 +1,49 @@
+(in-package :star-server-tests)
+
+(in-suite http-auth-tests)
+
+(test request-principal-accessors-return-defensive-copies
+  (let* ((principal
+           (star.auth::%make-request-principal
+            :id "principal-original"
+            :type "api_client"
+            :scopes '("documents:read" "search:read")
+            :credential-id "credential-original"))
+         (first-id (star.auth:request-principal-id principal))
+         (first-scopes (star.auth:request-principal-scopes principal))
+         (first-credential-id
+           (star.auth:request-principal-credential-id principal)))
+    (setf (char first-id 0) #\X
+          (char (first first-scopes) 0) #\X
+          (char first-credential-id 0) #\X)
+    (setf (cdr first-scopes) nil)
+    (is (string= "principal-original"
+                 (star.auth:request-principal-id principal)))
+    (is (equal '("documents:read" "search:read")
+               (star.auth:request-principal-scopes principal)))
+    (is (string= "credential-original"
+                 (star.auth:request-principal-credential-id principal)))))
+
+(test service-call-context-accessors-return-defensive-copies
+  (let* ((context
+           (star.auth::%make-service-call-context
+            :principal-id "service-original"
+            :principal-type "actor_component"
+            :credential-id "credential-original"
+            :scopes '("targets:lease")
+            :correlation-id "correlation-original"
+            :deadline 1000))
+         (principal-id
+           (star.auth:service-call-context-principal-id context))
+         (scopes (star.auth:service-call-context-scopes context))
+         (correlation-id
+           (star.auth:service-call-context-correlation-id context)))
+    (setf (char principal-id 0) #\X
+          (char (first scopes) 0) #\X
+          (char correlation-id 0) #\X)
+    (is (string= "service-original"
+                 (star.auth:service-call-context-principal-id context)))
+    (is (equal '("targets:lease")
+               (star.auth:service-call-context-scopes context)))
+    (is (string= "correlation-original"
+                 (star.auth:service-call-context-correlation-id context)))))

--- a/t/http-auth-oracle-test.lisp
+++ b/t/http-auth-oracle-test.lisp
@@ -1,0 +1,41 @@
+(in-package :star-server-tests)
+
+(in-suite http-auth-tests)
+
+(test unknown-credential-id-uses-the-verifier-comparison-path
+  (let* ((star:*auth-pepper* "unit-test-pepper")
+         (store (star.auth:make-memory-credential-store))
+         (calls 0)
+         (unknown-key
+           (format nil "star_sk_v1_unknown_~a"
+                   (make-string 64 :initial-element #\a))))
+    (let ((star.auth:*verifier-compare-function*
+            (lambda (left right)
+              (incf calls)
+              (star.auth:constant-time-octets= left right))))
+      (is (string= "invalid_credential"
+                   (captured-authentication-code
+                    (lambda ()
+                      (authenticate-test-key unknown-key store)))))
+      (is (= 1 calls)))))
+
+(test inactive-credential-still-uses-the-verifier-comparison-path
+  (let* ((star:*auth-pepper* "unit-test-pepper")
+         (store (star.auth:make-memory-credential-store))
+         (calls 0))
+    (multiple-value-bind (record raw-key)
+        (star.auth:create-api-key
+         "inactive-client" "api_client" '("documents:read")
+         :store store)
+      (star.auth:revoke-api-key
+       (star.auth:api-key-record-id record)
+       :store store)
+      (let ((star.auth:*verifier-compare-function*
+              (lambda (left right)
+                (incf calls)
+                (star.auth:constant-time-octets= left right))))
+        (is (string= "invalid_credential"
+                     (captured-authentication-code
+                      (lambda ()
+                        (authenticate-test-key raw-key store)))))
+        (is (= 1 calls))))))

--- a/t/http-auth-test.lisp
+++ b/t/http-auth-test.lisp
@@ -1,0 +1,280 @@
+(in-package :star-server-tests)
+
+(def-suite http-auth-tests
+  :description "API-key authentication, lifecycle, redaction, and concurrency")
+
+(in-suite http-auth-tests)
+
+(defun captured-authentication-code (thunk)
+  (handler-case
+      (progn
+        (funcall thunk)
+        nil)
+    (star.auth:authentication-error (condition)
+      (star.auth:authentication-error-code condition))))
+
+(defun captured-lifecycle-code (thunk)
+  (handler-case
+      (progn
+        (funcall thunk)
+        nil)
+    (star.auth:credential-lifecycle-error (condition)
+      (star.auth:credential-lifecycle-error-code condition))))
+
+(defun altered-api-key (api-key)
+  (let* ((last-index (1- (length api-key)))
+         (last-character (char api-key last-index))
+         (replacement (if (char= last-character #\0) #\1 #\0)))
+    (concatenate 'string
+                 (subseq api-key 0 last-index)
+                 (string replacement))))
+
+(defun authenticate-test-key (raw-key store &optional (correlation-id "corr-auth"))
+  (star.auth:authenticate-authorization-header
+   (format nil "Bearer ~a" raw-key)
+   correlation-id
+   (+ (star.auth:auth-now) 30)
+   :store store))
+
+(test missing-malformed-expired-disabled-revoked-and-incorrect-credentials-are-rejected
+  (let* ((now 1000)
+         (star.auth:*auth-clock* (lambda () now))
+         (star:*auth-pepper* "unit-test-pepper")
+         (store (star.auth:make-memory-credential-store)))
+    (multiple-value-bind (valid-record valid-key)
+        (star.auth:create-api-key
+         "valid-client" "api_client" '("documents:read") :store store)
+      (declare (ignore valid-record))
+      (dolist (header
+               (list nil
+                     ""
+                     "Basic abc"
+                     "Bearer broken"
+                     "Bearer star_sk_v2_bad_bad"
+                     (format nil "Bearer ~a" (altered-api-key valid-key))))
+        (is (string= "invalid_credential"
+                     (captured-authentication-code
+                      (lambda ()
+                        (star.auth:authenticate-authorization-header
+                         header "corr-reject" 1030 :store store)))))))
+    (multiple-value-bind (expired-record expired-key)
+        (star.auth:create-api-key
+         "expired-client" "api_client" '("documents:read")
+         :expires-in-seconds 1
+         :store store)
+      (declare (ignore expired-record))
+      (incf now 2)
+      (is (string= "invalid_credential"
+                   (captured-authentication-code
+                    (lambda ()
+                      (authenticate-test-key expired-key store))))))
+    (multiple-value-bind (disabled-record disabled-key)
+        (star.auth:create-api-key
+         "disabled-client" "api_client" '("documents:read") :store store)
+      (star.auth:disable-api-key
+       (star.auth:api-key-record-id disabled-record)
+       :store store)
+      (is (string= "invalid_credential"
+                   (captured-authentication-code
+                    (lambda ()
+                      (authenticate-test-key disabled-key store))))))
+    (multiple-value-bind (revoked-record revoked-key)
+        (star.auth:create-api-key
+         "revoked-client" "api_client" '("documents:read") :store store)
+      (star.auth:revoke-api-key
+       (star.auth:api-key-record-id revoked-record)
+       :store store)
+      (is (string= "invalid_credential"
+                   (captured-authentication-code
+                    (lambda ()
+                      (authenticate-test-key revoked-key store))))))))
+
+(test valid-credential-creates-immutable-request-principal
+  (let* ((star:*auth-pepper* "unit-test-pepper")
+         (store (star.auth:make-memory-credential-store)))
+    (multiple-value-bind (record raw-key)
+        (star.auth:create-api-key
+         "quasar-client"
+         "api_client"
+         '("documents:read" "search:read")
+         :store store)
+      (let* ((context (authenticate-test-key raw-key store "corr-valid"))
+             (principal
+               (star.auth:request-security-context-principal context)))
+        (is (string= "quasar-client"
+                     (star.auth:request-principal-id principal)))
+        (is (string= "api_client"
+                     (star.auth:request-principal-type principal)))
+        (is (string= (star.auth:api-key-record-id record)
+                     (star.auth:request-principal-credential-id principal)))
+        (is (equal '("documents:read" "search:read")
+                   (star.auth:request-principal-scopes principal)))
+        (is (string= "corr-valid"
+                     (star.auth:request-security-context-correlation-id
+                      context)))))))
+
+(test verifier-boundary-uses-constant-time-comparison
+  (let* ((star:*auth-pepper* "unit-test-pepper")
+         (store (star.auth:make-memory-credential-store))
+         (calls 0))
+    (multiple-value-bind (record raw-key)
+        (star.auth:create-api-key
+         "constant-time-client" "api_client" '("documents:read")
+         :store store)
+      (declare (ignore record))
+      (let ((star.auth:*verifier-compare-function*
+              (lambda (left right)
+                (incf calls)
+                (star.auth:constant-time-octets= left right))))
+        (authenticate-test-key raw-key store)
+        (is (= 1 calls))))))
+
+(test rotation-honors-overlap-and-then-invalidates-old-secret
+  (let* ((now 2000)
+         (star.auth:*auth-clock* (lambda () now))
+         (star:*auth-pepper* "unit-test-pepper")
+         (store (star.auth:make-memory-credential-store)))
+    (multiple-value-bind (original original-key)
+        (star.auth:create-api-key
+         "rotation-client" "service_instance" '("documents:write")
+         :store store)
+      (multiple-value-bind (replacement replacement-key)
+          (star.auth:rotate-api-key
+           (star.auth:api-key-record-id original)
+           10
+           :store store)
+        (is-true (authenticate-test-key original-key store))
+        (is-true (authenticate-test-key replacement-key store))
+        (is (string= (star.auth:api-key-record-id original)
+                     (star.auth:api-key-record-rotation-parent-id replacement)))
+        (setf now 2010)
+        (is (string= "invalid_credential"
+                     (captured-authentication-code
+                      (lambda ()
+                        (authenticate-test-key original-key store)))))
+        (is-true (authenticate-test-key replacement-key store))))))
+
+(test bootstrap-is-one-time-and-does-not-store-raw-secret
+  (let* ((star:*auth-pepper* "unit-test-pepper")
+         (star:*auth-bootstrap-secret* "bootstrap-secret")
+         (store (star.auth:make-memory-credential-store)))
+    (is (string= "bootstrap_denied"
+                 (captured-lifecycle-code
+                  (lambda ()
+                    (star.auth:bootstrap-api-key
+                     "wrong-secret" "admin" :store store)))))
+    (multiple-value-bind (record raw-key)
+        (star.auth:bootstrap-api-key
+         "bootstrap-secret" "admin" :store store)
+      (let* ((metadata
+               (jsown:to-json
+                (star.auth:api-key-metadata-json record)))
+             (stored
+               (star.auth:credential-store-get
+                store
+                (star.auth:api-key-record-id record))))
+        (is (search "star_sk_v1_" raw-key))
+        (is (null (search raw-key metadata :test #'char=)))
+        (is (null (search "verifier" metadata :test #'char-equal)))
+        (is (null (search "salt" metadata :test #'char-equal)))
+        (is (not (string= raw-key
+                          (star.auth:api-key-record-verifier stored))))))
+    (is (string= "bootstrap_complete"
+                 (captured-lifecycle-code
+                  (lambda ()
+                    (star.auth:bootstrap-api-key
+                     "bootstrap-secret" "other-admin" :store store)))))))
+
+(test revocation-has-zero-cache-bound-under-concurrency
+  (let* ((star:*auth-pepper* "unit-test-pepper")
+         (store (star.auth:make-memory-credential-store))
+         (gate-lock (bt:make-lock "auth-revocation-gate"))
+         (start nil)
+         (results (make-array 16 :initial-element nil)))
+    (multiple-value-bind (record raw-key)
+        (star.auth:create-api-key
+         "concurrent-client" "api_client" '("documents:read")
+         :store store)
+      (let ((threads
+              (loop for index below (length results)
+                    collect
+                    (bt:make-thread
+                     (lambda ()
+                       (loop until
+                         (bt:with-lock-held (gate-lock) start)
+                         do (sleep 0.001))
+                       (setf (aref results index)
+                             (if (captured-authentication-code
+                                  (lambda ()
+                                    (authenticate-test-key raw-key store)))
+                                 :rejected
+                                 :accepted)))))))
+        (star.auth:revoke-api-key
+         (star.auth:api-key-record-id record)
+         :store store)
+        (bt:with-lock-held (gate-lock)
+          (setf start t))
+        (dolist (thread threads)
+          (bt:join-thread thread))
+        (is (every (lambda (result) (eq result :rejected)) results))))))
+
+(test cors-is-allowlisted-and-never-wildcard
+  (let ((star:*http-cors-allowed-origins*
+          '("https://quasar.example")))
+    (is-true
+     (star.frontends.http-api::configured-origin-allowed-p
+      "https://quasar.example"))
+    (is-false
+     (star.frontends.http-api::configured-origin-allowed-p
+      "https://attacker.example"))
+    (let ((headers
+            (star.frontends.http-api::cors-headers-for-origin
+             "https://quasar.example")))
+      (is (string= "https://quasar.example"
+                   (getf headers :access-control-allow-origin)))
+      (is (null (member "*" headers :test #'equal))))))
+
+(test authenticated-service-context-propagates-without-secret
+  (let* ((principal
+           (star.auth::%make-request-principal
+            :id "actor-service"
+            :type "actor_component"
+            :scopes '("targets:lease")
+            :credential-id "key-public-id"))
+         (context
+           (star.auth::%make-request-security-context
+            :principal principal
+            :correlation-id "corr-service"
+            :deadline 9999
+            :authenticated-at 9000))
+         (star.auth:*request-security-context* context)
+         (service-context (star.auth:current-service-call-context))
+         (properties
+           (star.frontends.http-api::service-context-properties
+            "target" service-context))
+         (headers (cdr (assoc :headers properties))))
+    (is (string= "corr-service"
+                 (cdr (assoc :correlation-id properties))))
+    (is (string= "actor-service"
+                 (cdr (assoc "x-star-principal-id" headers
+                             :test #'string=))))
+    (is (string= "key-public-id"
+                 (cdr (assoc "x-star-credential-id" headers
+                             :test #'string=))))
+    (is (string= "9999"
+                 (cdr (assoc "x-star-deadline" headers
+                             :test #'string=))))
+    (is (null (search "star_sk_" (prin1-to-string properties))))))
+
+(test authentication-configuration-fails-closed
+  (let ((star:*auth-mode* "api-key")
+        (star:*auth-pepper* nil))
+    (signals error (star.auth:validate-auth-configuration)))
+  (let ((star:*auth-mode* "disabled")
+        (star:*auth-dev-bypass* t)
+        (star:*http-api-address* "0.0.0.0"))
+    (signals error (star.auth:validate-auth-configuration)))
+  (let ((star:*auth-mode* "disabled")
+        (star:*auth-dev-bypass* t)
+        (star:*http-api-address* "127.0.0.1"))
+    (is-true (star.auth:validate-auth-configuration))))

--- a/t/http-auth-test.lisp
+++ b/t/http-auth-test.lisp
@@ -198,17 +198,18 @@
       (let ((threads
               (loop for index below (length results)
                     collect
-                    (bt:make-thread
-                     (lambda ()
-                       (loop until
-                         (bt:with-lock-held (gate-lock) start)
-                         do (sleep 0.001))
-                       (setf (aref results index)
-                             (if (captured-authentication-code
-                                  (lambda ()
-                                    (authenticate-test-key raw-key store)))
-                                 :rejected
-                                 :accepted)))))))
+                    (let ((slot index))
+                      (bt:make-thread
+                       (lambda ()
+                         (loop until
+                           (bt:with-lock-held (gate-lock) start)
+                           do (sleep 0.001))
+                         (setf (aref results slot)
+                               (if (captured-authentication-code
+                                    (lambda ()
+                                      (authenticate-test-key raw-key store)))
+                                   :rejected
+                                   :accepted))))))))
         (star.auth:revoke-api-key
          (star.auth:api-key-record-id record)
          :store store)

--- a/t/run-tests.lisp
+++ b/t/run-tests.lisp
@@ -9,7 +9,8 @@
     couchdb-actor-tests
     event-actor-tests
     dataset-export-tests
-    http-boundary-tests))
+    http-boundary-tests
+    http-auth-tests))
 
 (defun run-all-gserver-tests ()
   "Run every hermetic unit suite and fail on empty, skipped, or failed tests."


### PR DESCRIPTION
## Runtime changes

- add default-deny HTTP API-key authentication middleware with one immutable request security context
- generate opaque `star_sk_v1` credentials containing a non-secret key id and 256-bit random secret
- store only salted/peppered verifier material, status, scopes, owner, timestamps, expiration, and rotation metadata
- use constant-time verifier comparison and uniform `401 invalid_credential` responses
- create a separate CouchDB authentication database and design view
- add one-time bootstrap, create, metadata list, rotate-with-overlap, revoke, disable, and authenticated-context routes
- never return a secret after initial bootstrap/create/rotate response; mark one-time secret responses `no-store`
- configure exact CORS allowlists and remove wildcard origin behavior
- propagate principal, credential id, scopes, correlation id, and deadline into bulk jobs and RabbitMQ service-call provenance
- restrict bulk-job status to the submitting principal or an administrator
- use no authentication cache, making successful revocation visible to the next verifier lookup

## Deployment and verification

- add pepper and bootstrap Docker secrets
- bootstrap a real administrator key in the container-stack test
- require authentication for FTS and context checks
- verify unauthenticated denial, one-time bootstrap, and credential persistence after restart
- add mandatory hermetic tests for malformed, incorrect, expired, disabled, revoked, and rotated credentials; constant-time comparison; redaction; CORS; service context; fail-closed configuration; and concurrent zero-cache revocation

## Known scope boundary

The repository has no implemented KV target-lease adapter yet. This PR propagates a lease-safe service context containing principal, credential id, scopes, correlation id, and deadline so the future adapter can require explicit authenticated context rather than inferring authority.

## Merge gates

- final-head schema lock, hermetic unit, service integration, and container-stack workflows must all pass
- issue #27 acceptance tests must all be discovered and pass
- documentation must describe bootstrap, lifecycle routes, configuration, CORS, error behavior, and the zero-second cache bound
- PR remains draft until every gate passes

Fixes #27