### PR TITLE
Make master the canonical development branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,9 @@ name: Container Stack
 
 on:
   push:
-    branches: [dev, master]
+    branches: [master]
   pull_request:
-    branches: [dev, master]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -2,9 +2,9 @@ name: Smoke Tests
 
 on:
   push:
-    branches: [ "dev", "master" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "dev", "master" ]
+    branches: [ "master" ]
 
 permissions:
   contents: read

--- a/.github/workflows/starintel-schema-lock.yml
+++ b/.github/workflows/starintel-schema-lock.yml
@@ -2,10 +2,11 @@ name: Canonical StarIntel schema lock
 
 on:
   pull_request:
+    branches:
+      - master
   push:
     branches:
       - master
-      - dev
       - "agent/**"
     paths:
       - "schema/starintel-schema.lock.json"

--- a/docs/development.org
+++ b/docs/development.org
@@ -1,0 +1,43 @@
+#+title: Development and Branch Policy
+
+* Canonical branch
+
+=master= is the only long-lived canonical development branch for this repository.
+
+The former =dev= integration branch is retired. It is historical only and must not receive new feature, fix, research, or hotfix work.
+
+* Branching invariant
+
+Every new short-lived branch starts from current =master=:
+
+#+begin_example
+master
+  |
+  +-- feature/<issue>-<slug>
+  +-- fix/<issue>-<slug>
+  +-- research/<slug>
+  +-- hotfix/<issue>-<slug>
+#+end_example
+
+Normal pull requests target =master=. After a pull request is merged and no dependency still needs its branch, the short-lived branch may be deleted.
+
+Do not:
+
+- create new work from =dev=;
+- target new pull requests at =dev=;
+- recreate a permanent integration branch;
+- force-push published canonical history to simulate reconciliation.
+
+* Starting work
+
+Before creating a branch, refresh and verify =master=, inspect open pull requests/issues for overlap, and branch from the current master SHA. Keep each branch to one coherent implementation slice.
+
+* Verification and merge
+
+Run the repository's applicable gates before merge. Required suites that discover or execute zero tests are failures. Do not hide missing dependencies, skipped suites, environment failures, flaky failures, or integration failures.
+
+Normal feature/fix pull requests merge to =master= only after the required checks for that head commit are green and no unresolved correctness blocker remains.
+
+* Historical dev branch
+
+The final semantic =dev -> master= reconciliation was performed in PR #99. The =dev= ref, if still present, is deprecated history rather than an integration target. Open historical pull requests that formerly targeted =dev= must be retargeted to =master= or closed with an explicit disposition before =dev= can be deleted safely.


### PR DESCRIPTION
Closes #53 after merge.

## Policy

- `master` is the sole long-lived canonical development branch.
- all new feature/fix/research/hotfix branches start from current `master`.
- all normal pull requests target `master`.
- `dev` is retired/deprecated and receives no new work.

## Checked-in changes

- add `docs/development.org` with the permanent branch invariant and merge/test policy;
- remove `dev` from normal Smoke and Container Stack push/PR filters;
- constrain schema-lock PRs to `master` and remove its `dev` push filter;
- operational-salvage was already moved to `master` PRs as part of #99 because otherwise the reconciliation could not run that gate.

The special schema-lock `agent/**` push trigger remains as a direct branch test hook; it is not an integration target. Normal PRs still target master.

## Historical PR disposition

#95 remains valid and will be retargeted/refreshed onto master after this policy PR lands. #79 remains a separate AGPL legal/contributor-permission review and is not folded into runtime work.
