### PR TITLE
feat(auth): add persistent users and first-run star:intel login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,13 @@ RABBITMQ_BIND_ADDRESS=127.0.0.1
 RABBITMQ_PORT=5672
 RABBITMQ_MANAGEMENT_PORT=15672
 
+# On an empty StarIntel auth database, star-server creates the initial
+# administrator as star:intel. Override these before exposing a new deployment.
+STAR_AUTH_INITIAL_USERNAME=star
+# STAR_AUTH_INITIAL_PASSWORD=replace-this-before-exposure
+STAR_AUTH_PASSWORD_MIN_LENGTH=12
+STAR_AUTH_PASSWORD_ITERATIONS=600000
+STAR_AUTH_LOGIN_SESSION_SECONDS=86400
+
 CREDENTIALS_DIR=./secrets
 CLOUSEAU_JAVA_OPTS=-Xms256m -Xmx1g

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -6,26 +6,40 @@ on:
   pull_request:
     branches: [ "dev", "master" ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v25
+        uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
+
+      - name: Evaluate flake
+        run: nix flake check --show-trace
+
+      - name: Build server
+        run: nix build .#default --no-link --print-build-logs
 
       - name: Run hermetic unit tests
         run: nix run .#star-unit-tests
 
   integration-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     services:
       rabbitmq:
@@ -57,25 +71,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v25
+        uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
 
       - name: Wait for services and initialize
         run: |
-          # Wait for RabbitMQ
           echo "Waiting for RabbitMQ..."
           timeout 60 bash -c 'until curl -f http://localhost:15672 > /dev/null 2>&1; do sleep 2; done'
 
-          # Wait for CouchDB
           echo "Waiting for CouchDB..."
           timeout 60 bash -c 'until curl -f http://localhost:5984/_up > /dev/null 2>&1; do sleep 2; done'
 
-          # Create CouchDB database
           echo "Creating CouchDB database..."
-          curl -X PUT http://admin:password@localhost:5984/starintel
+          curl --fail --silent --show-error \
+            --request PUT \
+            http://admin:password@localhost:5984/starintel \
+            >/dev/null
 
           echo "Services ready!"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       STAR_AUTH_PEPPER_FILE: /run/secrets/auth_pepper
       STAR_AUTH_BOOTSTRAP_SECRET_FILE: /run/secrets/auth_bootstrap_secret
       STAR_AUTH_ALLOWED_ORIGINS: ${STAR_AUTH_ALLOWED_ORIGINS:-}
+      STAR_AUTH_PASSWORD_ITERATIONS: ${STAR_AUTH_PASSWORD_ITERATIONS:-600000}
       STAR_SERVER_INIT_FILE: ${STAR_SERVER_INIT_FILE:-/etc/starintel/init.lisp}
     secrets:
       - couchdb_password
@@ -152,3 +153,5 @@ volumes:
 
 networks:
   backend:
+    driver: bridge
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,5 +153,3 @@ volumes:
 
 networks:
   backend:
-    driver: bridge
-    internal: true

--- a/docs/http-users.org
+++ b/docs/http-users.org
@@ -1,0 +1,184 @@
+#+title: StarIntel HTTP user authentication
+#+options: toc:3
+
+* First-run administrator
+
+When the authentication database contains no user records, star-server creates
+one initial human administrator during startup:
+
+#+begin_example
+username: star
+password: intel
+#+end_example
+
+The shorthand credential pair is =star:intel=. The account is stored in the
+separate StarIntel authentication database and is marked
+=must_change_password=true=.
+
+This built-in password exists only to make a fresh local installation usable.
+Change it immediately before exposing the HTTP listener to another machine or an
+untrusted network. The initial username and password can also be overridden
+before first startup.
+
+* Password storage
+
+StarIntel never stores recoverable user passwords. Passwords are transformed
+with PBKDF2-SHA256 using Ironclad. The password input is mixed with the server
+authentication pepper before derivation, and the combined PBKDF2 representation
+contains the per-password salt and work factor needed for verification.
+
+The default PBKDF2 iteration count is 600000. CI lowers this value explicitly so
+that integration tests exercise the same behavior without spending production
+work-factor time on disposable credentials.
+
+The short built-in =intel= password is a first-run compatibility exception.
+Passwords created or changed through the normal user lifecycle must satisfy the
+configured minimum length, which defaults to 12 characters.
+
+* Login
+
+=POST /auth/login= is public and accepts:
+
+#+begin_src json
+{
+  "username": "star",
+  "password": "intel"
+}
+#+end_src
+
+Successful login returns a normal StarIntel opaque API key:
+
+#+begin_src json
+{
+  "api_key": "star_sk_v1_...",
+  "credential": { "...": "..." },
+  "user": {
+    "username": "star",
+    "principal_type": "administrator",
+    "scopes": ["admin"],
+    "status": "active",
+    "must_change_password": true
+  }
+}
+#+end_src
+
+The raw API key is returned only in the login response. Subsequent requests use
+the existing bearer authentication model:
+
+#+begin_example
+Authorization: Bearer star_sk_v1_...
+#+end_example
+
+Incorrect usernames and passwords return the same =401 invalid_credential=
+response so the endpoint does not reveal whether a username exists.
+
+* Administrator user management
+
+All routes in this section require an administrator bearer credential.
+
+** Create a user
+
+#+begin_example
+POST /auth/users
+Authorization: Bearer <administrator-key>
+Content-Type: application/json
+#+end_example
+
+#+begin_src json
+{
+  "username": "analyst",
+  "password": "a-long-initial-password",
+  "principal_type": "user",
+  "scopes": ["documents:read", "search:read"],
+  "must_change_password": true
+}
+#+end_src
+
+Passwords are never returned by the API. User metadata does not contain password
+hashes.
+
+** List users
+
+#+begin_example
+GET /auth/users
+Authorization: Bearer <administrator-key>
+#+end_example
+
+Returns non-secret user metadata only.
+
+** Reset a password
+
+#+begin_example
+POST /auth/users/<username>/password
+Authorization: Bearer <administrator-key>
+Content-Type: application/json
+#+end_example
+
+#+begin_src json
+{
+  "password": "replacement-password",
+  "must_change_password": true
+}
+#+end_src
+
+* Change the current user's password
+
+An authenticated human user can change their own password:
+
+#+begin_example
+POST /auth/password
+Authorization: Bearer <login-key>
+Content-Type: application/json
+#+end_example
+
+#+begin_src json
+{
+  "current_password": "intel",
+  "new_password": "replacement-password"
+}
+#+end_src
+
+A successful change clears =must_change_password=. Existing API keys minted
+before a password change remain ordinary API-key credentials and follow the
+existing credential lifecycle; rotate or revoke them separately when required.
+
+* Persistence
+
+User records live in =STAR_AUTH_DATABASE= alongside credential records but use
+=user:= document identifiers and =kind=user=. The auth design document exposes a
+separate =users= view. Password hashes are never stored in StarIntel intelligence
+documents.
+
+Startup creates the default user only when the auth user store is empty, so a
+restart does not reset passwords or recreate deleted/renamed bootstrap state.
+
+* Configuration
+
+| Environment variable | Default | Purpose |
+|----------------------+---------+---------|
+| =STAR_AUTH_INITIAL_USERNAME= | =star= | First user created in an empty auth user store. |
+| =STAR_AUTH_INITIAL_PASSWORD= | =intel= | First user's initial password. |
+| =STAR_AUTH_INITIAL_PASSWORD_FILE= | none | File override for the first user's password. |
+| =STAR_AUTH_PASSWORD_MIN_LENGTH= | =12= | Minimum normal user password length. |
+| =STAR_AUTH_PASSWORD_ITERATIONS= | =600000= | PBKDF2 work factor. |
+| =STAR_AUTH_LOGIN_SESSION_SECONDS= | =86400= | Lifetime of API keys minted by password login. |
+
+The server authentication pepper remains mandatory in normal API-key mode and is
+also part of the password-verification boundary.
+
+* CI contract
+
+The container stack test proves the complete deployment path using Nix-built
+images:
+
+- a fresh auth database accepts =star:intel=;
+- the returned administrator key can create another user;
+- the new user can log in and resolve its bearer security context;
+- the default administrator can change the initial password;
+- =star:intel= stops authenticating after the change;
+- both the created user and changed administrator password survive a full stack
+  restart.
+
+Hermetic unit tests separately cover password policy, first-run idempotence,
+metadata redaction, login-to-API-key conversion, self-service password changes,
+and administrator resets.

--- a/scripts/stack-test.sh
+++ b/scripts/stack-test.sh
@@ -16,6 +16,8 @@ export STAR_SERVER_PORT="$port_base"
 export COUCHDB_PORT="$((port_base + 1))"
 export RABBITMQ_PORT="$((port_base + 2))"
 export RABBITMQ_MANAGEMENT_PORT="$((port_base + 3))"
+# Keep the container contract identical while making CI password tests fast.
+export STAR_AUTH_PASSWORD_ITERATIONS="1000"
 
 mkdir -p "$artifact_dir"
 rm -f "$artifact_dir"/*
@@ -111,6 +113,80 @@ bootstrap_response="$(
 api_key="$(jq --exit-status --raw-output '.api_key' <<<"$bootstrap_response")"
 [[ "$api_key" == star_sk_v1_* ]]
 auth_header="Authorization: Bearer ${api_key}"
+
+set_stage "verify-default-star-intel-login"
+default_login_response="$(
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data '{"username":"star","password":"intel"}' \
+    "${server_url}/auth/login"
+)"
+default_api_key="$(jq --exit-status --raw-output '.api_key' <<<"$default_login_response")"
+[[ "$default_api_key" == star_sk_v1_* ]]
+jq --exit-status \
+  '.user.username == "star" and .user.principal_type == "administrator" and .user.must_change_password == true' \
+  <<<"$default_login_response" >/dev/null
+default_auth_header="Authorization: Bearer ${default_api_key}"
+
+set_stage "create-human-user"
+stack_user_password="stack-user-password-123"
+curl --fail --silent --show-error \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --header "$default_auth_header" \
+  --data "{\"username\":\"stack-user\",\"password\":\"${stack_user_password}\",\"principal_type\":\"user\",\"scopes\":[\"documents:read\",\"search:read\"],\"must_change_password\":false}" \
+  "${server_url}/auth/users" |
+  jq --exit-status \
+    '.user.username == "stack-user" and .user.must_change_password == false' \
+    >/dev/null
+
+set_stage "login-created-user"
+stack_user_login_response="$(
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data "{\"username\":\"stack-user\",\"password\":\"${stack_user_password}\"}" \
+    "${server_url}/auth/login"
+)"
+stack_user_api_key="$(jq --exit-status --raw-output '.api_key' <<<"$stack_user_login_response")"
+[[ "$stack_user_api_key" == star_sk_v1_* ]]
+curl --fail --silent --show-error \
+  --header "Authorization: Bearer ${stack_user_api_key}" \
+  "${server_url}/auth/context" |
+  jq --exit-status \
+    '.principal_id == "stack-user" and .principal_type == "user"' \
+    >/dev/null
+
+set_stage "change-default-password"
+new_default_password="stack-default-password-456"
+curl --fail --silent --show-error \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --header "$default_auth_header" \
+  --data "{\"current_password\":\"intel\",\"new_password\":\"${new_default_password}\"}" \
+  "${server_url}/auth/password" |
+  jq --exit-status '.user.username == "star" and .user.must_change_password == false' \
+    >/dev/null
+
+old_default_status="$(
+  curl --silent --output /dev/null --write-out '%{http_code}' \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data '{"username":"star","password":"intel"}' \
+    "${server_url}/auth/login"
+)"
+[[ "$old_default_status" == "401" ]]
+
+new_default_login_response="$(
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data "{\"username\":\"star\",\"password\":\"${new_default_password}\"}" \
+    "${server_url}/auth/login"
+)"
+jq --exit-status '.user.username == "star" and .user.must_change_password == false' \
+  <<<"$new_default_login_response" >/dev/null
 
 set_stage "verify-unauthenticated-denial"
 unauthenticated_status="$(
@@ -216,7 +292,28 @@ curl --fail --silent --show-error \
   "${server_url}/auth/context" |
   jq --exit-status '.principal_id == "stack-administrator"' >/dev/null
 
+set_stage "verify-user-persistence"
+post_restart_user_login="$(
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data "{\"username\":\"stack-user\",\"password\":\"${stack_user_password}\"}" \
+    "${server_url}/auth/login"
+)"
+jq --exit-status '.user.username == "stack-user"' \
+  <<<"$post_restart_user_login" >/dev/null
+
+post_restart_default_login="$(
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data "{\"username\":\"star\",\"password\":\"${new_default_password}\"}" \
+    "${server_url}/auth/login"
+)"
+jq --exit-status '.user.username == "star" and .user.must_change_password == false' \
+  <<<"$post_restart_default_login" >/dev/null
+
 set_stage "verify-search-after-restart"
 wait_for_search
 
-printf 'Authenticated Nix-built stack passed bootstrap, denial, FTS, and restart persistence checks.\n'
+printf 'Authenticated Nix-built stack passed bootstrap, user login, user creation, password rotation, FTS, and restart persistence checks.\n'

--- a/source/auth/store.lisp
+++ b/source/auth/store.lisp
@@ -4,6 +4,9 @@
   ((records
     :initform (make-hash-table :test #'equal)
     :reader memory-store-records)
+   (users
+    :initform (make-hash-table :test #'equal)
+    :reader memory-store-users)
    (lock
     :initform (bt:make-lock "memory-credential-store")
     :reader memory-store-lock)))
@@ -237,7 +240,11 @@
        ("credentials"
         (jsown:new-js
           ("map"
-           "function(doc){if(doc.kind==='api-key'){emit(doc.created_at,null);}}")))))))
+           "function(doc){if(doc.kind==='api-key'){emit(doc.created_at,null);}}")))
+       ("users"
+        (jsown:new-js
+          ("map"
+           "function(doc){if(doc.kind==='user'){emit(doc.username,null);}}")))))))
 
 (defun ensure-auth-database (store)
   (anypool:with-connection (client (couchdb-store-pool store))

--- a/source/auth/users.lisp
+++ b/source/auth/users.lisp
@@ -1,0 +1,339 @@
+(in-package :star.auth)
+
+(defparameter +user-kind+ "user")
+
+(defstruct user-record
+  username
+  principal-type
+  scopes
+  status
+  password-hash
+  created-at
+  password-updated-at
+  must-change-password
+  revision)
+
+(defgeneric user-store-get (store username))
+(defgeneric user-store-put (store record))
+(defgeneric user-store-update (store record))
+(defgeneric user-store-list (store))
+(defgeneric user-store-count (store))
+
+(defun normalize-username (username)
+  (unless (and (stringp username)
+               (<= 1 (length username) 64)
+               (every (lambda (character)
+                        (or (alphanumericp character)
+                            (find character "-_.")))
+                      username))
+    (signal-lifecycle-error
+     "invalid_username"
+     "Username must be 1-64 characters using letters, digits, '-', '_', or '.'"))
+  (string-downcase username))
+
+(defun password-material (password)
+  (concatenate-octet-vectors
+   (string-octets star:*auth-pepper*)
+   (make-array 1 :element-type '(unsigned-byte 8) :initial-element 0)
+   (string-octets password)))
+
+(defun validate-user-password (password &key allow-weak-password)
+  (unless (and (stringp password) (plusp (length password)))
+    (signal-lifecycle-error
+     "invalid_password"
+     "Password must be a non-empty string"))
+  (unless (or allow-weak-password
+              (>= (length password) star:*auth-password-min-length*))
+    (signal-lifecycle-error
+     "password_too_short"
+     (format nil "Password must be at least ~d characters"
+             star:*auth-password-min-length*)))
+  password)
+
+(defun hash-user-password (password &key allow-weak-password)
+  (validate-user-password password :allow-weak-password allow-weak-password)
+  (ironclad:pbkdf2-hash-password-to-combined-string
+   (password-material password)
+   :digest :sha256
+   :iterations star:*auth-password-iterations*))
+
+(defun user-password-valid-p (record password)
+  (and record
+       (stringp password)
+       (handler-case
+           (ironclad:pbkdf2-check-password
+            (password-material password)
+            (user-record-password-hash record))
+         (error () nil))))
+
+(defun user-active-p (record)
+  (and record (eq :active (user-record-status record))))
+
+(defun user-metadata-json (record)
+  (jsown:new-js
+    ("username" (user-record-username record))
+    ("principal_type" (user-record-principal-type record))
+    ("scopes" (copy-list (user-record-scopes record)))
+    ("status" (string-downcase (symbol-name (user-record-status record))))
+    ("created_at" (user-record-created-at record))
+    ("password_updated_at" (user-record-password-updated-at record))
+    ("must_change_password"
+     (if (user-record-must-change-password record) :true :false))))
+
+(defun create-user (username password principal-type scopes
+                    &key
+                      (must-change-password t)
+                      allow-weak-password
+                      (store *credential-store*))
+  (unless store
+    (signal-lifecycle-error
+     "auth_store_unavailable"
+     "Credential store is unavailable"))
+  (let* ((normalized-username (normalize-username username))
+         (normalized-scopes (normalize-scopes scopes)))
+    (when (user-store-get store normalized-username)
+      (signal-lifecycle-error
+       "user_conflict"
+       "User already exists"))
+    (let* ((now (auth-now))
+           (record
+             (make-user-record
+              :username normalized-username
+              :principal-type (normalize-principal-type principal-type)
+              :scopes normalized-scopes
+              :status :active
+              :password-hash
+              (hash-user-password
+               password
+               :allow-weak-password allow-weak-password)
+              :created-at now
+              :password-updated-at now
+              :must-change-password (not (null must-change-password)))))
+      (user-store-put store record))))
+
+(defun list-user-metadata (&key (store *credential-store*))
+  (unless store
+    (signal-lifecycle-error
+     "auth_store_unavailable"
+     "Credential store is unavailable"))
+  (mapcar #'user-metadata-json (user-store-list store)))
+
+(defun authenticate-user-password (username password
+                                    &key (store *credential-store*))
+  (unless store
+    (signal-authentication-failure))
+  (handler-case
+      (let* ((normalized-username (normalize-username username))
+             (record (user-store-get store normalized-username)))
+        (unless (and (user-active-p record)
+                     (user-password-valid-p record password))
+          (signal-authentication-failure))
+        record)
+    (authentication-error (condition)
+      (error condition))
+    (error ()
+      (signal-authentication-failure))))
+
+(defun login-user (username password &key (store *credential-store*))
+  (let ((user (authenticate-user-password username password :store store)))
+    (multiple-value-bind (credential raw-key)
+        (create-api-key
+         (user-record-username user)
+         (user-record-principal-type user)
+         (user-record-scopes user)
+         :expires-in-seconds star:*auth-login-session-seconds*
+         :store store)
+      (values user credential raw-key))))
+
+(defun set-user-password (record password
+                          &key
+                            (must-change-password nil)
+                            allow-weak-password
+                            (store *credential-store*))
+  (unless record
+    (signal-lifecycle-error "user_not_found" "User was not found"))
+  (setf (user-record-password-hash record)
+        (hash-user-password password :allow-weak-password allow-weak-password)
+        (user-record-password-updated-at record) (auth-now)
+        (user-record-must-change-password record)
+        (not (null must-change-password)))
+  (user-store-update store record))
+
+(defun change-user-password (username current-password new-password
+                             &key (store *credential-store*))
+  (let ((record
+          (authenticate-user-password
+           username current-password :store store)))
+    (set-user-password record new-password :store store)))
+
+(defun admin-set-user-password (username new-password
+                                &key
+                                  (must-change-password t)
+                                  (store *credential-store*))
+  (let ((record
+          (user-store-get store (normalize-username username))))
+    (unless record
+      (signal-lifecycle-error "user_not_found" "User was not found"))
+    (set-user-password
+     record
+     new-password
+     :must-change-password must-change-password
+     :store store)))
+
+(defun ensure-initial-user (&key (store *credential-store*))
+  (unless store
+    (signal-lifecycle-error
+     "auth_store_unavailable"
+     "Credential store is unavailable"))
+  (if (plusp (user-store-count store))
+      (user-store-get store (normalize-username star:*auth-initial-username*))
+      (create-user
+       star:*auth-initial-username*
+       star:*auth-initial-password*
+       "administrator"
+       (list "admin")
+       :must-change-password t
+       :allow-weak-password t
+       :store store)))
+
+(defun user-document-id (username)
+  (format nil "user:~a" (normalize-username username)))
+
+(defun copy-user-record-or-nil (record)
+  (and record (copy-user-record record)))
+
+(defmethod user-store-get ((store memory-credential-store) username)
+  (bt:with-lock-held ((memory-store-lock store))
+    (copy-user-record-or-nil
+     (gethash (normalize-username username)
+              (memory-store-users store)))))
+
+(defmethod user-store-put ((store memory-credential-store) record)
+  (bt:with-lock-held ((memory-store-lock store))
+    (let ((username (user-record-username record)))
+      (when (gethash username (memory-store-users store))
+        (signal-lifecycle-error "user_conflict" "User already exists"))
+      (setf (gethash username (memory-store-users store))
+            (copy-user-record record))))
+  (copy-user-record record))
+
+(defmethod user-store-update ((store memory-credential-store) record)
+  (bt:with-lock-held ((memory-store-lock store))
+    (let ((username (user-record-username record)))
+      (unless (gethash username (memory-store-users store))
+        (signal-lifecycle-error "user_not_found" "User was not found"))
+      (setf (gethash username (memory-store-users store))
+            (copy-user-record record))))
+  (copy-user-record record))
+
+(defmethod user-store-list ((store memory-credential-store))
+  (bt:with-lock-held ((memory-store-lock store))
+    (sort
+     (loop for record being the hash-values of (memory-store-users store)
+           collect (copy-user-record record))
+     #'string<
+     :key #'user-record-username)))
+
+(defmethod user-store-count ((store memory-credential-store))
+  (bt:with-lock-held ((memory-store-lock store))
+    (hash-table-count (memory-store-users store))))
+
+(defun user-record-to-json (record)
+  (let ((document
+          (jsown:new-js
+            ("_id" (user-document-id (user-record-username record)))
+            ("kind" +user-kind+)
+            ("username" (user-record-username record))
+            ("principal_type" (user-record-principal-type record))
+            ("scopes" (copy-list (user-record-scopes record)))
+            ("status" (status-string (user-record-status record)))
+            ("password_hash" (user-record-password-hash record))
+            ("created_at" (user-record-created-at record))
+            ("password_updated_at" (user-record-password-updated-at record))
+            ("must_change_password"
+             (if (user-record-must-change-password record) :true :false)))))
+    (when (user-record-revision record)
+      (setf (jsown:val document "_rev") (user-record-revision record)))
+    document))
+
+(defun json-true-p (value)
+  (or (eq value t) (eq value :true)))
+
+(defun json-to-user-record (value)
+  (let ((document (if (stringp value) (jsown:parse value) value)))
+    (make-user-record
+     :username (jsown:val document "username")
+     :principal-type (jsown:val document "principal_type")
+     :scopes (copy-list (or (jsown:val-safe document "scopes") nil))
+     :status (parse-status (jsown:val document "status"))
+     :password-hash (jsown:val document "password_hash")
+     :created-at (jsown:val document "created_at")
+     :password-updated-at (jsown:val document "password_updated_at")
+     :must-change-password
+     (json-true-p (jsown:val-safe document "must_change_password"))
+     :revision (jsown:val-safe document "_rev"))))
+
+(defun update-user-revision-from-response (record response)
+  (let ((parsed (ignore-errors (jsown:parse response))))
+    (when parsed
+      (setf (user-record-revision record) (jsown:val-safe parsed "rev"))))
+  record)
+
+(defmethod user-store-get ((store couchdb-credential-store) username)
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (handler-case
+        (json-to-user-record
+         (cl-couch:get-document
+          client
+          (couchdb-store-database store)
+          (user-document-id username)))
+      (dex:http-request-not-found () nil))))
+
+(defmethod user-store-put ((store couchdb-credential-store) record)
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (handler-case
+        (update-user-revision-from-response
+         record
+         (cl-couch:create-document
+          client
+          (couchdb-store-database store)
+          (jsown:to-json (user-record-to-json record))))
+      (dex:http-request-conflict ()
+        (signal-lifecycle-error "user_conflict" "User already exists")))))
+
+(defmethod user-store-update ((store couchdb-credential-store) record)
+  (unless (user-record-revision record)
+    (let ((current
+            (user-store-get store (user-record-username record))))
+      (unless current
+        (signal-lifecycle-error "user_not_found" "User was not found"))
+      (setf (user-record-revision record) (user-record-revision current))))
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (handler-case
+        (update-user-revision-from-response
+         record
+         (cl-couch:create-document
+          client
+          (couchdb-store-database store)
+          (jsown:to-json (user-record-to-json record))))
+      (dex:http-request-conflict ()
+        (signal-lifecycle-error "user_conflict" "User update conflicted")))))
+
+(defmethod user-store-list ((store couchdb-credential-store))
+  (anypool:with-connection (client (couchdb-store-pool store))
+    (let* ((view
+             (star.databases.couchdb:query-view
+              client
+              (couchdb-store-database store)
+              "auth"
+              "users"
+              :include-docs t
+              :limit 10000
+              :reduce nil))
+           (rows (or (jsown:val-safe view "rows") nil)))
+      (loop for row in rows
+            for document = (jsown:val row "doc")
+            collect (json-to-user-record document)))))
+
+(defmethod user-store-count ((store couchdb-credential-store))
+  (length (user-store-list store)))

--- a/source/frontends/http-auth-routes.lisp
+++ b/source/frontends/http-auth-routes.lisp
@@ -4,13 +4,15 @@
   (cond
     ((member code
              '("invalid_owner" "invalid_scopes" "invalid_expiry"
-               "invalid_overlap")
+               "invalid_overlap" "invalid_username" "invalid_password"
+               "password_too_short")
              :test #'string=)
      422)
-    ((string= code "credential_not_found") 404)
+    ((member code '("credential_not_found" "user_not_found") :test #'string=)
+     404)
     ((member code
              '("credential_conflict" "credential_not_active"
-               "bootstrap_complete")
+               "bootstrap_complete" "user_conflict")
              :test #'string=)
      409)
     ((string= code "bootstrap_denied") 403)
@@ -47,6 +49,18 @@
         "invalid_auth_request"
         (format nil "Field ~a must be a positive integer" field))))))
 
+(defun optional-auth-boolean (document field default)
+  (let ((value (jsown:val-safe document field)))
+    (cond
+      ((or (null value) (eq value :null)) default)
+      ((or (eq value t) (eq value :true)) t)
+      ((eq value :false) nil)
+      (t
+       (signal-http-input-error
+        422
+        "invalid_auth_request"
+        (format nil "Field ~a must be a boolean" field))))))
+
 (defun require-scope-array (document)
   (let ((scopes (jsown:val-safe document "scopes")))
     (unless (and (json-array-p scopes)
@@ -73,6 +87,40 @@
      ("api_key" raw-key)
      ("credential" (star.auth:api-key-metadata-json record))
      ("correlation_id" (current-correlation-id)))))
+
+(defun user-login-response (user record raw-key)
+  (add-no-store-header)
+  (jsown:to-json
+   (jsown:new-js
+     ("api_key" raw-key)
+     ("credential" (star.auth:api-key-metadata-json record))
+     ("user" (star.auth:user-metadata-json user))
+     ("correlation_id" (current-correlation-id)))))
+
+(defun user-status-response (record message)
+  (jsown:to-json
+   (jsown:new-js
+     ("status" "ok")
+     ("msg" message)
+     ("user" (star.auth:user-metadata-json record))
+     ("correlation_id" (current-correlation-id)))))
+
+(defun handle-auth-login-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (with-credential-lifecycle-errors
+      (let* ((body (require-json-object (parse-json-request)))
+             (username (require-auth-string body "username"))
+             (password (require-auth-string body "password")))
+        (handler-case
+            (multiple-value-bind (user record raw-key)
+                (star.auth:login-user username password)
+              (user-login-response user record raw-key))
+          (star.auth:authentication-error ()
+            (signal-http-input-error
+             401
+             "invalid_credential"
+             "Authentication failed")))))))
 
 (defun handle-auth-bootstrap-route (params)
   (declare (ignore params))
@@ -123,6 +171,86 @@
     (with-credential-lifecycle-errors
       (jsown:to-json
        (star.auth:list-api-key-metadata)))))
+
+(defun handle-auth-create-user-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (let* ((body (require-json-object (parse-json-request)))
+             (username (require-auth-string body "username"))
+             (password (require-auth-string body "password"))
+             (principal-type
+               (or (jsown:val-safe body "principal_type") "user"))
+             (scopes (require-scope-array body))
+             (must-change-password
+               (optional-auth-boolean body "must_change_password" t)))
+        (unless (and (stringp principal-type) (plusp (length principal-type)))
+          (signal-http-input-error
+           422
+           "invalid_auth_request"
+           "Field principal_type must be a non-empty string"))
+        (let ((record
+                (star.auth:create-user
+                 username
+                 password
+                 principal-type
+                 scopes
+                 :must-change-password must-change-password)))
+          (setf (lack.response:response-status *response*) 201)
+          (user-status-response record "User created"))))))
+
+(defun handle-auth-list-users-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (jsown:to-json (star.auth:list-user-metadata)))))
+
+(defun user-name-param (params)
+  (let ((username (query-value params "username")))
+    (unless (and (stringp username) (plusp (length username)))
+      (signal-http-input-error
+       400
+       "missing_path_parameter"
+       "Username is required"))
+    username))
+
+(defun handle-auth-reset-user-password-route (params)
+  (with-http-boundary ()
+    (require-administrator-context)
+    (with-credential-lifecycle-errors
+      (let* ((body (require-json-object (parse-json-request)))
+             (password (require-auth-string body "password"))
+             (must-change-password
+               (optional-auth-boolean body "must_change_password" t))
+             (record
+               (star.auth:admin-set-user-password
+                (user-name-param params)
+                password
+                :must-change-password must-change-password)))
+        (user-status-response record "Password updated")))))
+
+(defun handle-auth-change-password-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (with-credential-lifecycle-errors
+      (let* ((username (star.auth:current-principal-id))
+             (body (require-json-object (parse-json-request)))
+             (current-password
+               (require-auth-string body "current_password"))
+             (new-password
+               (require-auth-string body "new_password")))
+        (handler-case
+            (user-status-response
+             (star.auth:change-user-password
+              username current-password new-password)
+             "Password changed")
+          (star.auth:authentication-error ()
+            (signal-http-input-error
+             401
+             "invalid_credential"
+             "Authentication failed")))))))
 
 (defun credential-id-param (params)
   (let ((credential-id (query-value params "credential-id")))
@@ -195,6 +323,9 @@
          ("deadline"
           (star.auth:request-security-context-deadline context)))))))
 
+(setf (ningle:route *app* "/auth/login" :method :post)
+      #'handle-auth-login-route)
+
 (setf (ningle:route *app* "/auth/bootstrap" :method :post)
       #'handle-auth-bootstrap-route)
 
@@ -203,6 +334,18 @@
 
 (setf (ningle:route *app* "/auth/credentials" :method :get)
       #'handle-auth-list-route)
+
+(setf (ningle:route *app* "/auth/users" :method :post)
+      #'handle-auth-create-user-route)
+
+(setf (ningle:route *app* "/auth/users" :method :get)
+      #'handle-auth-list-users-route)
+
+(setf (ningle:route *app* "/auth/users/:username/password" :method :post)
+      #'handle-auth-reset-user-password-route)
+
+(setf (ningle:route *app* "/auth/password" :method :post)
+      #'handle-auth-change-password-route)
 
 (setf (ningle:route *app* "/auth/credentials/:credential-id/rotate" :method :post)
       #'handle-auth-rotate-route)

--- a/source/frontends/http-auth-routes.lisp
+++ b/source/frontends/http-auth-routes.lisp
@@ -50,11 +50,16 @@
         (format nil "Field ~a must be a positive integer" field))))))
 
 (defun optional-auth-boolean (document field default)
+  ;; JSOWN's default reader maps JSON false to NIL, the same value returned by
+  ;; VAL-SAFE for a missing key. Check key presence first so an explicit false
+  ;; is not silently replaced by DEFAULT.
+  (unless (jsown:keyp document field)
+    (return-from optional-auth-boolean default))
   (let ((value (jsown:val-safe document field)))
     (cond
-      ((or (null value) (eq value :null)) default)
       ((or (eq value t) (eq value :true)) t)
-      ((eq value :false) nil)
+      ((or (null value) (eq value :false)) nil)
+      ((eq value :null) default)
       (t
        (signal-http-input-error
         422

--- a/source/gserver-settings.lisp
+++ b/source/gserver-settings.lisp
@@ -102,8 +102,24 @@
   (environment-integer "STAR_AUTH_DEFAULT_REQUEST_TIMEOUT_MS" 30000))
 (defparameter *auth-max-request-timeout-ms*
   (environment-integer "STAR_AUTH_MAX_REQUEST_TIMEOUT_MS" 600000))
+
+;;;; Human users
+(defparameter *auth-initial-username*
+  (or (uiop:getenv "STAR_AUTH_INITIAL_USERNAME") "star"))
+(defparameter *auth-initial-password*
+  (or (environment-secret
+       "STAR_AUTH_INITIAL_PASSWORD"
+       "STAR_AUTH_INITIAL_PASSWORD_FILE")
+      "intel"))
+(defparameter *auth-password-min-length*
+  (environment-integer "STAR_AUTH_PASSWORD_MIN_LENGTH" 12))
+(defparameter *auth-password-iterations*
+  (environment-integer "STAR_AUTH_PASSWORD_ITERATIONS" 600000))
+(defparameter *auth-login-session-seconds*
+  (environment-integer "STAR_AUTH_LOGIN_SESSION_SECONDS" 86400))
+
 (defparameter *auth-public-paths*
-  '("/health" "/" "/auth/bootstrap"))
+  '("/health" "/" "/auth/bootstrap" "/auth/login"))
 
 ;;;; RabbitMQ
 (defparameter *rabbit-address*

--- a/source/main.lisp
+++ b/source/main.lisp
@@ -18,6 +18,7 @@
         (lparallel:make-kernel star:*ingest-workers*))
   (star.databases.couchdb:init-db)
   (star.auth:initialize-auth-store)
+  (star.auth:ensure-initial-user)
   (star.actors:start-actors
    :rabbit-host *rabbit-address*
    :rabbit-vhost "/"

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -241,6 +241,7 @@
    #:+new-documents-key+
    #:+new-documents-fmt-key+
    #:+updated-documents-key+
+   #:+updated-documents-fmt-key+
    #:+new-targets-key+
    #:+targets-fmt-key+
    #:+ingest-topic-key+

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -32,6 +32,11 @@
    #:*auth-rotation-overlap-max-seconds*
    #:*auth-default-request-timeout-ms*
    #:*auth-max-request-timeout-ms*
+   #:*auth-initial-username*
+   #:*auth-initial-password*
+   #:*auth-password-min-length*
+   #:*auth-password-iterations*
+   #:*auth-login-session-seconds*
    #:*auth-public-paths*
    #:main
    #:reload
@@ -187,6 +192,28 @@
    #:disable-api-key
    #:api-key-metadata-json
    #:list-api-key-metadata
+   #:user-record
+   #:user-record-username
+   #:user-record-principal-type
+   #:user-record-scopes
+   #:user-record-status
+   #:user-record-created-at
+   #:user-record-password-updated-at
+   #:user-record-must-change-password
+   #:user-store-get
+   #:user-store-put
+   #:user-store-update
+   #:user-store-list
+   #:user-store-count
+   #:normalize-username
+   #:create-user
+   #:list-user-metadata
+   #:user-metadata-json
+   #:authenticate-user-password
+   #:login-user
+   #:change-user-password
+   #:admin-set-user-password
+   #:ensure-initial-user
    #:validate-auth-configuration
    #:initialize-auth-store))
 
@@ -214,7 +241,6 @@
    #:+new-documents-key+
    #:+new-documents-fmt-key+
    #:+updated-documents-key+
-   #:+updated-documents-fmt-key+
    #:+new-targets-key+
    #:+targets-fmt-key+
    #:+ingest-topic-key+

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -22,6 +22,7 @@
    (:file "auth/verification-hardening")
    (:file "auth/immutability")
    (:file "auth/store")
+   (:file "auth/users")
    (:file "init-loader")
    (:file "actors")
    (:file "actors/couchdb-service")

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -30,6 +30,7 @@
      (:file "dataset-export-test")
      (:file "http-boundary-test")
      (:file "http-auth-test")
+     (:file "auth-users-test")
      (:file "http-auth-oracle-test")
      (:file "http-auth-immutability-test")
      (:file "run-tests"))))

--- a/t/auth-users-test.lisp
+++ b/t/auth-users-test.lisp
@@ -146,3 +146,13 @@
     (is-true
      (star.auth:authenticate-user-password
       "analyst" "reset-password-456" :store store))))
+
+(test explicit-false-auth-boolean-is-not-defaulted
+  (let ((document (jsown:parse "{\"must_change_password\":false}")))
+    (is-false
+     (star.frontends.http-api::optional-auth-boolean
+      document "must_change_password" t)))
+  (let ((document (jsown:parse "{}")))
+    (is-true
+     (star.frontends.http-api::optional-auth-boolean
+      document "must_change_password" t))))

--- a/t/auth-users-test.lisp
+++ b/t/auth-users-test.lisp
@@ -1,0 +1,148 @@
+(in-package :star-server-tests)
+
+(def-suite auth-users-tests
+  :description "Persistent human users, default bootstrap login, and password lifecycle")
+
+(in-suite auth-users-tests)
+
+(defun captured-user-authentication-code (thunk)
+  (handler-case
+      (progn
+        (funcall thunk)
+        nil)
+    (star.auth:authentication-error (condition)
+      (star.auth:authentication-error-code condition))))
+
+(defun captured-user-lifecycle-code (thunk)
+  (handler-case
+      (progn
+        (funcall thunk)
+        nil)
+    (star.auth:credential-lifecycle-error (condition)
+      (star.auth:credential-lifecycle-error-code condition))))
+
+(test first-run-creates-star-intel-administrator-once
+  (let* ((star:*auth-pepper* "unit-test-user-pepper")
+         (star:*auth-password-iterations* 1000)
+         (star:*auth-password-min-length* 12)
+         (star:*auth-initial-username* "star")
+         (star:*auth-initial-password* "intel")
+         (store (star.auth:make-memory-credential-store)))
+    (let ((record (star.auth:ensure-initial-user :store store)))
+      (is (string= "star" (star.auth:user-record-username record)))
+      (is (string= "administrator"
+                   (star.auth:user-record-principal-type record)))
+      (is (equal '("admin") (star.auth:user-record-scopes record)))
+      (is-true (star.auth:user-record-must-change-password record))
+      (is-true
+       (star.auth:authenticate-user-password
+        "STAR" "intel" :store store))
+      (is (string= "invalid_credential"
+                   (captured-user-authentication-code
+                    (lambda ()
+                      (star.auth:authenticate-user-password
+                       "star" "wrong" :store store))))))
+    (star.auth:ensure-initial-user :store store)
+    (is (= 1 (star.auth:user-store-count store)))
+    (let ((metadata
+            (jsown:to-json
+             (first (star.auth:list-user-metadata :store store)))))
+      (is (search "\"username\":\"star\"" metadata))
+      (is (null (search "password_hash" metadata :test #'char-equal)))
+      (is (null (search "intel" metadata :test #'char-equal))))))
+
+(test normal-users-reject-short-passwords
+  (let* ((star:*auth-pepper* "unit-test-user-pepper")
+         (star:*auth-password-iterations* 1000)
+         (star:*auth-password-min-length* 12)
+         (store (star.auth:make-memory-credential-store)))
+    (is (string= "password_too_short"
+                 (captured-user-lifecycle-code
+                  (lambda ()
+                    (star.auth:create-user
+                     "alice"
+                     "short"
+                     "user"
+                     '("documents:read")
+                     :store store)))))
+    (is (= 0 (star.auth:user-store-count store)))))
+
+(test password-login-mints-existing-api-key-credentials
+  (let* ((star:*auth-pepper* "unit-test-user-pepper")
+         (star:*auth-password-iterations* 1000)
+         (star:*auth-password-min-length* 12)
+         (star:*auth-login-session-seconds* 3600)
+         (store (star.auth:make-memory-credential-store)))
+    (star.auth:create-user
+     "alice"
+     "correct-horse-battery-staple"
+     "user"
+     '("documents:read" "search:read")
+     :must-change-password nil
+     :store store)
+    (multiple-value-bind (user credential raw-key)
+        (star.auth:login-user
+         "alice" "correct-horse-battery-staple" :store store)
+      (is (string= "alice" (star.auth:user-record-username user)))
+      (is (string= "alice" (star.auth:api-key-record-owner credential)))
+      (is (search "star_sk_v1_" raw-key))
+      (let* ((context
+               (star.auth:authenticate-api-key
+                raw-key "corr-user-login" (+ (star.auth:auth-now) 30)
+                :store store))
+             (principal
+               (star.auth:request-security-context-principal context)))
+        (is (string= "alice" (star.auth:request-principal-id principal)))
+        (is (equal '("documents:read" "search:read")
+                   (star.auth:request-principal-scopes principal)))))))
+
+(test password-change-rejects-old-password-and-clears-bootstrap-flag
+  (let* ((star:*auth-pepper* "unit-test-user-pepper")
+         (star:*auth-password-iterations* 1000)
+         (star:*auth-password-min-length* 12)
+         (store (star.auth:make-memory-credential-store)))
+    (star.auth:create-user
+     "alice"
+     "initial-password-123"
+     "user"
+     '("documents:read")
+     :must-change-password t
+     :store store)
+    (let ((updated
+            (star.auth:change-user-password
+             "alice"
+             "initial-password-123"
+             "replacement-password-456"
+             :store store)))
+      (is-false (star.auth:user-record-must-change-password updated)))
+    (is (string= "invalid_credential"
+                 (captured-user-authentication-code
+                  (lambda ()
+                    (star.auth:authenticate-user-password
+                     "alice" "initial-password-123" :store store)))))
+    (is-true
+     (star.auth:authenticate-user-password
+      "alice" "replacement-password-456" :store store))))
+
+(test administrator-can-reset-an-existing-user-password
+  (let* ((star:*auth-pepper* "unit-test-user-pepper")
+         (star:*auth-password-iterations* 1000)
+         (star:*auth-password-min-length* 12)
+         (store (star.auth:make-memory-credential-store)))
+    (star.auth:create-user
+     "analyst"
+     "analyst-password-123"
+     "user"
+     '("documents:read")
+     :must-change-password nil
+     :store store)
+    (let ((updated
+            (star.auth:admin-set-user-password
+             "analyst"
+             "reset-password-456"
+             :must-change-password t
+             :store store)))
+      (is-true (star.auth:user-record-must-change-password updated)))
+    (is-true
+     (star.auth:authenticate-user-password
+      "analyst" "reset-password-456" :store store))))

--- a/t/run-tests.lisp
+++ b/t/run-tests.lisp
@@ -10,7 +10,8 @@
     event-actor-tests
     dataset-export-tests
     http-boundary-tests
-    http-auth-tests))
+    http-auth-tests
+    auth-users-tests))
 
 (defun run-all-gserver-tests ()
   "Run every hermetic unit suite and fail on empty, skipped, or failed tests."


### PR DESCRIPTION
## Summary

Adds persistent human users on top of StarIntel's existing opaque API-key authentication model.

### First-run account

- fresh auth user store creates `star:intel`
  - username: `star`
  - password: `intel`
  - administrator principal with `admin` scope
  - `must_change_password=true`
- the short built-in password is allowed only for first-run bootstrap; normal user passwords use the configured minimum length
- first-run username/password can be overridden through environment/file settings

### User lifecycle

- `POST /auth/login` authenticates username/password and mints the existing `star_sk_v1_...` bearer credential
- admin `POST /auth/users` creates users
- admin `GET /auth/users` lists redacted metadata
- admin `POST /auth/users/:username/password` resets passwords
- authenticated `POST /auth/password` changes the current human user's password
- user records persist in the separate StarIntel auth CouchDB database
- passwords are stored as PBKDF2-SHA256 combined hashes using Ironclad, with the server auth pepper mixed into the password material

### Tests / CI

- adds hermetic tests for first-run idempotence, redaction, password policy, login-to-bearer conversion, self password changes, and admin resets
- makes the new suite mandatory in the canonical unit runner
- extends the full Nix-built container stack test to prove:
  - fresh `star:intel` login
  - admin-created user login
  - default password change and rejection of old `star:intel`
  - persistence of both users/password changes across restart
- upgrades Nix setup in smoke CI, adds `nix flake check`, a server build gate, job timeouts, least-privilege workflow permissions, and stale-run cancellation

### Safety

`star:intel` is intentionally a first-run default and should be changed immediately before exposing a deployment beyond a trusted/local environment. The initial password can be overridden before first startup.