### PR TITLE
Fix RabbitMQ queue-arg conflict and mount init file in Docker

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -24,7 +24,7 @@ a project-owned image.
 Build every project-owned image without loading it:
 
 ```bash
-nix build .#star-server-image .#couchdb-image .#clouseau-image
+nix build .#star-server-image .#couchdb-image .#clouseau-image .#rabbitmq-image
 ```
 
 Build the images, merge their archives, and load them into Docker:
@@ -34,7 +34,8 @@ nix run .#load-images
 ```
 
 The loaded tags are `starintel/server:0.1.0`,
-`starintel/couchdb:3.5.2`, and `starintel/clouseau:3.3.0`.
+`starintel/couchdb:3.5.2`, `starintel/clouseau:3.3.0`, and
+`rabbitmq:4.3.4-management`.
 
 ## Configure secrets
 
@@ -165,7 +166,8 @@ backup because its indexes can be rebuilt from CouchDB.
 
 1. Read the CouchDB and Clouseau release notes and compatibility requirements.
 2. Export every CouchDB database.
-3. Update the pinned versions, digest, and hashes in `nix/images.nix`.
+3. Update the pinned versions, digest, and hashes in `nix/images.nix`
+   (CouchDB, Clouseau, and RabbitMQ).
 4. Update the matching image tags in `docker-compose.yml`.
 5. Run `nix build` for all three images and `./scripts/stack-test.sh`.
 6. Load the new images and recreate the stack with

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ integration-test:
 	nix run .#star-integration-tests
 
 images:
-	nix build .#star-server-image .#couchdb-image .#clouseau-image
+	nix build .#star-server-image .#couchdb-image .#clouseau-image .#rabbitmq-image
 
 load-images:
 	nix run .#load-images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,11 +104,17 @@ services:
       STAR_AUTH_PEPPER_FILE: /run/secrets/auth_pepper
       STAR_AUTH_BOOTSTRAP_SECRET_FILE: /run/secrets/auth_bootstrap_secret
       STAR_AUTH_ALLOWED_ORIGINS: ${STAR_AUTH_ALLOWED_ORIGINS:-}
+      STAR_SERVER_INIT_FILE: ${STAR_SERVER_INIT_FILE:-/etc/starintel/init.lisp}
     secrets:
       - couchdb_password
       - rabbitmq_password
       - auth_pepper
       - auth_bootstrap_secret
+    volumes:
+      - type: bind
+        source: ${STAR_SERVER_INIT_HOST_FILE:-./docker/star-server-init.lisp}
+        target: /etc/starintel/init.lisp
+        read_only: true
     ports:
       - "${STAR_SERVER_BIND_ADDRESS:-127.0.0.1}:${STAR_SERVER_PORT:-5000}:5000"
     networks:

--- a/docker/star-server-entrypoint.sh
+++ b/docker/star-server-entrypoint.sh
@@ -25,5 +25,7 @@ load_secret RABBITMQ_PASSWORD
 load_secret STAR_AUTH_PEPPER
 load_secret STAR_AUTH_BOOTSTRAP_SECRET
 
+STAR_SERVER_INIT_FILE="${STAR_SERVER_INIT_FILE:-/etc/starintel/init.lisp}"
+
 exec su-exec 65532:65532 \
-  /bin/star-server start -i /etc/starintel/init.lisp
+  /bin/star-server start -i "$STAR_SERVER_INIT_FILE"

--- a/flake.nix
+++ b/flake.nix
@@ -346,6 +346,7 @@ EOF
         star-server-image = containerImages.serverImage;
         couchdb-image = containerImages.couchdbImage;
         clouseau-image = containerImages.clouseauImage;
+        rabbitmq-image = containerImages.rabbitmqImage;
         container-images = containerImages.allImages;
         load-images = containerImages.loadImages;
 

--- a/nix/images.nix
+++ b/nix/images.nix
@@ -3,6 +3,7 @@
 let
   couchdbVersion = "3.5.2";
   clouseauVersion = "3.3.0";
+  rabbitmqVersion = "4.3.4-management";
 
   couchdbBase = pkgs.dockerTools.pullImage {
     imageName = "couchdb";
@@ -10,6 +11,14 @@ let
     hash = "sha256-9ZAkDiaUE1xBwjn48KUkQqxDjEQyuhv/ghJzyVEXR7U=";
     finalImageName = "couchdb";
     finalImageTag = couchdbVersion;
+  };
+
+  rabbitmqBase = pkgs.dockerTools.pullImage {
+    imageName = "rabbitmq";
+    imageDigest = "sha256:36703420d34df0701f441730ef0ee5a28efc27611ca5b4b48a2bf6571c9b2854";
+    hash = "sha256-CkNRzzUJNiBd9eH68PUdGxu5hjHtjK9LS3GZcTXaMxI=";
+    finalImageName = "rabbitmq";
+    finalImageTag = rabbitmqVersion;
   };
 
   clouseauDist = pkgs.stdenvNoCC.mkDerivation {
@@ -146,14 +155,18 @@ let
         "XDG_CONFIG_HOME=/tmp/.config"
       ];
       ExposedPorts."5000/tcp" = { };
+      Volumes."/etc/starintel" = { };
       WorkingDir = "/tmp";
     };
   };
+
+  rabbitmqImage = rabbitmqBase;
 
   allImages = pkgs.dockerTools.mergeImages [
     serverImage
     couchdbImage
     clouseauImage
+    rabbitmqImage
   ];
 
   loadImages = pkgs.writeShellApplication {
@@ -170,6 +183,7 @@ in
     clouseauImage
     couchdbImage
     loadImages
+    rabbitmqImage
     serverImage
     ;
 }

--- a/source/consumers/rabbit-settlement.lisp
+++ b/source/consumers/rabbit-settlement.lisp
@@ -79,6 +79,55 @@
      (when routing-key
        (list (cons "x-dead-letter-routing-key" routing-key))))))
 
+(defun declare-queue-with-retry (stream connection)
+  "Declare the queue with its configured arguments.
+
+  RabbitMQ rejects queue-declare when an existing queue has inequivalent
+  arguments (PRECONDITION_FAILED, reply code 406). This commonly happens
+  when a durable queue was created without dead-letter policy and the
+  code is later upgraded to use one.
+
+  When that occurs and the stale queue is empty, we delete it and
+  redeclare with the correct arguments. If the queue still holds
+  messages we refuse to drop them and surface a clear, actionable
+  error so an operator can drain or explicitly delete the queue."
+  (flet ((declare-queue ()
+           (cl-rabbit:queue-declare
+            connection
+            1
+            :queue (rabbit-stream-queue-name stream)
+            :durable (rabbit-stream-queue-durable-p stream)
+            :arguments (rabbit-dead-letter-arguments stream))))
+    (handler-case
+        (declare-queue)
+      (cl-rabbit:rabbitmq-server-error (condition)
+        (unless (= cl-rabbit:+amqp-precondition-failed+
+                   (cl-rabbit:rabbitmq-server-error/reply-code condition))
+          (error condition))
+        (log:warn (format nil
+                          "Queue ~a has inequivalent arguments (PRECONDITION_FAILED); ~
+                           attempting to recreate empty queue"
+                          (rabbit-stream-queue-name stream)))
+        ;; The failed declare closes the channel; reopen it before retrying.
+        (cl-rabbit:channel-open connection 1)
+        (handler-case
+            (cl-rabbit:queue-delete
+             connection
+             1
+             (rabbit-stream-queue-name stream)
+             :if-empty t
+             :if-unused t)
+          (cl-rabbit:rabbitmq-server-error (delete-condition)
+            (error "Cannot recreate queue ~a: it is not empty. ~
+                    Drain or delete the stale queue (and its bindings) ~
+                    before restarting. Server message: ~a"
+                   (rabbit-stream-queue-name stream)
+                   (cl-rabbit:rabbitmq-server-error/message delete-condition))))
+        (log:info (format nil
+                          "Recreated queue ~a with current dead-letter policy"
+                          (rabbit-stream-queue-name stream)))
+        (declare-queue)))))
+
 (defmethod open-stream ((stream settled-rabbit-queue-stream))
   (let* ((connection (cl-rabbit:new-connection))
          (socket (cl-rabbit:tcp-socket-new connection))
@@ -116,12 +165,7 @@
        dead-letter-exchange
        "topic"
        :durable t))
-    (cl-rabbit:queue-declare
-     connection
-     1
-     :queue (rabbit-stream-queue-name stream)
-     :durable (rabbit-stream-queue-durable-p stream)
-     :arguments (rabbit-dead-letter-arguments stream))
+    (declare-queue-with-retry stream connection)
     (cl-rabbit:queue-bind
      connection
      1


### PR DESCRIPTION
## Summary

The server crashed on startup with `PRECONDITION_FAILED - inequivalent arg
'x-dead-letter-exchange' for queue 'events'` because the durable `events`
queue existed in the persistent RabbitMQ volume without dead-letter args,
while the upgraded code declares it with them. RabbitMQ refuses to change
args on an existing queue, which closed the channel and aborted the
Hunchentoot listener thread.

## Changes

### RabbitMQ queue-arg conflict recovery
- `source/consumers/rabbit-settlement.lisp`: Add `declare-queue-with-retry`.
  On `PRECONDITION_FAILED` (reply code 406) it reopens the closed channel,
  deletes the stale queue only when empty (`:if-empty t :if-unused t`), and
  redeclares it with the current dead-letter policy. If the queue still
  holds messages, it errors with an actionable message instructing the
  operator to drain or delete the queue.

### Pass init file to the server in Docker
- `nix/images.nix`: Add `Volumes."/etc/starintel" = { };` so the init path
  is mountable.
- `docker/star-server-entrypoint.sh`: Honor `STAR_SERVER_INIT_FILE` env var
  (defaults to `/etc/starintel/init.lisp`) and pass it via `-i`.
- `docker-compose.yml`: Add `STAR_SERVER_INIT_FILE` env var and a read-only
  bind mount from `${STAR_SERVER_INIT_HOST_FILE:-./docker/star-server-init.lisp}`
  to `/etc/starintel/init.lisp`.

### Load RabbitMQ image via Nix
- `nix/images.nix`: Add `rabbitmqBase` via `pullImage` pinned to the
  `4.3.4-management` amd64 manifest digest
  (`sha256:36703420...c9b2854`, content hash
  `sha256-CkNRzzUJNiBd9eH68PUdGxu5hjHtjK9LS3GZcTXaMxI=`). Include it in
  `allImages` and the export set.
- `flake.nix`: Expose `rabbitmq-image` package.
- `Makefile`: Add `.#rabbitmq-image` to the `images` target.
- `DOCKER.md`: Document the fourth loaded tag and update the upgrade
  checklist.

## Verification

- `nix run .#star-unit-tests` — all suites pass
  (consumer, couchdb-actor, event-actor, dataset-export).
- `nix build .#rabbitmq-image .#container-images` — both succeed.
- `nix run .#load-images` — loads all four tags.
- `docker compose up --detach --wait` — all four containers healthy.
- Server logs confirm the queue fix fired:
  `Queue events has inequivalent arguments (PRECONDITION_FAILED); attempting to recreate empty queue`
  followed by `Recreated queue events with current dead-letter policy`.
- `curl http://127.0.0.1:5000/health` returns `{"msg":"OK","status":"info"}`.
