### PR TITLE
Enforce StarIntel v0.9 documents at ingest

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -114,4 +114,20 @@ jobs:
           COUCHDB_PASSWORD: password
           RABBITMQ_USER: guest
           RABBITMQ_PASSWORD: guest
-        run: nix run .#star-integration-tests
+        shell: bash
+        run: |
+          set +e
+          log_file="$RUNNER_TEMP/service-backed-integration-tests.log"
+          nix run .#star-integration-tests >"$log_file" 2>&1
+          status=$?
+          tail -n 400 "$log_file"
+          exit "$status"
+
+      - name: Upload service-backed integration-test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-backed-integration-tests-${{ github.sha }}
+          path: ${{ runner.temp }}/service-backed-integration-tests.log
+          if-no-files-found: warn
+          retention-days: 1

--- a/docs/document-spec.org
+++ b/docs/document-spec.org
@@ -1,73 +1,93 @@
 #+title: StarIntel document specification in star-server
 #+options: toc:3
 
-* Document specification
+* Active document specification
 
-StarIntel Server currently sits between two document generations:
+StarIntel Server's canonical document format is *StarIntel 0.9.0*.
 
-1. *StarIntel 0.9.0*: the strict, schema-driven format implemented by the
-   validators in =lost-rob0t/star-cl= and =lost-rob0t/starintel-doc=.
-2. *Legacy flat 0.8.0*: Common Lisp classes and constructors still used by parts
-   of this server and its actor examples.
+The Common Lisp document model and strict validator are supplied by
+=lost-rob0t/star-cl=. This repository pins that runtime through both Nix and
+QLot and keeps a separate schema lock in =schema/starintel-schema.lock.json=.
+Those build paths must agree on the same v0.9-capable runtime.
 
-The server reports the =star-cl= document version from =GET /=, but the HTTP and
-RabbitMQ ingest handlers do not currently call the strict 0.9 validator. A
-=document= with a non-empty =dtype= can reach CouchDB even when it does not
-conform to 0.9.
+Canonical document ingest does not accept the older flat 0.7/0.8 envelope.
+Legacy target routing remains a narrow compatibility path and is documented
+separately below.
 
 ** StarIntel 0.9 envelope
 
-The 0.9 adapters require:
+The v0.9 schema distinguishes the specification revision from the document's own
+revision counter:
 
-- a JSON object;
-- =schema_version= exactly ="0.9.0"=;
-- a canonical =dtype= from the schema;
-- fields and data types defined by the schema;
-- RFC 3339 date-time strings where the schema requires =date-time=;
-- no undeclared fields in closed schema sections.
+- =schema_version= is a string and must be exactly ="0.9.0"=;
+- =version= is an integer document revision counter.
 
-The adapters preserve unknown extension data and missing optional fields when
-the schema permits them.
-
-Conceptual envelope:
+A representative envelope is:
 
 #+begin_src json
 {
-  "schema_version": "0.9.0",
-  "dtype": "person",
   "_id": "01J...",
   "dataset": "investigation-a",
-  "sources": ["manual"],
+  "dtype": "person",
+  "schema_version": "0.9.0",
+  "version": 1,
+  "date_added": "2026-08-24T09:00:00Z",
+  "date_updated": "2026-08-24T09:00:00Z",
+  "title": "Ada Lovelace",
+  "sources": [],
+  "evidence": [],
   "data": {
     "fname": "Ada",
     "lname": "Lovelace"
   },
-  "extensions": {
-    "star_server": {
-      "trace_id": "01J...",
-      "root_id": "01J...",
-      "parent_id": null,
-      "actor_path": []
-    }
-  }
+  "extensions": {}
 }
 #+end_src
 
-Use the canonical schema distributed by the StarIntel conformance/spec
-repository. The adapters locate it through:
+The exact required fields and per-dtype =data= contract come from the canonical
+JSON schema rather than this example.
 
-| Variable | Meaning |
-|----------+---------|
-| =STARINTEL_SCHEMA= | Explicit path to =starintel-doc-v0.9.0.schema.json= |
-| =STARINTEL_CONFORMANCE_ROOT= | Root containing =schemas/starintel-doc-v0.9.0.schema.json= |
+** Strict validation
 
-The current server does not consume either variable directly; =star-cl='s
-validator does.
+Canonical validation requires:
 
-** Rejected 0.9 aliases
+- a JSON object;
+- =schema_version= exactly ="0.9.0"=;
+- a canonical =dtype= from the schema;
+- required envelope and dtype-specific fields;
+- field types defined by the schema;
+- RFC 3339 date-time strings where =date-time= is required;
+- no undeclared fields in closed schema sections.
 
-The 0.9 adapters explicitly reject these dtype aliases rather than silently
-normalizing them:
+The validator preserves extension data where the schema permits it. It does not
+silently reinterpret a legacy flat document as v0.9.
+
+The server adapter is =star.documents:validate-v09-document=. It reuses the
+validator implemented in =star-cl= and locates the schema distributed with the
+loaded =starintel= ASDF system. The server intentionally does not maintain a
+second schema implementation.
+
+** Canonical ingest boundaries
+
+Strict v0.9 validation runs before publish or persistence on:
+
+- =POST /new/document/:dtype=;
+- =POST /documents/bulk=;
+- RabbitMQ =documents.ingest.#=;
+- RabbitMQ =documents.update.#=.
+
+HTTP validation failures are =422= responses. A missing =schema_version= uses
+=schema_version_required=, an unsupported revision uses
+=unsupported_schema_version=, and a full-schema violation uses
+=invalid_document_schema=.
+
+RabbitMQ schema-invalid deliveries are permanent processing failures and enter
+the existing settlement/quarantine policy instead of reaching CouchDB.
+
+** Canonical dtype spelling
+
+The strict v0.9 validator rejects non-canonical aliases. In particular, callers
+must not depend on transport normalization of aliases such as:
 
 #+begin_example
 organization
@@ -84,271 +104,52 @@ lobbying_filing
 campaign_finance
 #+end_example
 
-Use the canonical dtype from the schema inventory.
+Use the canonical dtype emitted by the schema inventory.
 
-** Legacy flat 0.8 common fields
+** Data placement
 
-The legacy Common Lisp =document= class serializes Lisp slot names to camelCase,
-while preserving leading underscore keys.
+v0.9 separates common envelope metadata from dtype-specific data.
 
-| JSON field | Type | Meaning |
-|------------+------+---------|
-| =_id= | string | Document identity; ULID or deterministic hash |
-| =_rev= | string, optional | CouchDB revision; emitted only when syntactically valid |
-| =dataset= | string | Logical corpus/dataset |
-| =dtype= | string | Object type |
-| =sources= | array | Provenance labels/URIs/actor names |
-| =version= | string | Legacy document version, normally ="0.8.0"= |
-| =dateAdded= | integer | Unix timestamp |
-| =dateUpdated= | integer | Unix timestamp |
+Common metadata belongs at the top level. Dtype-specific properties belong under
+=data=. Runtime- or actor-specific metadata belongs under a schema-permitted
+=extensions= namespace instead of adding arbitrary top-level keys.
 
-When encoding legacy classes, missing strings become =""=, integers become =0=,
-lists become =[]=, booleans become =false=, and unknown values may become JSON
-=null=.
+Relations use the canonical v0.9 relation representation under =data=, including
+=subject=, =predicate=, and =object=. Compatibility aliases in the Common Lisp
+object model do not change the wire contract.
 
-** Legacy object types
+** Identity and timestamps
 
-These are the concrete classes currently exported by =star-cl=. They are not a
-substitute for the canonical 0.9 schema.
+The current v0.9 =star-cl= runtime uses SHA-256 for deterministic document IDs
+where a document class has deterministic identity semantics. Other document
+classes can use ULIDs.
 
-*** person
+Canonical =date_added= and =date_updated= values are ISO/RFC 3339 strings, not
+the integer Unix timestamps used by the older flat envelope.
 
-| Field | Type |
-|-------+------|
-| =fname= | string |
-| =mname= | string |
-| =lname= | string |
-| =bio= | string |
-| =dob= | string |
-| =region= | string |
-| =misc= | array |
-| =etype= | string, default =person= |
-| =eid= | string |
+CouchDB remains responsible for =_rev=. Application-level =version= is separate
+from both CouchDB =_rev= and schema =schema_version=.
 
-ID strategy: ULID.
+** Legacy target compatibility
 
-*** org
+The historical target interface is not a general document-ingest escape hatch.
+The following paths remain explicitly legacy while the versioned target
+lifecycle API is completed:
 
-| Field | Type |
-|-------+------|
-| =reg= | string |
-| =name= | string |
-| =bio= | string |
-| =country= | string |
-| =website= | string |
-| =etype= | string, default =org= |
-| =eid= | string |
+- =POST /new/target/:actor=;
+- the target-dispatch Rabbit compatibility route.
 
-ID strategy: hash of name, registration, and country.
+They use the historical flat target shape and opt out of strict v0.9 document
+validation at that boundary only. Canonical document and bulk ingest remain
+strict.
 
-*** relation
+New producers should not model new document types after this compatibility
+shape.
 
-| Field | Type | Meaning |
-|-------+------+---------|
-| =source= | string | Source document ID |
-| =target= | string | Target document ID |
-| =predicate= | string | Directed edge label |
-| =note= | string | Human/actor note |
+** Recursive provenance
 
-ID strategy: ULID. Relations are directed.
-
-*** target
-
-| Field | Type |
-|-------+------|
-| =actor= | string | Local registered actor or external actor name |
-| =target= | string | Target value/document ID |
-| =delay= | integer | Recurrence interval in seconds |
-| =recurring= | boolean | Re-deliver on timer |
-| =options= | array | Actor-defined values |
-
-ID strategy: hash of dataset, target, and actor.
-
-*** domain
-
-| Field | Type |
-|-------+------|
-| =recordType= | string |
-| =record= | string |
-| =resolvedAddresses= | array |
-
-ID strategy: hash of record and record type.
-
-*** host
-
-| Field | Type |
-|-------+------|
-| =hostname= | string |
-| =ip= | string |
-| =os= | string |
-| =ports= | array of service-like values |
-
-ID strategy: hash of IP.
-
-*** service
-
-Embedded object fields: =port= integer, =name= string, =ver= string.
-
-*** network
-
-Fields: =org= string, =subnet= string, =asn= integer. ID is derived from ASN and
-organization.
-
-*** url
-
-Fields: =url= string, =path= string, =query= string, =content= string. ID is
-derived from URL and content.
-
-*** email
-
-Fields: =user= string, =domain= string, =password= string. ID includes password
-only when non-empty.
-
-#+begin_quote
-Do not store credential material unless the collection and storage are lawful,
-authorized, necessary, and access-controlled. The current server has no
-field-level encryption or authorization.
-#+end_quote
-
-*** emailmessage
-
-Fields: =body=, =subject=, =to=, =from=, =headers= strings; =cc= and =bcc=
-arrays.
-
-*** user
-
-Fields: =url=, =name=, =platform=, =bio= strings and =misc= array.
-
-*** breach
-
-Fields: =total= integer, =description= string, =url= string.
-
-*** message
-
-Fields:
-
-- =content= string
-- =platform= string
-- =user= string
-- =isReply= boolean
-- =media= array
-- =messageId= string
-- =replyTo= string
-- =group= string
-- =channel= string
-- =mentions= array
-
-*** socialmpost
-
-Fields:
-
-- =content=, =user=, =url=, =title=, =group=, =replyTo= strings
-- =replies=, =media=, =links=, =tags= arrays
-- =replyCount=, =repostCount= integers
-
-*** phone
-
-Fields: =number=, =carrier=, =status=, =phoneType= strings.
-
-*** geo and address
-
-=geo=: =lat=, =long=, =alt= numbers.
-
-=address= extends geo with =city=, =state=, =postal=, =country=, =street=, and
-=street2=.
-
-** Relation predicates
-
-The current =star-cl= relation constructor validates predicates against an
-allowlist. Groups include:
-
-- identity: =same-as=, =duplicate-of=, =aka=, =alias-of=, =username-of=,
-  =email-of=, =phone-of=, =account-of=;
-- people/org: =member-of=, =employed-by=, =contractor-for=, =works-with=,
-  =manages=, =reports-to=;
-- ownership/control: =owns=, =owned-by=, =controls=, =controlled-by=,
-  =operates=, =operated-by=, =administers=, =administered-by=;
-- registration: =registered-to=, =registrant-of=, =whois-registrant-of=,
-  =whois-admin-of=, =whois-tech-of=;
-- location: =located-at=, =geolocated-at=, =seen-at=;
-- communication: =communicates-with=, =contacted=, =contacted-by=, =mentions=,
-  =replies-to=, =follows=;
-- web: =links-to=, =redirects-to=, =canonical-url-of=, =hosts=, =hosted-by=,
-  =served-by=;
-- DNS/network: =resolves-to=, =ptr-to=, =has-a=, =has-aaaa=, =has-cname=,
-  =has-ns=, =has-mx=, =has-txt=, =has-spf=, =has-dkim=, =has-dmarc=,
-  =has-soa=, =behind-cdn=, =belongs-to-asn=, =served-from=,
-  =shares-ip-with=, =shares-asn-with=;
-- services: =hosts-service=, =listens-on=, =exposes-port=, =runs=, =runs-on=;
-- credential/breach: =leaked-in=, =credential-for=, =compromised-by=;
-- provenance/evidence: =observed-on=, =observed-by=, =collected-from=,
-  =extracted-from=, =derived-from=, =downloaded-from=, =uploaded-to=,
-  =created-by=, =modified-by=, =hashes-to=, =matches-hash=, =evidence-of=,
-  =indicates=;
-- security/research: =attributed-to=, =uses=, =targets=, =exploits=,
-  =mitigates=, =c2-for=, =in-scope-of=, =out-of-scope-of=,
-  =discovered-by=, =scanned-by=, =has-finding=, =vulnerable-to=;
-- generic: =related-to=.
-
-Constructor:
-
-#+begin_src lisp
-(spec:new-relation
- "dataset"
- "source-id"
- "target-id"
- :predicate "derived-from"
- :note "Generated by actor")
-#+end_src
-
-** ID strategies
-
-The legacy constructors mix two identity models:
-
-- *ULID*: person, relation, default document when the server normalizes a
-  missing ID.
-- *Deterministic hash*: org, domain, network, host, URL, email, user, message,
-  social post, phone, target, geo/address.
-
-Deterministic IDs support idempotent recursive actors, but the current default
-hash algorithm in =star-cl= is MD5. Treat it as a deduplication key, not a
-cryptographic integrity proof. Use SHA-256 in provenance extensions when
-integrity matters.
-
-** CouchDB fields
-
-The ingest handler:
-
-1. generates a ULID when =_id= is missing or empty;
-2. writes the JSON document;
-3. replaces/sets =_id= from CouchDB's response;
-4. adds =_rev=;
-5. republishes the enriched document as =documents.new.<dtype>=.
-
-The update handler requires =_id= and =dtype=. It fetches the current document,
-deep-merges the patch, applies the latest =_rev=, retries conflicts, and emits
-the new revision.
-
-** Actor event document
-
-Current actor-event fields:
-
-| Field | Type |
-|-------+------|
-| =_id= | ULID string |
-| =timestamp= | Unix integer |
-| =dtype= | intended =actorevent= |
-| =actorName= | string |
-| =eventType= | string |
-| =details= | string |
-| =sourceId= | string |
-
-Actor events are stored in the separate event database.
-
-** Recursive provenance convention
-
-No server component automatically adds recursive provenance. Use a stable
-extension contract across actors:
+Actor/runtime provenance that is not part of the canonical envelope should use
+a stable extension namespace, for example:
 
 #+begin_src json
 {
@@ -361,30 +162,28 @@ extension contract across actors:
       "actor_path": ["seed", "domain-enricher", "dns-resolver"],
       "depth": 2,
       "hop": 3,
-      "max_depth": 8,
-      "max_hops": 32,
       "derivation": "dns-resolution",
-      "input_hash": "sha256:...",
-      "output_hash": "sha256:...",
-      "emitted_at": "2026-07-26T20:00:00Z"
+      "emitted_at": "2026-08-24T09:00:00Z"
     }
   }
 }
 #+end_src
 
-Also emit a relation from source to derived output. Metadata alone does not
-replace graph edges.
+When provenance represents a graph relationship, also emit the canonical
+relation document. Extension metadata does not replace explicit graph edges.
 
-** Migration guidance
+** Producer guidance
 
 For new producers:
 
-1. emit strict 0.9 when the deployed server path validates it;
-2. keep one canonical dtype and field spelling;
-3. put actor/runtime-specific data under =extensions=;
-4. do not silently convert aliases;
-5. test round-trip preservation against every language adapter;
-6. document any legacy 0.8 bridge at the boundary.
+1. emit strict v0.9;
+2. send =schema_version: "0.9.0"= and keep =version= numeric;
+3. use one canonical dtype and field spelling;
+4. place dtype-specific data under =data=;
+5. put actor/runtime-specific data only under schema-permitted extensions;
+6. validate locally against the same canonical schema when practical;
+7. treat an HTTP =422= or Rabbit schema-invalid settlement as a producer bug,
+   not as a signal to downgrade to the old flat envelope.
 
-For the current server, verify downstream consumers before switching an active
-pipeline from flat 0.8 fields to nested 0.9 =data=.
+See [[file:v09-runtime.org][StarIntel v0.9 runtime]] for the server-side boundary and
+deployment consistency rules.

--- a/docs/index.org
+++ b/docs/index.org
@@ -15,18 +15,19 @@ the corresponding controls are implemented.
 1. [[file:../README.org][README]] — install, run, submit a document, and find the main entry points.
 2. [[file:architecture.org][Architecture]] — understand startup, components, concurrency, and the repository.
 3. [[file:document-spec.org][Document specification]] — understand the data that moves through the system.
-4. [[file:actors.org][Actors]] — build local actors and connect external actor services.
-5. [[file:messaging.org][Messaging]] — understand routing, delivery, recursion, and loop control.
-6. [[file:configuration.org][Configuration]] — configure local, container, remote, and tuned deployments.
-7. [[file:http-api-docs.org][HTTP API]] — call the service.
-8. [[file:http-authentication-runtime.org][HTTP authentication runtime]] — bootstrap, API-key lifecycle, CORS, request context, revocation behavior, and deployment.
-9. [[file:http-authorization-runtime.org][HTTP authorization runtime]] — capabilities, tenant/dataset/actor/target policy, route mapping, search isolation, Rabbit provenance, audit, and quotas.
-10. [[file:../DOCKER.md][Docker/Nix stack]] and [[file:testing.md][testing]] — operate and verify it.
-11. [[file:http-auth-threat-model.org][HTTP authentication threat model]] — protected assets, attackers, boundaries, controls, failures, and residual risks. Design contract.
-12. [[file:http-auth-kv-lease-boundary.org][KV lease authentication boundary]] — target-lease assets, atomic ownership, fencing, replay controls, and the KV trust boundary. Normative design contract.
-13. [[file:target-lease-semantics.org][Distributed target lease semantics]] — canonical lock identity, records, state transitions, operations, idempotency, deadlines, fencing enforcement, races, errors, audit, and recovery. Normative design contract.
-14. [[file:lease-store-usage.org][Lease-store protocol usage]] — Common Lisp examples for canonical identity, acquire, renew, inspect, list, release, serialization, typed outcomes, and owned shutdown.
-15. [[file:http-principal-capability-contract.org][HTTP principal and capability contract]] — principal classes, credentials, capabilities, scopes, decisions, and route mapping. Design contract.
+4. [[file:v09-runtime.org][StarIntel v0.9 runtime]] — canonical schema validation, version semantics, ingest boundaries, and the legacy target compatibility adapter.
+5. [[file:actors.org][Actors]] — build local actors and connect external actor services.
+6. [[file:messaging.org][Messaging]] — understand routing, delivery, recursion, and loop control.
+7. [[file:configuration.org][Configuration]] — configure local, container, remote, and tuned deployments.
+8. [[file:http-api-docs.org][HTTP API]] — call the service.
+9. [[file:http-authentication-runtime.org][HTTP authentication runtime]] — bootstrap, API-key lifecycle, CORS, request context, revocation behavior, and deployment.
+10. [[file:http-authorization-runtime.org][HTTP authorization runtime]] — capabilities, tenant/dataset/actor/target policy, route mapping, search isolation, Rabbit provenance, audit, and quotas.
+11. [[file:../DOCKER.md][Docker/Nix stack]] and [[file:testing.md][testing]] — operate and verify it.
+12. [[file:http-auth-threat-model.org][HTTP authentication threat model]] — protected assets, attackers, boundaries, controls, failures, and residual risks. Design contract.
+13. [[file:http-auth-kv-lease-boundary.org][KV lease authentication boundary]] — target-lease assets, atomic ownership, fencing, replay controls, and the KV trust boundary. Normative design contract.
+14. [[file:target-lease-semantics.org][Distributed target lease semantics]] — canonical lock identity, records, state transitions, operations, idempotency, deadlines, fencing enforcement, races, errors, audit, and recovery. Normative design contract.
+15. [[file:lease-store-usage.org][Lease-store protocol usage]] — Common Lisp examples for canonical identity, acquire, renew, inspect, list, release, serialization, typed outcomes, and owned shutdown.
+16. [[file:http-principal-capability-contract.org][HTTP principal and capability contract]] — principal classes, credentials, capabilities, scopes, decisions, and route mapping. Design contract.
 
 ** Development workflow
 
@@ -37,9 +38,9 @@ the corresponding controls are implemented.
 | Area | Status | Notes |
 |------+--------+-------|
 | CouchDB database initialization | Active | Creates main, actor-event, and separate authentication databases; upserts required design documents |
-| RabbitMQ document ingest | Active | =documents.ingest.#= |
-| RabbitMQ update ingest | Active | =documents.updated.#=; partial deep merge and conflict retry |
-| Target routing | Active | Local Sento actor or =actors.<name>.new.target= |
+| RabbitMQ document ingest | Active | =documents.ingest.#=; canonical mutations are strict v0.9 before persistence |
+| RabbitMQ update ingest | Active | =documents.update.#=; canonical mutations are strict v0.9 before persistence |
+| Target routing | Active | Local Sento actor or =actors.<name>.new.target=; legacy target envelope remains an explicit compatibility adapter |
 | Actor event storage | Active | Local receiver and separate =events= exchange consumer |
 | HTTP API-key authentication | Active | Default-deny bearer authentication, immutable request context, lifecycle routes, exact-origin CORS, and separate credential storage |
 | Fine-grained route authorization | Active | Closed capabilities and tenant/dataset/actor/target scopes enforced at HTTP and embedded service boundaries; unmapped routes deny |
@@ -49,13 +50,12 @@ the corresponding controls are implemented.
 | URL extractor pattern | Experimental | Actor starts; complete global pattern dispatcher is not evident |
 | User-finder/user-hunt actors | Present, inactive | Files are not in the ASDF component list |
 | HTTP event endpoint | Stub | =/new/event/:id= has no implementation; replay authorization is active but backend returns =501= |
-| Strict StarIntel 0.9 ingest validation | Partially wired | HTTP boundary validates required envelope fields and schema version; Rabbit ingest remains a separate boundary |
+| Strict StarIntel 0.9 ingest validation | Active | Canonical HTTP and Rabbit document mutations call the strict =star-cl= v0.9 validator; legacy target compatibility is explicitly isolated |
 
 ** Source-of-truth rule
 
 When documentation and code disagree, the current code wins. Correct the docs in
 the same pull request as behavior changes.
 
-The document model itself lives in [[https://github.com/lost-rob0t/star-cl][lost-rob0t/star-cl]]. The Python adapter lives
-in [[https://github.com/lost-rob0t/starintel-doc][lost-rob0t/starintel-doc]]. This server transports and stores those documents,
-but it currently also carries legacy flat 0.8 behavior.
+The document model and canonical Common Lisp validator live in [[https://github.com/lost-rob0t/star-cl][lost-rob0t/star-cl]]. The Python adapter lives
+in [[https://github.com/lost-rob0t/starintel-doc][lost-rob0t/starintel-doc]]. This server transports and stores canonical v0.9 documents while retaining a narrow legacy target compatibility path until the versioned target lifecycle API replaces it.

--- a/docs/v09-runtime.org
+++ b/docs/v09-runtime.org
@@ -1,0 +1,72 @@
+#+title: StarIntel v0.9 document runtime
+#+options: toc:2
+
+* Runtime contract
+
+StarIntel Server's canonical document mutation boundary is StarIntel document
+specification =0.9.0=.
+
+The server runtime and both dependency locks use the v0.9 implementation from
+=lost-rob0t/star-cl=. The checked-in schema lock remains the authority for the
+canonical schema revision.
+
+A canonical document carries two different version fields:
+
+- =schema_version= is the document specification revision and must be exactly
+  ="0.9.0"=;
+- =version= is the integer revision counter for the document itself.
+
+These fields are not interchangeable.
+
+* Validation
+
+Canonical HTTP and RabbitMQ document mutation paths validate the complete JSON
+document with the strict v0.9 validator supplied by =star-cl= before publish or
+persistence.
+
+The server does not maintain a fork of the JSON schema validator. The
+=star.documents:validate-v09-document= adapter locates the schema distributed
+with the loaded =starintel= ASDF system, converts the server's JSOWN value to the
+validator's Jzon representation, and translates validation failures into a
+stable server condition.
+
+HTTP schema failures return =422= and =invalid_document_schema=. A missing
+=schema_version= returns =schema_version_required=; a non-v0.9 revision returns
+=unsupported_schema_version=.
+
+RabbitMQ canonical ingest and update deliveries that fail v0.9 validation are
+classified as permanent schema-invalid deliveries and follow the existing
+retry/quarantine settlement policy rather than reaching CouchDB.
+
+* Canonical mutation paths
+
+Strict v0.9 validation is active on:
+
+- =POST /new/document/:dtype=;
+- =POST /documents/bulk=;
+- =documents.ingest.#= RabbitMQ deliveries;
+- =documents.update.#= RabbitMQ deliveries.
+
+The capability endpoint reports the document schema revision from the loaded
+=star-cl= runtime.
+
+* Legacy target compatibility
+
+=POST /new/target/:actor= and the existing target-dispatch Rabbit compatibility
+path still use the historical flat target envelope. They explicitly opt out of
+strict document-schema validation until the versioned target lifecycle API
+replaces that compatibility adapter.
+
+This exemption is narrow: it does not weaken canonical document or bulk ingest.
+New document producers should emit v0.9 documents and must not rely on the legacy
+target envelope as a general schema escape hatch.
+
+* Deployment consistency
+
+Both =flake.lock= and =qlfile.lock= must point at the same v0.9-capable =star-cl=
+revision. The source-contract test fails if either build path drifts back to the
+older 0.7/0.8 runtime.
+
+The Nix build remains the deployment authority. CI evaluates the flake, builds
+the server, and runs the hermetic and service-backed suites against the exact
+pull-request head.

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769361023,
+        "lastModified": 1786244418,
         "narHash": "sha256-CJMDv+FVsrSTIolKxOS7DIRrPxI70uE/YRvoDBtucAY=",
         "owner": "lost-rob0t",
         "repo": "star-cl",
-        "rev": "36c88aabcbe43a02c189e5b7704a1f063461c888",
+        "rev": "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -30,7 +30,7 @@
       },
       "locked": {
         "lastModified": 1786244418,
-        "narHash": "sha256-CJMDv+FVsrSTIolKxOS7DIRrPxI70uE/YRvoDBtucAY=",
+        "narHash": "sha256-WO/qeIgw7nvRDYeM21Iuwb5HUGttVPMOXj69Ghfmlj4=",
         "owner": "lost-rob0t",
         "repo": "star-cl",
         "rev": "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa",

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -65,7 +65,7 @@
 ("star-cl" .
  (:class qlot/source/github:source-github
   :initargs (:repos "lost-rob0t/star-cl" :ref nil :branch nil :tag nil)
-  :version "github-4065d8689ad118dc93fc95688ca1bf63973e3c0d"))
+  :version "github-b8dfbe2f9f56065ace8c3313b92ca748a115cdfa"))
 ("cl-couch" .
  (:class qlot/source/github:source-github
   :initargs (:repos "lost-rob0t/cl-couch" :ref nil :branch nil :tag nil)

--- a/source/document-access-package.lisp
+++ b/source/document-access-package.lisp
@@ -1,6 +1,9 @@
 (uiop:define-package :star.documents
   (:use :cl)
   (:export
+   #:document-schema-validation-error
+   #:document-schema-validation-category
+   #:document-schema-validation-reason
    #:object-has-key-p
    #:object-value
    #:object-keys
@@ -15,6 +18,7 @@
    #:document-date-added
    #:document-date-updated
    #:document-transient-p
+   #:validate-v09-document
    #:ensure-document
    #:document-json
    #:utc-now))

--- a/source/document-access.lisp
+++ b/source/document-access.lisp
@@ -1,5 +1,21 @@
 (in-package :star.documents)
 
+(define-condition document-schema-validation-error (error)
+  ((category
+    :initarg :category
+    :reader document-schema-validation-category)
+   (reason
+    :initarg :reason
+    :reader document-schema-validation-reason))
+  (:report
+   (lambda (condition stream)
+     (format stream "StarIntel v0.9 validation failed (~a): ~a"
+             (document-schema-validation-category condition)
+             (document-schema-validation-reason condition)))))
+
+(defvar *v09-schema* nil)
+(defvar *v09-schema-lock* (bt:make-lock "starintel-v09-schema"))
+
 (defun object-has-key-p (object key)
   (and object
        (handler-case
@@ -81,11 +97,46 @@
   (let ((value (document-value document "transient" nil)))
     (or (eq value t) (eq value :true))))
 
-(defun ensure-document (document &key route-dtype)
-  "Parse DOCUMENT and enforce the transport-level identity invariants.
+(defun v09-schema-path ()
+  (merge-pathnames
+   "../schemas/starintel-doc-v0.9.0.schema.json"
+   (asdf:system-source-directory :starintel)))
 
-Schema validation remains owned by star-cl. This accessor only guarantees a
-JSON object, a stable _id, and a route-compatible dtype."
+(defun load-v09-schema ()
+  (let ((path (v09-schema-path)))
+    (unless (probe-file path)
+      (error "StarIntel v0.9 schema not found: ~a" path))
+    (com.inuoe.jzon:parse path)))
+
+(defun v09-schema ()
+  (or *v09-schema*
+      (bt:with-lock-held (*v09-schema-lock*)
+        (or *v09-schema*
+            (setf *v09-schema* (load-v09-schema))))))
+
+(defun validate-v09-document (document)
+  "Validate DOCUMENT against the canonical StarIntel v0.9 JSON schema.
+
+The canonical validator remains implemented by star-cl. This adapter owns only
+schema discovery, JSOWN/Jzon conversion, and a stable server-side condition."
+  (let* ((object (parse-document-object document))
+         (jzon-object
+           (com.inuoe.jzon:parse (jsown:to-json object))))
+    (handler-case
+        (progn
+          (starintel::validate-v090-document jzon-object (v09-schema))
+          object)
+      (starintel::starintel-validation-error (condition)
+        (error 'document-schema-validation-error
+               :category (starintel::validation-category condition)
+               :reason (starintel::validation-message condition))))))
+
+(defun ensure-document (document &key route-dtype)
+  "Parse DOCUMENT and enforce transport-level identity invariants.
+
+Strict StarIntel v0.9 schema validation is intentionally separate so legacy
+compatibility transports can normalize their old envelope without being
+mistaken for canonical v0.9 ingest."
   (let* ((object (parse-document-object document))
          (dtype (document-dtype object))
          (route (and route-dtype (canonical-dtype route-dtype))))

--- a/source/frontends/http-boundary-core.lisp
+++ b/source/frontends/http-boundary-core.lisp
@@ -185,26 +185,42 @@
     value))
 
 (defun validate-schema-version (document &key index)
-  (let ((version (jsown:val-safe document "version"))
+  (let ((schema-version (jsown:val-safe document "schema_version"))
         (expected starintel:+starintel-doc-version+))
-    (unless version
+    (unless schema-version
       (signal-http-input-error
        422
        "schema_version_required"
        (if index
-           (format nil "Document at index ~d requires a version field" index)
-           "Document requires a version field")))
-    (unless (string= (princ-to-string version)
-                     (princ-to-string expected))
+           (format nil "Document at index ~d requires a schema_version field" index)
+           "Document requires a schema_version field")))
+    (unless (and (stringp schema-version)
+                 (string= schema-version expected))
       (signal-http-input-error
        422
        "unsupported_schema_version"
        "Document schema version is not supported"
-       (jsown:new-js ("expected" (princ-to-string expected))
-                     ("received" (princ-to-string version))
+       (jsown:new-js ("expected" expected)
+                     ("received" (princ-to-string schema-version))
                      ("index" (or index :null)))))))
 
-(defun validate-document-input (document &key path-dtype index)
+(defun validate-document-schema (document &key index)
+  (handler-case
+      (star.documents:validate-v09-document document)
+    (star.documents:document-schema-validation-error (condition)
+      (signal-http-input-error
+       422
+       "invalid_document_schema"
+       "Document does not conform to the StarIntel v0.9 schema"
+       (jsown:new-js
+         ("category"
+          (star.documents:document-schema-validation-category condition))
+         ("reason"
+          (star.documents:document-schema-validation-reason condition))
+         ("index" (or index :null)))))))
+
+(defun validate-document-input
+    (document &key path-dtype index (strict-schema-p t))
   (unless (json-object-p document)
     (signal-http-input-error
      422
@@ -224,6 +240,8 @@
        (jsown:new-js ("path_dtype" path-dtype)
                      ("document_dtype" dtype))))
     (validate-schema-version document :index index)
+    (when strict-schema-p
+      (validate-document-schema document :index index))
     document))
 
 (defun query-value (params name)

--- a/source/frontends/http-boundary-routes.lisp
+++ b/source/frontends/http-boundary-routes.lisp
@@ -24,7 +24,13 @@
          "Route actor is required"))
       (setf (jsown:val document "dtype") "target"
             (jsown:val document "actor") actor)
-      (validate-document-input document :path-dtype "target")
+      ;; /new/target/:actor is an explicit legacy compatibility adapter. It
+      ;; keeps the old flat target shape until the versioned target API lands;
+      ;; canonical document ingest remains strict v0.9.
+      (validate-document-input
+       document
+       :path-dtype "target"
+       :strict-schema-p nil)
       (publish-document document)
       (jsown:to-json document))))
 

--- a/source/rabbit.lisp
+++ b/source/rabbit.lisp
@@ -63,12 +63,20 @@
    :password password
    :vhost vhost))
 
-(defun decode-rabbit-document (message &key route-dtype)
-  "Parse one Rabbit delivery and convert malformed payloads to permanent errors."
+(defun decode-rabbit-document
+    (message &key route-dtype (strict-schema-p t))
+  "Parse one Rabbit delivery and convert malformed payloads to permanent errors.
+
+Canonical document mutation queues enforce the StarIntel v0.9 schema. Legacy
+compatibility queues must opt out explicitly."
   (handler-case
-      (star.documents:ensure-document
-       (car message)
-       :route-dtype route-dtype)
+      (let ((document
+              (star.documents:ensure-document
+               (car message)
+               :route-dtype route-dtype)))
+        (when strict-schema-p
+          (star.documents:validate-v09-document document))
+        document)
     (star.consumers:delivery-processing-error (condition)
       (error condition))
     (error (condition)
@@ -182,7 +190,10 @@
   (target-outcome-settlement
    (star.actors:accept-target-delivery
     consumer
-    (decode-rabbit-document message :route-dtype "target"))))
+    (decode-rabbit-document
+     message
+     :route-dtype "target"
+     :strict-schema-p nil))))
 
 (defun consumer-retry-options ()
   (list

--- a/source/rabbit.lisp
+++ b/source/rabbit.lisp
@@ -158,8 +158,9 @@ compatibility queues must opt out explicitly."
      #'publish-outbox-event)))
 
 (defun transient-p (message)
+  "Inspect legacy transport metadata without weakening canonical mutation validation."
   (star.documents:document-transient-p
-   (decode-rabbit-document message)))
+   (decode-rabbit-document message :strict-schema-p nil)))
 
 (defun target-outcome-settlement (outcome)
   (case (star.actors:target-dispatch-outcome-status outcome)

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -83,6 +83,7 @@
    (:file "authorization/services-final"))
   :depends-on
   (#:starintel
+   #:com.inuoe.jzon
    #:cl-couch
    #:serapeum
    #:alexandria

--- a/t/http-boundary-test.lisp
+++ b/t/http-boundary-test.lisp
@@ -6,13 +6,20 @@
 (in-suite http-boundary-tests)
 
 (defun make-boundary-document (&key (dtype "host")
-                                    (version starintel:+starintel-doc-version+)
+                                    (schema-version starintel:+starintel-doc-version+)
+                                    (version 1)
                                     (id "boundary-doc-1"))
-  (jsown:new-js
-    ("_id" id)
-    ("dataset" "boundary-tests")
-    ("dtype" dtype)
-    ("version" version)))
+  (let ((document
+          (starintel:encode
+           (starintel:new-host
+            "boundary-tests"
+            :id id
+            :hostname "boundary.example"
+            :ip "192.0.2.10"))))
+    (setf (jsown:val document "dtype") dtype
+          (jsown:val document "schema_version") schema-version
+          (jsown:val document "version") version)
+    document))
 
 (defun capture-http-input-error (thunk)
   (handler-case
@@ -69,6 +76,22 @@
     (is (string= "request_body_too_large"
                  (star.frontends.http-api:http-input-error-code condition)))))
 
+(test canonical-v09-document-passes-strict-validation
+  (let ((document (make-boundary-document)))
+    (is (eq document
+            (star.frontends.http-api:validate-document-input
+             document
+             :path-dtype "host")))))
+
+(test document-version-is-not-schema-version
+  (let ((document (make-boundary-document :version 7)))
+    (is (eq document
+            (star.frontends.http-api:validate-document-input
+             document
+             :path-dtype "host")))
+    (is (= 7 (jsown:val document "version")))
+    (is (string= "0.9.0" (jsown:val document "schema_version")))))
+
 (test missing-and-mismatched-dtype-return-422
   (let* ((missing (make-boundary-document))
          (mismatch (make-boundary-document :dtype "email")))
@@ -95,17 +118,55 @@
                    (star.frontends.http-api:http-input-error-code
                     mismatch-condition))))))
 
+(test missing-schema-version-is-rejected-even-when-version-looks-like-schema
+  (let ((document (make-boundary-document)))
+    (jsown:remkey document "schema_version")
+    (setf (jsown:val document "version") "0.9.0")
+    (let ((condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:validate-document-input
+                document
+                :path-dtype "host")))))
+      (is (= 422
+             (star.frontends.http-api:http-input-error-status condition)))
+      (is (string= "schema_version_required"
+                   (star.frontends.http-api:http-input-error-code condition))))))
+
 (test unsupported-schema-version-is-rejected
   (let ((condition
           (capture-http-input-error
            (lambda ()
              (star.frontends.http-api:validate-document-input
-              (make-boundary-document :version "999.0")
+              (make-boundary-document :schema-version "999.0")
               :path-dtype "host")))))
     (is (= 422
            (star.frontends.http-api:http-input-error-status condition)))
     (is (string= "unsupported_schema_version"
                  (star.frontends.http-api:http-input-error-code condition)))))
+
+(test undeclared-v09-field-is-rejected-by-canonical-schema
+  (let ((document (make-boundary-document)))
+    (setf (jsown:val document "legacy_flat_field") "not-v09")
+    (let ((condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:validate-document-input
+                document
+                :path-dtype "host")))))
+      (is (= 422
+             (star.frontends.http-api:http-input-error-status condition)))
+      (is (string= "invalid_document_schema"
+                   (star.frontends.http-api:http-input-error-code condition))))))
+
+(test legacy-target-adapter-can-skip-strict-document-schema
+  (let ((document (make-boundary-document :dtype "target")))
+    (setf (jsown:val document "actor") "legacy-actor")
+    (is (eq document
+            (star.frontends.http-api:validate-document-input
+             document
+             :path-dtype "target"
+             :strict-schema-p nil)))))
 
 (test client-status-envelopes-never-expose-tracebacks
   (let* ((star.frontends.http-api::*http-correlation-id* "corr-test")

--- a/tests/test_v09_runtime_contract.py
+++ b/tests/test_v09_runtime_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STAR_CL_V09 = "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa"
+
+
+class V09RuntimeContractTests(unittest.TestCase):
+    def text(self, relative: str) -> str:
+        return (ROOT / relative).read_text(encoding="utf-8")
+
+    def test_schema_and_dependency_locks_agree_on_v09(self) -> None:
+        schema_lock = json.loads(self.text("schema/starintel-schema.lock.json"))
+        flake_lock = json.loads(self.text("flake.lock"))
+        qlot_lock = self.text("qlfile.lock")
+
+        self.assertEqual(schema_lock["schema_version"], "0.9.0")
+        self.assertEqual(flake_lock["nodes"]["star-cl"]["locked"]["rev"], STAR_CL_V09)
+        self.assertIn(f'github-{STAR_CL_V09}', qlot_lock)
+        self.assertNotIn("github-4065d8689ad118dc93fc95688ca1bf63973e3c0d", qlot_lock)
+        self.assertNotEqual(
+            flake_lock["nodes"]["star-cl"]["locked"]["rev"],
+            "36c88aabcbe43a02c189e5b7704a1f063461c888",
+        )
+
+    def test_http_boundary_uses_schema_version_not_document_revision(self) -> None:
+        boundary = self.text("source/frontends/http-boundary-core.lisp")
+        self.assertIn('(jsown:val-safe document "schema_version")', boundary)
+        self.assertIn("star.documents:validate-v09-document", boundary)
+        self.assertIn('"invalid_document_schema"', boundary)
+        self.assertNotIn('(jsown:val-safe document "version")', boundary)
+
+    def test_canonical_validator_is_reused_not_forked(self) -> None:
+        access = self.text("source/document-access.lisp")
+        system = self.text("source/starintel-gserver.asd")
+        self.assertIn("starintel::validate-v090-document", access)
+        self.assertIn("starintel-doc-v0.9.0.schema.json", access)
+        self.assertIn("#:com.inuoe.jzon", system)
+        self.assertNotIn("defun validate-v090-value", access)
+
+    def test_rabbit_mutations_are_strict_but_legacy_targets_are_explicit(self) -> None:
+        rabbit = self.text("source/rabbit.lisp")
+        self.assertIn("(strict-schema-p t)", rabbit)
+        self.assertIn("star.documents:validate-v09-document", rabbit)
+        self.assertIn(':strict-schema-p nil', rabbit)
+        self.assertIn(':route-dtype "target"', rabbit)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Make StarIntel 0.9.0 the canonical document runtime across server build and ingest paths.

- converge Nix and QLot onto the current v0.9 `star-cl` runtime;
- validate `schema_version`, not the integer document `version` counter;
- reuse the canonical `star-cl` v0.9 JSON-schema validator through `star.documents:validate-v09-document`;
- reject invalid canonical documents before HTTP publish or RabbitMQ persistence;
- keep the historical target route/Rabbit target path as an explicit narrow compatibility adapter;
- add hermetic Lisp and Python contract coverage for v0.9 version semantics and dependency drift;
- update runtime/document-spec documentation.

## Why

The repository schema lock already declares v0.9.0, but QLot was pinned to a 0.7.3 `star-cl` revision and Nix was pinned to 0.8.0. The HTTP boundary also compared the document `version` field against the schema version, which is incorrect in v0.9 (`schema_version` is the spec revision; `version` is an integer document revision).

## Related

Advances #59: canonical document ingest is schema-aware and validates v0.9 before publish/persist. This does not implement the full versioned batch/target lifecycle API from #59.