### PR TITLE
API v1: public search and watch-safe stats

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -76,7 +76,9 @@ jobs:
         env:
           COUCHDB_USER: admin
           COUCHDB_PASSWORD: password
+          NODENAME: 127.0.0.1
           COUCHDB_ERLANG_COOKIE: starintel-ci-clouseau
+          ERL_FLAGS: -setcookie starintel-ci-clouseau
         options: >-
           --health-cmd "curl -f http://localhost:5984/_up || exit 1"
           --health-interval 10s
@@ -93,6 +95,33 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      - name: Prepare Clouseau 2.25.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          clouseau_dir="$RUNNER_TEMP/clouseau"
+          config_dir="$RUNNER_TEMP/clouseau-config"
+          data_dir="$RUNNER_TEMP/clouseau-data"
+          mkdir -p "$clouseau_dir" "$config_dir" "$data_dir"
+          curl --fail --location --retry 3 \
+            --output "$RUNNER_TEMP/clouseau.zip" \
+            https://github.com/cloudant-labs/clouseau/releases/download/2.25.0/clouseau-2.25.0-dist.zip
+          unzip -q "$RUNNER_TEMP/clouseau.zip" -d "$clouseau_dir"
+          cat >"$config_dir/clouseau.ini" <<'EOF'
+          [clouseau]
+          name=clouseau@127.0.0.1
+          cookie=starintel-ci-clouseau
+          dir=/data
+          max_indexes_open=500
+          EOF
+          cat >"$config_dir/log4j.properties" <<'EOF'
+          log4j.rootLogger=info, CONSOLE
+          log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+          log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+          log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %c [%p] %m%n
+          EOF
+          test -n "$(find "$clouseau_dir" -type f -name '*.jar' -print -quit)"
+
       - name: Start Clouseau search sidecar
         shell: bash
         run: |
@@ -102,10 +131,12 @@ jobs:
           docker run --detach \
             --name starintel-clouseau \
             --network "container:$couchdb_id" \
-            --env ERLANG_COOKIE=starintel-ci-clouseau \
+            --volume "$RUNNER_TEMP/clouseau:/opt/clouseau:ro" \
+            --volume "$RUNNER_TEMP/clouseau-config:/config:ro" \
+            --volume "$RUNNER_TEMP/clouseau-data:/data" \
             --entrypoint sh \
-            ghcr.io/jaydoane/clouseau:3.0.0 \
-            -c 'set -eu; printf "%s\n" "$ERLANG_COOKIE" > /opt/couchdb-search/.erlang.cookie; chmod 400 /opt/couchdb-search/.erlang.cookie; exec tini -- java -server -Dsun.net.inetaddr.ttl=30 -Dsun.net.inetaddr.negative.ttl=30 -classpath "/opt/couchdb-search/lib/*" com.cloudant.ziose.clouseau.Main /opt/couchdb-search/etc/app.conf'
+            eclipse-temurin:8-jre \
+            -c 'set -eu; classpath="$(find /opt/clouseau -type f -name "*.jar" -print | paste -sd: -)"; test -n "$classpath"; exec java -server -Xmx1G -Dsun.net.inetaddr.ttl=30 -Dsun.net.inetaddr.negative.ttl=30 -Dlog4j.configuration=file:/config/log4j.properties -XX:OnOutOfMemoryError="kill -9 %p" -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -classpath "$classpath" com.cloudant.clouseau.Main /config/clouseau.ini'
 
       - name: Wait for services and initialize
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -114,4 +114,20 @@ jobs:
           COUCHDB_PASSWORD: password
           RABBITMQ_USER: guest
           RABBITMQ_PASSWORD: guest
-        run: nix run .#star-integration-tests
+        shell: bash
+        run: |
+          set +e
+          log_file="$RUNNER_TEMP/service-backed-integration-tests.log"
+          nix run .#star-integration-tests >"$log_file" 2>&1
+          status=$?
+          tail -n 400 "$log_file"
+          exit "$status"
+
+      - name: Upload service-backed integration-test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-backed-integration-tests-${{ github.sha }}
+          path: ${{ runner.temp }}/service-backed-integration-tests.log
+          if-no-files-found: warn
+          retention-days: 1

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           COUCHDB_USER: admin
           COUCHDB_PASSWORD: password
+          COUCHDB_ERLANG_COOKIE: starintel-ci-clouseau
         options: >-
           --health-cmd "curl -f http://localhost:5984/_up || exit 1"
           --health-interval 10s
@@ -92,6 +93,20 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      - name: Start Clouseau search sidecar
+        shell: bash
+        run: |
+          set -euo pipefail
+          couchdb_id="$(docker ps --filter 'ancestor=couchdb:3.5.2' --format '{{.ID}}' | head -n 1)"
+          test -n "$couchdb_id"
+          docker run --detach \
+            --name starintel-clouseau \
+            --network "container:$couchdb_id" \
+            --env ERLANG_COOKIE=starintel-ci-clouseau \
+            --entrypoint sh \
+            ghcr.io/jaydoane/clouseau:3.0.0 \
+            -c 'set -eu; printf "%s\n" "$ERLANG_COOKIE" > /opt/couchdb-search/.erlang.cookie; chmod 400 /opt/couchdb-search/.erlang.cookie; exec tini -- java -server -Dsun.net.inetaddr.ttl=30 -Dsun.net.inetaddr.negative.ttl=30 -classpath "/opt/couchdb-search/lib/*" com.cloudant.ziose.clouseau.Main /opt/couchdb-search/etc/app.conf'
+
       - name: Wait for services and initialize
         run: |
           echo "Waiting for RabbitMQ..."
@@ -99,6 +114,9 @@ jobs:
 
           echo "Waiting for CouchDB..."
           timeout 60 bash -c 'until curl -f http://localhost:5984/_up > /dev/null 2>&1; do sleep 2; done'
+
+          echo "Waiting for CouchDB Search / Clouseau..."
+          timeout 90 bash -c 'until curl --fail --silent --user admin:password http://localhost:5984/_node/_local/_versions | jq -e ".clouseau.version" >/dev/null; do docker logs --tail 20 starintel-clouseau || true; sleep 2; done'
 
           echo "Creating CouchDB database..."
           curl --fail --silent --show-error \
@@ -131,3 +149,7 @@ jobs:
           path: ${{ runner.temp }}/service-backed-integration-tests.log
           if-no-files-found: warn
           retention-days: 1
+
+      - name: Show Clouseau logs on failure
+        if: failure()
+        run: docker logs starintel-clouseau || true

--- a/cli/http-contract-final.lisp
+++ b/cli/http-contract-final.lisp
@@ -38,6 +38,47 @@
 (refresh-operation-response-schema "auth.credentials.revoke" (credential-status-schema))
 (refresh-operation-response-schema "auth.credentials.disable" (credential-status-schema))
 
+(defun upsert-http-operation (operation)
+  "Replace OPERATION by ID or append it once. Safe across interactive reloads."
+  (setf *http-operations*
+        (append
+         (remove (http-operation-id operation)
+                 *http-operations*
+                 :key #'http-operation-id
+                 :test #'string=)
+         (list operation)))
+  operation)
+
+(upsert-http-operation
+ (make-http-operation
+  :id "public.search.get"
+  :client-name "public-search"
+  :method :get
+  :path "/api/v1/search"
+  :summary "Search the server-owned public intelligence scope"
+  :tags '("public" "search")
+  :authority :public
+  :responses
+  (list
+   (response 200 "Public search result." (generic-object-schema))
+   (response 400 "Invalid public search request." +error-schema+)
+   (response 500 "Search backend failure." +error-schema+))))
+
+(upsert-http-operation
+ (make-http-operation
+  :id "stats.get"
+  :client-name "public-stats"
+  :method :get
+  :path "/api/v1/stats"
+  :summary "Compact aggregate server statistics for public clients"
+  :tags '("public" "system" "stats")
+  :authority :public
+  :responses
+  (list
+   (response 200 "Aggregate server statistics." (generic-object-schema))
+   (response 500 "Statistics backend failure." +error-schema+)
+   (response 504 "Statistics backend timeout." +error-schema+))))
+
 (defun remove-json-object-key (object key)
   (when (and (consp object) (eq (first object) :obj))
     (setf (cdr object)

--- a/example_configs/init.lisp
+++ b/example_configs/init.lisp
@@ -30,6 +30,9 @@
 (setf *http-api-address*
       (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") "127.0.0.1")
       *http-api-port* 5000
+      ;; Public-read mode is the default. Set NIL for authenticated-only
+      ;; /api/v1/search and /api/v1/stats deployments.
+      *public-mode* t
       *bulk-max-documents* 500)
 
 ;;; Concurrency ------------------------------------------------------------

--- a/source/frontends/http-auth.lisp
+++ b/source/frontends/http-auth.lisp
@@ -52,10 +52,16 @@
           '("/api/v1/search" "/api/v1/stats")
           :test #'string=))
 
+;; Keep the default public-read surface visible to existing introspection while
+;; making PUBLIC-AUTH-PATH-P the authoritative runtime decision. This means an
+;; init.lisp setting of *PUBLIC-MODE* NIL can override these default entries.
+(dolist (path '("/api/v1/search" "/api/v1/stats"))
+  (pushnew path star:*auth-public-paths* :test #'string=))
+
 (defun public-auth-path-p (path)
-  (or (member path star:*auth-public-paths* :test #'string=)
-      (and star::*public-mode*
-           (public-mode-read-path-p path))))
+  (if (public-mode-read-path-p path)
+      star::*public-mode*
+      (member path star:*auth-public-paths* :test #'string=)))
 
 (defun development-security-context (correlation-id deadline)
   (star.auth::%make-request-security-context

--- a/source/frontends/http-auth.lisp
+++ b/source/frontends/http-auth.lisp
@@ -47,8 +47,15 @@
   (+ (get-universal-time)
      (ceiling (parse-request-timeout-ms env) 1000)))
 
+(defun public-mode-read-path-p (path)
+  (member path
+          '("/api/v1/search" "/api/v1/stats")
+          :test #'string=))
+
 (defun public-auth-path-p (path)
-  (member path star:*auth-public-paths* :test #'string=))
+  (or (member path star:*auth-public-paths* :test #'string=)
+      (and star::*public-mode*
+           (public-mode-read-path-p path))))
 
 (defun development-security-context (correlation-id deadline)
   (star.auth::%make-request-security-context

--- a/source/frontends/http-capabilities.lisp
+++ b/source/frontends/http-capabilities.lisp
@@ -23,6 +23,9 @@
       ((string= mode "disabled") (list "disabled"))
       (t (list "configured")))))
 
+(defun public-read-authority ()
+  (if star::*public-mode* "public" "authenticated"))
+
 (defun capabilities-data ()
   (jsown:new-js
     ("build"
@@ -37,6 +40,7 @@
     ("authentication"
      (jsown:new-js
        ("modes" (configured-auth-modes))
+       ("public_mode" (json-boolean star::*public-mode*))
        ("capabilities_endpoint_requires_auth" :false)))
     ("features"
      (jsown:new-js
@@ -69,10 +73,10 @@
        :authority "public")
       (capability-endpoint
        "public_search" "GET" "/api/v1/search"
-       :authority "public")
+       :authority (public-read-authority))
       (capability-endpoint
        "stats" "GET" "/api/v1/stats"
-       :authority "public")
+       :authority (public-read-authority))
       (capability-endpoint
        "document_create" "POST" "/new/document/:dtype"
        :legacy t :scopes '("documents:write"))

--- a/source/frontends/http-capabilities.lisp
+++ b/source/frontends/http-capabilities.lisp
@@ -6,12 +6,15 @@
 (defun json-boolean (value)
   (if value :true :false))
 
-(defun capability-endpoint (id method path &key legacy)
+(defun capability-endpoint
+    (id method path &key legacy (authority "authenticated") scopes)
   (jsown:new-js
     ("id" id)
     ("method" method)
     ("path" path)
-    ("legacy" (json-boolean legacy))))
+    ("legacy" (json-boolean legacy))
+    ("authority" authority)
+    ("scopes" (or scopes nil))))
 
 (defun configured-auth-modes ()
   (let ((mode (string-downcase (or star:*auth-mode* ""))))
@@ -40,6 +43,7 @@
        ("documents" :true)
        ("bulk_ingest" :true)
        ("search" :true)
+       ("stats" :true)
        ("targets" :true)
        ("views"
         (jsown:new-js
@@ -49,10 +53,11 @@
        ("queue_ingest" :true)
        ("target_leases" :false)
        ("streams" :false)
-       ("openapi" :false)))
+       ("openapi" :true)))
     ("limits"
      (jsown:new-js
        ("bulk_documents" star:*bulk-max-documents*)
+       ("public_search_results" 50)
        ("default_request_timeout_ms"
         star:*auth-default-request-timeout-ms*)
        ("max_request_timeout_ms"
@@ -60,19 +65,32 @@
     ("endpoints"
      (list
       (capability-endpoint
-       "capabilities" "GET" +capabilities-path+)
+       "capabilities" "GET" +capabilities-path+
+       :authority "public")
       (capability-endpoint
-       "document_create" "POST" "/new/document/:dtype" :legacy t)
+       "public_search" "GET" "/api/v1/search"
+       :authority "public")
       (capability-endpoint
-       "document_read" "GET" "/document/:id" :legacy t)
+       "stats" "GET" "/api/v1/stats"
+       :authority "public")
       (capability-endpoint
-       "document_bulk" "POST" "/documents/bulk" :legacy t)
+       "document_create" "POST" "/new/document/:dtype"
+       :legacy t :scopes '("documents:write"))
       (capability-endpoint
-       "search" "GET" "/search" :legacy t)
+       "document_read" "GET" "/document/:id"
+       :legacy t :scopes '("documents:read"))
       (capability-endpoint
-       "target_create" "POST" "/new/target/:actor" :legacy t)
+       "document_bulk" "POST" "/documents/bulk"
+       :legacy t :scopes '("documents:bulk"))
       (capability-endpoint
-       "targets_by_actor" "GET" "/targets/:actor" :legacy t)))
+       "search" "GET" "/search"
+       :legacy t :scopes '("search:read"))
+      (capability-endpoint
+       "target_create" "POST" "/new/target/:actor"
+       :legacy t :scopes '("targets:dispatch"))
+      (capability-endpoint
+       "targets_by_actor" "GET" "/targets/:actor"
+       :legacy t :scopes '("targets:read"))))
     ("compatibility"
      (jsown:new-js
        ("legacy_routes" :true)

--- a/source/frontends/http-contract-routes.lisp
+++ b/source/frontends/http-contract-routes.lisp
@@ -4,7 +4,7 @@
   (or (star::split-comma-setting
        (uiop:getenv "STAR_PUBLIC_SEARCH_DATASETS"))
       '("*"))
-  "Datasets visible through the unauthenticated v1 search surface.
+  "Datasets visible through the v1 public-read search surface.
 The default wildcard matches the public-server deployment model. Operators
 that mix public and private datasets must explicitly configure this list.")
 
@@ -14,10 +14,12 @@ that mix public and private datasets must explicitly configure this list.")
 (defparameter +public-search-max-results+ 50)
 (defparameter +public-stats-cache-seconds+ 15)
 
+;; Schema/discovery artifacts remain safe to fetch anonymously regardless of
+;; deployment mode. Data-bearing read endpoints are gated dynamically by
+;; STAR::*PUBLIC-MODE* in the authentication middleware, so init.lisp can
+;; switch them between anonymous and authenticated operation after system load.
 (dolist (path '("/openapi.json"
-                "/client-manifest.json"
-                "/api/v1/search"
-                "/api/v1/stats"))
+                "/client-manifest.json"))
   (pushnew path star:*auth-public-paths* :test #'string=))
 
 (defun mount-http-operation (operation-id handler)

--- a/source/frontends/http-contract-routes.lisp
+++ b/source/frontends/http-contract-routes.lisp
@@ -1,6 +1,23 @@
 (in-package :star.frontends.http-api)
 
-(dolist (path '("/openapi.json" "/client-manifest.json"))
+(defparameter *public-search-datasets*
+  (or (star::split-comma-setting
+       (uiop:getenv "STAR_PUBLIC_SEARCH_DATASETS"))
+      '("*"))
+  "Datasets visible through the unauthenticated v1 search surface.
+The default wildcard matches the public-server deployment model. Operators
+that mix public and private datasets must explicitly configure this list.")
+
+(defparameter +public-search-path+ "/api/v1/search")
+(defparameter +public-stats-path+ "/api/v1/stats")
+(defparameter +public-search-max-query-length+ 512)
+(defparameter +public-search-max-results+ 50)
+(defparameter +public-stats-cache-seconds+ 15)
+
+(dolist (path '("/openapi.json"
+                "/client-manifest.json"
+                "/api/v1/search"
+                "/api/v1/stats"))
   (pushnew path star:*auth-public-paths* :test #'string=))
 
 (defun mount-http-operation (operation-id handler)
@@ -11,6 +28,11 @@
                         :method (star.http.contract:http-operation-method operation))
           handler)
     operation))
+
+(defun set-cache-control (value)
+  (setf (lack.response:response-headers *response*)
+        (append (lack.response:response-headers *response*)
+                (list :cache-control value))))
 
 (defun handle-contracted-health-route (params)
   (declare (ignore params))
@@ -30,6 +52,142 @@
        ("openapi" "/openapi.json")
        ("client_manifest" "/client-manifest.json")))))
 
+(defun public-search-scopes ()
+  (append
+   '("search:read" "tenant:*")
+   (mapcar (lambda (dataset)
+             (format nil "dataset:~a" dataset))
+           *public-search-datasets*)))
+
+(defun public-search-context ()
+  (star.authorization:make-trusted-authorization-context
+   :id "public-api-v1"
+   :principal-type "public_reader"
+   :scopes (public-search-scopes)))
+
+(defun public-search-authorized-query (query)
+  "Compile QUERY through the normal authorization scoper using only
+server-owned public scopes. No caller principal or caller scope enters here."
+  (let ((context (public-search-context)))
+    (star.authorization:with-trusted-authorization-context (context)
+      (star.authorization:authorized-search-query
+       query
+       :principal context
+       :requested-dataset nil
+       :requested-tenant nil
+       :metadata (route-policy-metadata +public-search-path+ "GET")))))
+
+(defun reject-public-scope-overrides (params)
+  (when (or (query-value params "dataset")
+            (query-value params "tenant"))
+    (signal-http-input-error
+     400
+     "public_scope_is_server_owned"
+     "Public search dataset and tenant scope cannot be overridden")))
+
+(defun handle-public-search-route (params)
+  (with-http-boundary ()
+    (reject-public-scope-overrides params)
+    (let* ((q (require-query-string params "q"))
+           (limit (bounded-query-integer
+                   params "limit"
+                   :default 25
+                   :minimum 1
+                   :maximum +public-search-max-results+)))
+      (when (> (length q) +public-search-max-query-length+)
+        (signal-http-input-error
+         400
+         "search_query_too_long"
+         "Public search query exceeds the configured length limit"
+         (jsown:new-js
+           ("maximum" +public-search-max-query-length+))))
+      (let ((scoped-query (public-search-authorized-query q)))
+        (couchdb-handler (client *couchdb-pool*)
+          (let* ((bookmark (query-value params "bookmark"))
+                 (query (jsown:new-js
+                          ("q" scoped-query)
+                          ("limit" limit)
+                          ("include_docs" t))))
+            (when bookmark
+              (setf (jsown:val query "bookmark") bookmark))
+            (set-cache-control "no-store")
+            (cl-couch:fts-search
+             client
+             (jsown:to-json query)
+             star:*couchdb-default-database*
+             "search"
+             "fts")))))))
+
+(defun reduced-view-value (response)
+  (let* ((rows (or (jsown:val-safe response "rows") nil))
+         (row (first rows)))
+    (or (and row (jsown:val-safe row "value")) 0)))
+
+(defun dtype-count-object (response)
+  (let ((result (list :obj)))
+    (dolist (row (or (jsown:val-safe response "rows") nil) result)
+      (let ((dtype (jsown:val-safe row "key"))
+            (count (jsown:val-safe row "value")))
+        (when (and (stringp dtype) (numberp count))
+          (setf (jsown:val result dtype) count))))))
+
+(defun dtype-count (counts dtype)
+  (or (jsown:val-safe counts dtype) 0))
+
+(defun unix-time-now ()
+  (- (get-universal-time) 2208988800))
+
+(defun public-stats-document-from-view-responses
+    (total-response dtype-response)
+  "Build the stable public stats envelope from aggregate CouchDB view output."
+  (let* ((by-dtype (dtype-count-object dtype-response))
+         (target-total
+           (+ (dtype-count by-dtype "target")
+              (dtype-count by-dtype "investigation-target"))))
+    (jsown:new-js
+      ("status" "ok")
+      ("data"
+       (jsown:new-js
+         ("service" "starintel-gserver")
+         ("version" star:*star-server-version*)
+         ("generated_at" (unix-time-now))
+         ("documents"
+          (jsown:new-js
+            ("total" (reduced-view-value total-response))
+            ("by_dtype" by-dtype)))
+         ("targets"
+          (jsown:new-js
+            ("total" target-total))))))))
+
+(defun handle-public-stats-route (params)
+  (declare (ignore params))
+  (with-http-boundary ()
+    (couchdb-handler (client *couchdb-pool*)
+      (let ((total-response
+              (query-view
+               client
+               star:*couchdb-default-database*
+               "data"
+               "total"
+               :limit 1
+               :include-docs nil
+               :reduce t))
+            (dtype-response
+              (query-view
+               client
+               star:*couchdb-default-database*
+               "data"
+               "count_by_dtype"
+               :limit 1000
+               :include-docs nil
+               :reduce t
+               :group t)))
+        (set-cache-control
+         (format nil "public, max-age=~d" +public-stats-cache-seconds+))
+        (jsown:to-json
+         (public-stats-document-from-view-responses
+          total-response dtype-response))))))
+
 (defun handle-openapi-route (params)
   (declare (ignore params))
   (with-http-boundary ()
@@ -40,7 +198,7 @@
   (with-http-boundary ()
     (star.http.contract:client-manifest-json)))
 
-;; Re-mount the first contracted surface from operation IDs. Some legacy route
+;; Re-mount the contracted surface from operation IDs. Some legacy route
 ;; declarations still exist in their historical source files; these final
 ;; mounts are authoritative and prevent method/path drift for the contracted
 ;; client surface while the remaining legacy API is migrated incrementally.
@@ -48,6 +206,8 @@
 (mount-http-operation "server.get" #'handle-contracted-server-info-route)
 (mount-http-operation "schema.openapi.get" #'handle-openapi-route)
 (mount-http-operation "schema.client-manifest.get" #'handle-client-manifest-route)
+(mount-http-operation "public.search.get" #'handle-public-search-route)
+(mount-http-operation "stats.get" #'handle-public-stats-route)
 
 (mount-http-operation "auth.login" #'handle-auth-login-route)
 (mount-http-operation "auth.bootstrap" #'handle-auth-bootstrap-route)

--- a/source/gserver-settings.lisp
+++ b/source/gserver-settings.lisp
@@ -76,6 +76,11 @@
 (defparameter *http-cert-file* nil)
 (defparameter *http-key-file* nil)
 (defparameter *http-scheme* 'http)
+(defparameter *public-mode*
+  (not (null (environment-boolean "STAR_PUBLIC_MODE" t)))
+  "When true, safe v1 read endpoints such as search and aggregate stats may be
+used without credentials. Operators can set this to NIL in init.lisp (or set
+STAR_PUBLIC_MODE=false before init loads) for authenticated-only deployments.")
 (defparameter *http-cors-allowed-origins*
   (split-comma-setting (uiop:getenv "STAR_AUTH_ALLOWED_ORIGINS")))
 (defparameter *http-cors-allowed-methods*

--- a/starintel-gserver-integration-tests.asd
+++ b/starintel-gserver-integration-tests.asd
@@ -11,6 +11,7 @@
                              (:file "valkey-lease-integration-test")
                              (:file "valkey-lease-review-regression-test")
                              (:file "http-api-test")
+                             (:file "http-public-api-integration-test")
                              (:file "run-integration-tests"))))
   :perform (test-op (o c)
              (declare (ignore o c))

--- a/t/http-capabilities-test.lisp
+++ b/t/http-capabilities-test.lisp
@@ -105,7 +105,8 @@
                (jsown:val target-create "scopes")))))
 
 (test api-v1-public-search-uses-server-owned-scope
-  (let ((star:*http-public-search-datasets* '("public-a" "public-b")))
+  (let ((star.frontends.http-api::*public-search-datasets*
+          '("public-a" "public-b")))
     (let ((query
             (star.frontends.http-api::public-search-authorized-query
              "alice")))
@@ -114,7 +115,7 @@
       (is (null (search "private-dataset" query))))))
 
 (test api-v1-public-search-wildcard-mode-is-explicit
-  (let ((star:*http-public-search-datasets* '("*")))
+  (let ((star.frontends.http-api::*public-search-datasets* '("*")))
     (is (string=
          "(alice)"
          (star.frontends.http-api::public-search-authorized-query

--- a/t/http-capabilities-test.lisp
+++ b/t/http-capabilities-test.lisp
@@ -39,11 +39,13 @@
             (capability-feature-value document "search")))
     (is (eq :true
             (capability-feature-value document "targets")))
+    (is (eq :true
+            (capability-feature-value document "stats")))
     (is (eq :false
             (capability-feature-value document "target_leases")))
     (is (eq :false
             (capability-feature-value document "streams")))
-    (is (eq :false
+    (is (eq :true
             (capability-feature-value document "openapi")))))
 
 (test api-v1-capabilities-identifies-versioned-and-legacy-routes
@@ -51,15 +53,101 @@
            (star.frontends.http-api::capabilities-document))
          (capabilities
            (capability-endpoint-by-id document "capabilities"))
+         (public-search
+           (capability-endpoint-by-id document "public_search"))
+         (stats
+           (capability-endpoint-by-id document "stats"))
          (legacy-document
            (capability-endpoint-by-id document "document_create")))
     (is (not (null capabilities)))
+    (is (not (null public-search)))
+    (is (not (null stats)))
     (is (not (null legacy-document)))
     (is (string= "GET" (jsown:val capabilities "method")))
     (is (string= "/api/v1/capabilities"
                  (jsown:val capabilities "path")))
     (is (eq :false (jsown:val capabilities "legacy")))
-    (is (eq :true (jsown:val legacy-document "legacy")))))
+    (is (eq :false (jsown:val public-search "legacy")))
+    (is (eq :false (jsown:val stats "legacy")))
+    (is (eq :true (jsown:val legacy-document "legacy")))
+    (is (string= "public" (jsown:val public-search "authority")))
+    (is (string= "public" (jsown:val stats "authority")))
+    (is (string= "authenticated" (jsown:val legacy-document "authority")))))
+
+(test api-v1-public-read-surface-is-public
+  (dolist (path '("/api/v1/capabilities"
+                  "/api/v1/search"
+                  "/api/v1/stats"))
+    (is (member path star:*auth-public-paths* :test #'string=)))
+  (dolist (operation-id '("public.search.get" "stats.get"))
+    (let ((operation (star.http.contract:find-http-operation operation-id)))
+      (is (eq :public
+              (star.http.contract:http-operation-authority operation))))))
+
+(test api-v1-mutation-routes-remain-authenticated
+  (dolist (path '("/new/document/message"
+                  "/new/target/nmap"
+                  "/documents/bulk"))
+    (is (null (member path star:*auth-public-paths* :test #'string=))))
+  (let ((document-create
+          (capability-endpoint-by-id
+           (star.frontends.http-api::capabilities-document)
+           "document_create"))
+        (target-create
+          (capability-endpoint-by-id
+           (star.frontends.http-api::capabilities-document)
+           "target_create")))
+    (is (string= "authenticated" (jsown:val document-create "authority")))
+    (is (equal '("documents:write")
+               (jsown:val document-create "scopes")))
+    (is (string= "authenticated" (jsown:val target-create "authority")))
+    (is (equal '("targets:dispatch")
+               (jsown:val target-create "scopes")))))
+
+(test api-v1-public-search-uses-server-owned-scope
+  (let ((star:*http-public-search-datasets* '("public-a" "public-b")))
+    (let ((query
+            (star.frontends.http-api::public-search-authorized-query
+             "alice")))
+      (is (search "dataset:\"public-a\"" query))
+      (is (search "dataset:\"public-b\"" query))
+      (is (null (search "private-dataset" query))))))
+
+(test api-v1-public-search-wildcard-mode-is-explicit
+  (let ((star:*http-public-search-datasets* '("*")))
+    (is (string=
+         "(alice)"
+         (star.frontends.http-api::public-search-authorized-query
+          "alice")))))
+
+(test api-v1-public-stats-are-aggregate-only
+  (let* ((total-response
+           (jsown:new-js
+             ("rows"
+              (list (jsown:new-js ("key" :null) ("value" 42))))))
+         (dtype-response
+           (jsown:new-js
+             ("rows"
+              (list
+               (jsown:new-js ("key" "person") ("value" 10))
+               (jsown:new-js ("key" "relation") ("value" 20))
+               (jsown:new-js ("key" "target") ("value" 3))
+               (jsown:new-js
+                 ("key" "investigation-target") ("value" 2))))))
+         (document
+           (star.frontends.http-api::public-stats-document-from-view-responses
+            total-response dtype-response))
+         (data (jsown:val document "data"))
+         (documents (jsown:val data "documents"))
+         (by-dtype (jsown:val documents "by_dtype"))
+         (targets (jsown:val data "targets")))
+    (is (string= "ok" (jsown:val document "status")))
+    (is (= 42 (jsown:val documents "total")))
+    (is (= 10 (jsown:val by-dtype "person")))
+    (is (= 20 (jsown:val by-dtype "relation")))
+    (is (= 5 (jsown:val targets "total")))
+    (is (null (jsown:val-safe data "documents_raw")))
+    (is (null (search "_id" (jsown:to-json document))))))
 
 (test api-v1-capabilities-is-public-discovery
   (is (member "/api/v1/capabilities"

--- a/t/http-public-api-integration-test.lisp
+++ b/t/http-public-api-integration-test.lisp
@@ -2,6 +2,11 @@
 
 (in-suite http-api-tests)
 
+(defun report-public-api-response (case status body)
+  (format t "~&[public-api-integration] ~a status=~a body=~s~%"
+          case status body)
+  (finish-output))
+
 (test test-public-mode-defaults-enabled
   "Public-read mode is the default server posture unless init disables it."
   (is star::*public-mode*))
@@ -14,6 +19,7 @@
          (dex:get
           (make-test-url "/api/v1/stats")
           :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+    (report-public-api-response "public-stats" status body)
     (is (= 200 status))
     (let* ((document (jsown:parse body))
            (data (jsown:val document "data"))
@@ -42,7 +48,7 @@ server-owned authorization scope before the backend query executes."
          (dex:get
           (make-test-url "/api/v1/search?q=public-search-needle&limit=5")
           :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
-    (declare (ignore body))
+    (report-public-api-response "public-search" status body)
     (is (= 200 status))))
 
 (test test-private-mode-requires-authentication-for-v1-search
@@ -51,12 +57,13 @@ server-owned authorization scope before the backend query executes."
     (unwind-protect
          (progn
            (setf star::*public-mode* nil)
-           (multiple-value-bind (status)
+           (multiple-value-bind (status body)
                (perform-request
                 (lambda ()
                   (dex:get
                    (make-test-url "/api/v1/search?q=test")
                    :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+             (report-public-api-response "private-mode-search" status body)
              (is (= 401 status))))
       (setf star::*public-mode* original))))
 
@@ -66,12 +73,13 @@ server-owned authorization scope before the backend query executes."
     (unwind-protect
          (progn
            (setf star::*public-mode* nil)
-           (multiple-value-bind (status)
+           (multiple-value-bind (status body)
                (perform-request
                 (lambda ()
                   (dex:get
                    (make-test-url "/api/v1/stats")
                    :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+             (report-public-api-response "private-mode-stats" status body)
              (is (= 401 status))))
       (setf star::*public-mode* original))))
 
@@ -85,12 +93,15 @@ server-owned authorization scope before the backend query executes."
            (dex:get
             (make-test-url (format nil "/api/v1/search?~a" query))
             :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+      (report-public-api-response
+       (format nil "scope-override ~a" query)
+       status body)
       (is (= 400 status))
       (is (search "public_scope_is_server_owned" body)))))
 
 (test test-public-api-does-not-open-document-ingest
   "Making the read plane public must not make document ingestion anonymous."
-  (multiple-value-bind (status)
+  (multiple-value-bind (status body)
       (perform-request
        (lambda ()
          (dex:post
@@ -98,11 +109,12 @@ server-owned authorization scope before the backend query executes."
           :content "{}"
           :headers '(("Content-Type" . "application/json")
                      ("X-Test-Auth-Mode" . "unauthenticated")))))
+    (report-public-api-response "anonymous-document-ingest" status body)
     (is (= 401 status))))
 
 (test test-public-api-does-not-open-target-dispatch
   "Target dispatch remains authenticated even when public search is enabled."
-  (multiple-value-bind (status)
+  (multiple-value-bind (status body)
       (perform-request
        (lambda ()
          (dex:post
@@ -110,4 +122,5 @@ server-owned authorization scope before the backend query executes."
           :content "{}"
           :headers '(("Content-Type" . "application/json")
                      ("X-Test-Auth-Mode" . "unauthenticated")))))
+    (report-public-api-response "anonymous-target-dispatch" status body)
     (is (= 401 status))))

--- a/t/http-public-api-integration-test.lisp
+++ b/t/http-public-api-integration-test.lisp
@@ -2,8 +2,12 @@
 
 (in-suite http-api-tests)
 
+(test test-public-mode-defaults-enabled
+  "Public-read mode is the default server posture unless init disables it."
+  (is star:*public-mode*))
+
 (test test-public-stats-does-not-require-authentication
-  "The watch-safe aggregate stats endpoint is intentionally public."
+  "The watch-safe aggregate stats endpoint is intentionally public by default."
   (multiple-value-bind (status body)
       (perform-request
        (lambda ()
@@ -40,6 +44,36 @@ server-owned authorization scope before the backend query executes."
           :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
     (declare (ignore body))
     (is (= 200 status))))
+
+(test test-private-mode-requires-authentication-for-v1-search
+  "Init can disable public reads without removing the versioned search route."
+  (let ((original star:*public-mode*))
+    (unwind-protect
+         (progn
+           (setf star:*public-mode* nil)
+           (multiple-value-bind (status)
+               (perform-request
+                (lambda ()
+                  (dex:get
+                   (make-test-url "/api/v1/search?q=test")
+                   :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+             (is (= 401 status))))
+      (setf star:*public-mode* original))))
+
+(test test-private-mode-requires-authentication-for-v1-stats
+  "Init can disable anonymous aggregate stats for private deployments."
+  (let ((original star:*public-mode*))
+    (unwind-protect
+         (progn
+           (setf star:*public-mode* nil)
+           (multiple-value-bind (status)
+               (perform-request
+                (lambda ()
+                  (dex:get
+                   (make-test-url "/api/v1/stats")
+                   :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+             (is (= 401 status))))
+      (setf star:*public-mode* original))))
 
 (test test-public-search-rejects-caller-scope-overrides
   "Anonymous callers cannot supply tenant or dataset scope to widen search."

--- a/t/http-public-api-integration-test.lisp
+++ b/t/http-public-api-integration-test.lisp
@@ -1,0 +1,79 @@
+(in-package :star-server-tests)
+
+(in-suite http-api-tests)
+
+(test test-public-stats-does-not-require-authentication
+  "The watch-safe aggregate stats endpoint is intentionally public."
+  (multiple-value-bind (status body)
+      (perform-request
+       (lambda ()
+         (dex:get
+          (make-test-url "/api/v1/stats")
+          :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+    (is (= 200 status))
+    (let* ((document (jsown:parse body))
+           (data (jsown:val document "data"))
+           (documents (jsown:val data "documents"))
+           (targets (jsown:val data "targets")))
+      (is (string= "ok" (jsown:val document "status")))
+      (is (integerp (jsown:val data "generated_at")))
+      (is (integerp (jsown:val documents "total")))
+      (is (not (null (jsown:val documents "by_dtype"))))
+      (is (integerp (jsown:val targets "total")))
+      (is (null (search "password" body :test #'char-equal)))
+      (is (null (search "credential" body :test #'char-equal))))))
+
+(test test-public-search-does-not-require-authentication
+  "Public v1 search bypasses credential authentication but still uses the
+server-owned authorization scope before the backend query executes."
+  (insert-test-document
+   (make-test-user
+    :id "public-search-test-user"
+    :name "public-search-needle"
+    :platform "github"))
+  (sleep 2)
+  (multiple-value-bind (status body)
+      (perform-request
+       (lambda ()
+         (dex:get
+          (make-test-url "/api/v1/search?q=public-search-needle&limit=5")
+          :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+    (declare (ignore body))
+    (is (= 200 status))))
+
+(test test-public-search-rejects-caller-scope-overrides
+  "Anonymous callers cannot supply tenant or dataset scope to widen search."
+  (dolist (query '("q=test&dataset=private"
+                   "q=test&tenant=other"))
+    (multiple-value-bind (status body)
+        (perform-request
+         (lambda ()
+           (dex:get
+            (make-test-url (format nil "/api/v1/search?~a" query))
+            :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
+      (is (= 400 status))
+      (is (search "public_scope_is_server_owned" body)))))
+
+(test test-public-api-does-not-open-document-ingest
+  "Making the read plane public must not make document ingestion anonymous."
+  (multiple-value-bind (status)
+      (perform-request
+       (lambda ()
+         (dex:post
+          (make-test-url "/new/document/host")
+          :content "{}"
+          :headers '(("Content-Type" . "application/json")
+                     ("X-Test-Auth-Mode" . "unauthenticated")))))
+    (is (= 401 status))))
+
+(test test-public-api-does-not-open-target-dispatch
+  "Target dispatch remains authenticated even when public search is enabled."
+  (multiple-value-bind (status)
+      (perform-request
+       (lambda ()
+         (dex:post
+          (make-test-url "/new/target/nmap")
+          :content "{}"
+          :headers '(("Content-Type" . "application/json")
+                     ("X-Test-Auth-Mode" . "unauthenticated")))))
+    (is (= 401 status))))

--- a/t/http-public-api-integration-test.lisp
+++ b/t/http-public-api-integration-test.lisp
@@ -9,7 +9,7 @@
 
 (test test-public-mode-defaults-enabled
   "Public-read mode is the default server posture unless init disables it."
-  (is star::*public-mode*))
+  (is (not (null star::*public-mode*))))
 
 (test test-public-stats-does-not-require-authentication
   "The watch-safe aggregate stats endpoint is intentionally public by default."

--- a/t/http-public-api-integration-test.lisp
+++ b/t/http-public-api-integration-test.lisp
@@ -4,7 +4,7 @@
 
 (test test-public-mode-defaults-enabled
   "Public-read mode is the default server posture unless init disables it."
-  (is star:*public-mode*))
+  (is star::*public-mode*))
 
 (test test-public-stats-does-not-require-authentication
   "The watch-safe aggregate stats endpoint is intentionally public by default."
@@ -47,10 +47,10 @@ server-owned authorization scope before the backend query executes."
 
 (test test-private-mode-requires-authentication-for-v1-search
   "Init can disable public reads without removing the versioned search route."
-  (let ((original star:*public-mode*))
+  (let ((original star::*public-mode*))
     (unwind-protect
          (progn
-           (setf star:*public-mode* nil)
+           (setf star::*public-mode* nil)
            (multiple-value-bind (status)
                (perform-request
                 (lambda ()
@@ -58,14 +58,14 @@ server-owned authorization scope before the backend query executes."
                    (make-test-url "/api/v1/search?q=test")
                    :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
              (is (= 401 status))))
-      (setf star:*public-mode* original))))
+      (setf star::*public-mode* original))))
 
 (test test-private-mode-requires-authentication-for-v1-stats
   "Init can disable anonymous aggregate stats for private deployments."
-  (let ((original star:*public-mode*))
+  (let ((original star::*public-mode*))
     (unwind-protect
          (progn
-           (setf star:*public-mode* nil)
+           (setf star::*public-mode* nil)
            (multiple-value-bind (status)
                (perform-request
                 (lambda ()
@@ -73,7 +73,7 @@ server-owned authorization scope before the backend query executes."
                    (make-test-url "/api/v1/stats")
                    :headers '(("X-Test-Auth-Mode" . "unauthenticated")))))
              (is (= 401 status))))
-      (setf star:*public-mode* original))))
+      (setf star::*public-mode* original))))
 
 (test test-public-search-rejects-caller-scope-overrides
   "Anonymous callers cannot supply tenant or dataset scope to widen search."


### PR DESCRIPTION
Closes #109

## RAGE slice

Implements the public/private authority split requested for the API overhaul while preserving the existing authenticated legacy/control plane.

### Deployment mode
- `*public-mode*` is an init-file setting and defaults to `T`
- `STAR_PUBLIC_MODE=false` can also provide the pre-init default
- `example_configs/init.lisp` sets `*public-mode* t` explicitly
- when public mode is `T`, `/api/v1/search` and `/api/v1/stats` are anonymous read endpoints
- when public mode is `NIL`, those same versioned routes remain mounted but require authentication
- capabilities report `public_mode` and the effective search/stats authority

### Public read plane
- `GET /api/v1/search`
  - no bearer credential required when public mode is enabled
  - executes through a server-owned synthetic `public_reader` authorization context
  - reuses `authorized-search-query` so configured dataset scope is applied before backend retrieval
  - `STAR_PUBLIC_SEARCH_DATASETS` controls server-owned visible datasets; defaults to `*` for the public-server deployment model
  - rejects caller `dataset` / `tenant` scope overrides
  - query length <= 512, result limit <= 50
- `GET /api/v1/stats`
  - no bearer credential required when public mode is enabled
  - compact aggregate-only response from fixed `data/total` + `data/count_by_dtype` views
  - document totals, dtype counts, target-like total, service/version/generated timestamp
  - 15s public cache policy

### Protected plane remains protected
No target, document-create, bulk-ingest, deletion, admin, credential, or lease path becomes anonymous. Existing route-level capability checks remain authoritative.

### Contract/discovery
- adds `public.search.get` and `stats.get` to the canonical HTTP contract/OpenAPI/client manifest
- capabilities expose endpoint authority/scopes plus the effective public-mode setting
- capabilities advertise stats and the existing OpenAPI surface

### TDD / review trail
- initial red contract/security tests first: `bdf763b`
- public-mode regression tests added before implementation changes
- implementation follows without weakening mutation/auth assertions
- service-backed integration coverage proves default anonymous stats/search, private-mode 401s, and 401 for anonymous ingest/target dispatch

Current exact head: `118fc8ce725d84e067d423384719920cda021740`

Do not merge unless exact-head unit/integration/contract/CI gates are green.