### PR TITLE
Add v1 capability discovery endpoint

### DIFF
--- a/source/frontends/http-capabilities.lisp
+++ b/source/frontends/http-capabilities.lisp
@@ -1,7 +1,7 @@
 (in-package :star.frontends.http-api)
 
-(defconstant +api-v1-version+ "v1")
-(defconstant +capabilities-path+ "/api/v1/capabilities")
+(defparameter +api-v1-version+ "v1")
+(defparameter +capabilities-path+ "/api/v1/capabilities")
 
 (defun json-boolean (value)
   (if value :true :false))

--- a/source/frontends/http-capabilities.lisp
+++ b/source/frontends/http-capabilities.lisp
@@ -1,0 +1,95 @@
+(in-package :star.frontends.http-api)
+
+(defconstant +api-v1-version+ "v1")
+(defconstant +capabilities-path+ "/api/v1/capabilities")
+
+(defun json-boolean (value)
+  (if value :true :false))
+
+(defun capability-endpoint (id method path &key legacy)
+  (jsown:new-js
+    ("id" id)
+    ("method" method)
+    ("path" path)
+    ("legacy" (json-boolean legacy))))
+
+(defun configured-auth-modes ()
+  (let ((mode (string-downcase (or star:*auth-mode* ""))))
+    (cond
+      ((string= mode "api-key") (list "api-key"))
+      ((string= mode "disabled") (list "disabled"))
+      (t (list "configured")))))
+
+(defun capabilities-data ()
+  (jsown:new-js
+    ("build"
+     (jsown:new-js
+       ("service" "starintel-gserver")
+       ("version" star:*star-server-version*)))
+    ("schema_revisions"
+     (jsown:new-js
+       ("api" +api-v1-version+)
+       ("document" starintel:+starintel-doc-version+)))
+    ("transports" (list "http"))
+    ("authentication"
+     (jsown:new-js
+       ("modes" (configured-auth-modes))
+       ("capabilities_endpoint_requires_auth" :false)))
+    ("features"
+     (jsown:new-js
+       ("documents" :true)
+       ("bulk_ingest" :true)
+       ("search" :true)
+       ("targets" :true)
+       ("views"
+        (jsown:new-js
+          ("available" :true)
+          ("registry" :true)
+          ("query" :true)))
+       ("queue_ingest" :true)
+       ("target_leases" :false)
+       ("streams" :false)
+       ("openapi" :false)))
+    ("limits"
+     (jsown:new-js
+       ("bulk_documents" star:*bulk-max-documents*)
+       ("default_request_timeout_ms"
+        star:*auth-default-request-timeout-ms*)
+       ("max_request_timeout_ms"
+        star:*auth-max-request-timeout-ms*)))
+    ("endpoints"
+     (list
+      (capability-endpoint
+       "capabilities" "GET" +capabilities-path+)
+      (capability-endpoint
+       "document_create" "POST" "/new/document/:dtype" :legacy t)
+      (capability-endpoint
+       "document_read" "GET" "/document/:id" :legacy t)
+      (capability-endpoint
+       "document_bulk" "POST" "/documents/bulk" :legacy t)
+      (capability-endpoint
+       "search" "GET" "/search" :legacy t)
+      (capability-endpoint
+       "target_create" "POST" "/new/target/:actor" :legacy t)
+      (capability-endpoint
+       "targets_by_actor" "GET" "/targets/:actor" :legacy t)))
+    ("compatibility"
+     (jsown:new-js
+       ("legacy_routes" :true)
+       ("legacy_routes_deprecated" :false)))))
+
+(defun capabilities-document ()
+  (jsown:new-js
+    ("status" "ok")
+    ("data" (capabilities-data))))
+
+(defun capabilities-json ()
+  (jsown:to-json (capabilities-document)))
+
+(pushnew +capabilities-path+ star:*auth-public-paths* :test #'string=)
+
+(setf (ningle:route *app* +capabilities-path+ :method :get)
+      (lambda (params)
+        (declare (ignore params))
+        (set-default-headers)
+        (capabilities-json)))

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -59,6 +59,7 @@
    (:file "frontends/http-view-registry")
    (:file "frontends/http-status-message")
    (:file "frontends/http-boundary-core")
+   (:file "frontends/http-capabilities")
    (:file "frontends/http-auth")
    (:file "frontends/http-authorization")
    (:file "frontends/http-bulk-jobs")

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -31,6 +31,7 @@
      (:file "couchdb-view-request-test")
      (:file "lease-store-contract-test")
      (:file "http-boundary-test")
+     (:file "http-capabilities-test")
      (:file "http-auth-test")
      (:file "auth-users-test")
      (:file "http-auth-oracle-test")

--- a/t/http-capabilities-test.lisp
+++ b/t/http-capabilities-test.lisp
@@ -53,8 +53,8 @@
            (capability-endpoint-by-id document "capabilities"))
          (legacy-document
            (capability-endpoint-by-id document "document_create")))
-    (is capabilities)
-    (is legacy-document)
+    (is (not (null capabilities)))
+    (is (not (null legacy-document)))
     (is (string= "GET" (jsown:val capabilities "method")))
     (is (string= "/api/v1/capabilities"
                  (jsown:val capabilities "path")))

--- a/t/http-capabilities-test.lisp
+++ b/t/http-capabilities-test.lisp
@@ -1,0 +1,90 @@
+(in-package :star-server-tests)
+
+(in-suite http-boundary-tests)
+
+(defun capability-data-value (document key)
+  (jsown:val (jsown:val document "data") key))
+
+(defun capability-feature-value (document key)
+  (jsown:val (capability-data-value document "features") key))
+
+(defun capability-endpoint-by-id (document id)
+  (find id
+        (capability-data-value document "endpoints")
+        :key (lambda (endpoint)
+               (jsown:val endpoint "id"))
+        :test #'string=))
+
+(test api-v1-capabilities-has-stable-envelope
+  (let* ((document
+           (star.frontends.http-api::capabilities-document))
+         (data (jsown:val document "data"))
+         (schemas (jsown:val data "schema_revisions"))
+         (build (jsown:val data "build")))
+    (is (string= "ok" (jsown:val document "status")))
+    (is (string= "v1" (jsown:val schemas "api")))
+    (is (string= starintel:+starintel-doc-version+
+                 (jsown:val schemas "document")))
+    (is (string= "starintel-gserver"
+                 (jsown:val build "service")))
+    (is (string= star:*star-server-version*
+                 (jsown:val build "version")))))
+
+(test api-v1-capabilities-advertises-only-current-features
+  (let ((document
+          (star.frontends.http-api::capabilities-document)))
+    (is (eq :true
+            (capability-feature-value document "documents")))
+    (is (eq :true
+            (capability-feature-value document "search")))
+    (is (eq :true
+            (capability-feature-value document "targets")))
+    (is (eq :false
+            (capability-feature-value document "target_leases")))
+    (is (eq :false
+            (capability-feature-value document "streams")))
+    (is (eq :false
+            (capability-feature-value document "openapi")))))
+
+(test api-v1-capabilities-identifies-versioned-and-legacy-routes
+  (let* ((document
+           (star.frontends.http-api::capabilities-document))
+         (capabilities
+           (capability-endpoint-by-id document "capabilities"))
+         (legacy-document
+           (capability-endpoint-by-id document "document_create")))
+    (is capabilities)
+    (is legacy-document)
+    (is (string= "GET" (jsown:val capabilities "method")))
+    (is (string= "/api/v1/capabilities"
+                 (jsown:val capabilities "path")))
+    (is (eq :false (jsown:val capabilities "legacy")))
+    (is (eq :true (jsown:val legacy-document "legacy")))))
+
+(test api-v1-capabilities-is-public-discovery
+  (is (member "/api/v1/capabilities"
+              star:*auth-public-paths*
+              :test #'string=)))
+
+(test api-v1-capabilities-does-not-leak-secrets
+  (let ((star:*couchdb-password* "capabilities-db-secret")
+        (star:*rabbit-password* "capabilities-rabbit-secret")
+        (star:*auth-pepper* "capabilities-pepper-secret")
+        (star:*auth-bootstrap-secret* "capabilities-bootstrap-secret"))
+    (let ((json (star.frontends.http-api::capabilities-json)))
+      (is (null (search "capabilities-db-secret" json)))
+      (is (null (search "capabilities-rabbit-secret" json)))
+      (is (null (search "capabilities-pepper-secret" json)))
+      (is (null (search "capabilities-bootstrap-secret" json))))))
+
+(test api-v1-capabilities-reports-auth-mode-without-auth-material
+  (let ((star:*auth-mode* "api-key"))
+    (let* ((document
+             (star.frontends.http-api::capabilities-document))
+           (authentication
+             (capability-data-value document "authentication")))
+      (is (equal '("api-key")
+                 (jsown:val authentication "modes")))
+      (is (eq :false
+              (jsown:val authentication
+                         "capabilities_endpoint_requires_auth"))))))


### PR DESCRIPTION
## Summary

Start issue #58 with a small, self-contained versioned API contract slice.

- add public `GET /api/v1/capabilities`
- return a stable `{status,data}` envelope
- advertise server/API/document schema revisions
- advertise the currently supported HTTP transport and configured auth mode
- expose current feature availability and bounded request/bulk limits
- enumerate the new discovery route plus the existing legacy document/search/target routes
- explicitly report target leases, streams, and OpenAPI as unavailable on the current canonical `master`
- add hermetic contract coverage to the existing required HTTP boundary suite
- prove configured credential/database/broker secrets are not emitted

This intentionally does **not** overlap PR #101 / issue #32 target-lease and fencing work.

## Why

Clients such as Quasar need one stable request for feature detection instead of inferring server behavior from 404s or hard-coding legacy route assumptions. This is the first bounded piece of #58 rather than a wholesale API migration.

## Validation

The branch is based exactly on canonical `master` `7834d6614378e01232a1c810249d9ae83cec25c5` and is currently 0 commits behind it.

Local execution was not available in this environment, so the PR is intentionally draft and CI is the validation authority for the Common Lisp test suite.

Refs #58