### PR TITLE
Fix admin CLI Compose secret-file resolution

### DIFF
--- a/docker/star-server-init.lisp
+++ b/docker/star-server-init.lisp
@@ -9,13 +9,15 @@
       *couchdb-user*
       (or (uiop:getenv "COUCHDB_USER") *couchdb-user*)
       *couchdb-password*
-      (or (uiop:getenv "COUCHDB_PASSWORD") *couchdb-password*)
+      (or (environment-secret "COUCHDB_PASSWORD" "COUCHDB_PASSWORD_FILE")
+          *couchdb-password*)
       *rabbit-address*
       (or (uiop:getenv "RABBITMQ_ADDRESS") *rabbit-address*)
       *rabbit-user*
       (or (uiop:getenv "RABBITMQ_USER") *rabbit-user*)
       *rabbit-password*
-      (or (uiop:getenv "RABBITMQ_PASSWORD") *rabbit-password*)
+      (or (environment-secret "RABBITMQ_PASSWORD" "RABBITMQ_PASSWORD_FILE")
+          *rabbit-password*)
       *http-api-address*
       (or (uiop:getenv "HTTP_API_LISTEN_ADDRESS") *http-api-address*)
       *http-cors-allowed-origins*
@@ -24,9 +26,12 @@
       *auth-mode*
       (or (uiop:getenv "STAR_AUTH_MODE") *auth-mode*)
       *auth-pepper*
-      (or (uiop:getenv "STAR_AUTH_PEPPER") *auth-pepper*)
+      (or (environment-secret "STAR_AUTH_PEPPER" "STAR_AUTH_PEPPER_FILE")
+          *auth-pepper*)
       *auth-bootstrap-secret*
-      (or (uiop:getenv "STAR_AUTH_BOOTSTRAP_SECRET")
+      (or (environment-secret
+           "STAR_AUTH_BOOTSTRAP_SECRET"
+           "STAR_AUTH_BOOTSTRAP_SECRET_FILE")
           *auth-bootstrap-secret*)
       *auth-dev-bypass*
       (not (null

--- a/scripts/stack-test.sh
+++ b/scripts/stack-test.sh
@@ -137,6 +137,9 @@ api_key="$(jq --exit-status --raw-output '.api_key' <<<"$bootstrap_response")"
 [[ "$api_key" == star_sk_v1_* ]]
 auth_header="Authorization: Bearer ${api_key}"
 
+set_stage "verify-admin-cli-file-secrets"
+docker compose exec -T star-server /bin/star-server admin user list >/dev/null
+
 set_stage "verify-unauthenticated-denial"
 unauthenticated_status="$(
   http_status \

--- a/t/init-loader-test.lisp
+++ b/t/init-loader-test.lisp
@@ -53,7 +53,7 @@
 
 (test ensure-init-file-exists-creates-minimal-if-no-example
       "Test that ensure-init-file-exists creates minimal config if example missing"
-      (let ((temp-file (pathname (format nil "/tmp/test-init-~A.lisp" (get-universal-time)))))
+      (let ((temp-file (pathname (format nil "/tmp/test-init-~A.lisp" (get-universal-time))))
             ;; Temporarily shadow the system source directory to simulate missing example
             (original-dir (asdf:system-source-directory :starintel-gserver)))
         (unwind-protect

--- a/t/init-loader-test.lisp
+++ b/t/init-loader-test.lisp
@@ -53,10 +53,9 @@
 
 (test ensure-init-file-exists-creates-minimal-if-no-example
       "Test that ensure-init-file-exists creates minimal config if example missing"
-      (let ((temp-file (pathname (format nil "/tmp/test-init-~A.lisp" (get-universal-time))))
+      (let ((temp-file (pathname (format nil "/tmp/test-init-~A.lisp" (get-universal-time)))))
             ;; Temporarily shadow the system source directory to simulate missing example
             (original-dir (asdf:system-source-directory :starintel-gserver)))
-        (declare (ignore original-dir))
         (unwind-protect
              (progn
                ;; This will fail to find example_configs and create minimal file
@@ -91,6 +90,12 @@
                       (star:load-init-file temp-file))
           (cleanup-temp-path temp-file))))
 
+
+
+
+
+
+
 ;;; Tests for safe-load-init
 
 (test safe-load-init-loads-file
@@ -102,6 +107,8 @@
                (is-true (star:safe-load-init temp-file))
                (is (= 100 (symbol-value (find-symbol "*TEST-SAFE-LOAD*" :star)))))
           (cleanup-temp-path temp-file))))
+
+
 
 (test safe-load-init-creates-missing-file
       "Test that safe-load-init creates file if it doesn't exist"
@@ -135,8 +142,27 @@
                                 file-variable)
                         source))))))
 
+
+
+;;; Tests for load-modular-init
+
+
+
+
 ;;; Run all init-loader tests
 
 (defun run-init-loader-tests ()
   "Run all init loader tests"
   (run! 'init-loader-tests))
+
+
+
+
+
+
+
+
+
+
+
+

--- a/t/init-loader-test.lisp
+++ b/t/init-loader-test.lisp
@@ -31,6 +31,13 @@
         (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)
         (delete-file path))))
 
+(defun without-layout-whitespace (value)
+  (remove-if (lambda (character)
+               (member character
+                       '(#\Space #\Tab #\Newline #\Return)
+                       :test #'char=))
+             value))
+
 ;;; Tests for ensure-init-file-exists
 
 (test ensure-init-file-exists-creates-from-example
@@ -49,6 +56,7 @@
       (let ((temp-file (pathname (format nil "/tmp/test-init-~A.lisp" (get-universal-time))))
             ;; Temporarily shadow the system source directory to simulate missing example
             (original-dir (asdf:system-source-directory :starintel-gserver)))
+        (declare (ignore original-dir))
         (unwind-protect
              (progn
                ;; This will fail to find example_configs and create minimal file
@@ -83,12 +91,6 @@
                       (star:load-init-file temp-file))
           (cleanup-temp-path temp-file))))
 
-
-
-
-
-
-
 ;;; Tests for safe-load-init
 
 (test safe-load-init-loads-file
@@ -101,8 +103,6 @@
                (is (= 100 (symbol-value (find-symbol "*TEST-SAFE-LOAD*" :star)))))
           (cleanup-temp-path temp-file))))
 
-
-
 (test safe-load-init-creates-missing-file
       "Test that safe-load-init creates file if it doesn't exist"
       (let ((temp-file (pathname (format nil "/tmp/test-missing-~A.lisp" (get-universal-time)))))
@@ -113,27 +113,30 @@
                (is-true (probe-file temp-file)))
           (cleanup-temp-path temp-file))))
 
-
-
-;;; Tests for load-modular-init
-
-
-
+(test container-init-resolves-compose-secret-files
+      "The container init must refresh every Compose *_FILE secret at command runtime"
+      (let* ((source-path
+               (uiop:merge-pathnames*
+                "docker/star-server-init.lisp"
+                (asdf:system-source-directory :starintel-gserver)))
+             (source
+               (without-layout-whitespace
+                (alexandria:read-file-into-string source-path))))
+        (dolist (variables
+                 '(("COUCHDB_PASSWORD" "COUCHDB_PASSWORD_FILE")
+                   ("RABBITMQ_PASSWORD" "RABBITMQ_PASSWORD_FILE")
+                   ("STAR_AUTH_PEPPER" "STAR_AUTH_PEPPER_FILE")
+                   ("STAR_AUTH_BOOTSTRAP_SECRET"
+                    "STAR_AUTH_BOOTSTRAP_SECRET_FILE")))
+          (destructuring-bind (value-variable file-variable) variables
+            (is (search (format nil
+                                "(environment-secret~s~s)"
+                                value-variable
+                                file-variable)
+                        source))))))
 
 ;;; Run all init-loader tests
 
 (defun run-init-loader-tests ()
   "Run all init loader tests"
   (run! 'init-loader-tests))
-
-
-
-
-
-
-
-
-
-
-
-

--- a/t/init-loader-test.lisp
+++ b/t/init-loader-test.lisp
@@ -31,13 +31,6 @@
         (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)
         (delete-file path))))
 
-(defun without-layout-whitespace (value)
-  (remove-if (lambda (character)
-               (member character
-                       '(#\Space #\Tab #\Newline #\Return)
-                       :test #'char=))
-             value))
-
 ;;; Tests for ensure-init-file-exists
 
 (test ensure-init-file-exists-creates-from-example
@@ -119,28 +112,6 @@
                (is-true (star:safe-load-init temp-file))
                (is-true (probe-file temp-file)))
           (cleanup-temp-path temp-file))))
-
-(test container-init-resolves-compose-secret-files
-      "The container init must refresh every Compose *_FILE secret at command runtime"
-      (let* ((source-path
-               (uiop:merge-pathnames*
-                "docker/star-server-init.lisp"
-                (asdf:system-source-directory :starintel-gserver)))
-             (source
-               (without-layout-whitespace
-                (alexandria:read-file-into-string source-path))))
-        (dolist (variables
-                 '(("COUCHDB_PASSWORD" "COUCHDB_PASSWORD_FILE")
-                   ("RABBITMQ_PASSWORD" "RABBITMQ_PASSWORD_FILE")
-                   ("STAR_AUTH_PEPPER" "STAR_AUTH_PEPPER_FILE")
-                   ("STAR_AUTH_BOOTSTRAP_SECRET"
-                    "STAR_AUTH_BOOTSTRAP_SECRET_FILE")))
-          (destructuring-bind (value-variable file-variable) variables
-            (is (search (format nil
-                                "(environment-secret~s~s)"
-                                value-variable
-                                file-variable)
-                        source))))))
 
 
 


### PR DESCRIPTION
Closes #112

## Problem

`docker exec <star-server> /bin/star-server admin ...` bypasses `docker/star-server-entrypoint.sh`. Compose supplies server credentials through `*_FILE` variables, but `docker/star-server-init.lisp` refreshed the dumped runtime settings only from the corresponding plaintext environment variables. Normal `start` appeared correct only because the container entrypoint first copied secret-file contents into plaintext variables.

## Fix

- make the container runtime init use the existing `environment-secret` resolver for CouchDB, RabbitMQ, auth pepper, and auth bootstrap secrets;
- preserve direct-value precedence and the current runtime-value fallback;
- cover the real failure path in the repository stack test by running `docker compose exec -T star-server /bin/star-server admin user list` after bootstrap while Compose provides the credentials through mounted `*_FILE` secrets.

## TDD / verification trail

- The first unit-level regression guard exposed that source inspection was the wrong boundary and was removed rather than kept as a brittle test.
- The final regression is end-to-end at the Compose/admin boundary from #112.
- Do not merge unless the exact PR head passes the repository-native CI/test gates.