### PR TITLE
RAGE #111: core OAuth provider plus reload-safe Bixby add-on

### DIFF
--- a/addons/bixby/bixby.lisp
+++ b/addons/bixby/bixby.lisp
@@ -19,7 +19,7 @@
   (string-right-trim "/" value))
 
 (defun normalize-redirect-uri (value)
-  (unless (star.auth::valid-https-redirect-uri-p value)
+  (unless (star.auth:valid-https-redirect-uri-p value)
     (error "Bixby redirect URI must be an absolute HTTPS callback URI"))
   value)
 
@@ -34,10 +34,10 @@ owned by STAR.AUTH."
   (when redirect-uri
     (setf *redirect-uri* (normalize-redirect-uri redirect-uri)))
   (when read-scopes
-    (setf *read-scopes* (star.auth::normalize-oauth-scopes read-scopes)))
+    (setf *read-scopes* (star.auth:normalize-oauth-scopes read-scopes)))
   (when operations-scopes
     (setf *operations-scopes*
-          (star.auth::normalize-oauth-scopes operations-scopes)))
+          (star.auth:normalize-oauth-scopes operations-scopes)))
   (bixby-oauth-settings))
 
 (defun require-bixby-config ()

--- a/addons/bixby/bixby.lisp
+++ b/addons/bixby/bixby.lisp
@@ -1,9 +1,9 @@
 (in-package :star.addons.bixby)
 
-(defparameter *public-base-url* nil)
-(defparameter *redirect-uri* nil)
-(defparameter *read-scopes* '("documents:read" "search:read"))
-(defparameter *operations-scopes*
+(defvar *public-base-url* nil)
+(defvar *redirect-uri* nil)
+(defvar *read-scopes* '("documents:read" "search:read"))
+(defvar *operations-scopes*
   '("starintel.targets.write" "starintel.autodig.read" "starintel.autodig.control"))
 
 (defun normalize-base-url (value)

--- a/addons/bixby/bixby.lisp
+++ b/addons/bixby/bixby.lisp
@@ -1,0 +1,92 @@
+(in-package :star.addons.bixby)
+
+(defparameter *public-base-url* nil)
+(defparameter *redirect-uri* nil)
+(defparameter *read-scopes* '("documents:read" "search:read"))
+(defparameter *operations-scopes*
+  '("starintel.targets.write" "starintel.autodig.read" "starintel.autodig.control"))
+
+(defun normalize-base-url (value)
+  (unless (and (stringp value)
+               (plusp (length value)))
+    (error "Bixby public base URL must be a non-empty HTTPS URL"))
+  (let ((uri (ignore-errors (quri:uri value))))
+    (unless (and uri
+                 (string-equal "https" (quri:uri-scheme uri))
+                 (quri:uri-host uri)
+                 (null (quri:uri-fragment uri)))
+      (error "Bixby public base URL must be an absolute HTTPS URL without a fragment")))
+  (string-right-trim "/" value))
+
+(defun normalize-redirect-uri (value)
+  (unless (star.auth::valid-https-redirect-uri-p value)
+    (error "Bixby redirect URI must be an absolute HTTPS callback URI"))
+  value)
+
+(defun configure-bixby (&key public-base-url redirect-uri read-scopes operations-scopes)
+  "Configure Samsung-specific adapter metadata without changing core OAuth.
+
+This function is intended for init.lisp. It records only Bixby integration
+settings. OAuth users, clients, codes, tokens, scopes, and authorization remain
+owned by STAR.AUTH."
+  (when public-base-url
+    (setf *public-base-url* (normalize-base-url public-base-url)))
+  (when redirect-uri
+    (setf *redirect-uri* (normalize-redirect-uri redirect-uri)))
+  (when read-scopes
+    (setf *read-scopes* (star.auth::normalize-oauth-scopes read-scopes)))
+  (when operations-scopes
+    (setf *operations-scopes*
+          (star.auth::normalize-oauth-scopes operations-scopes)))
+  (bixby-oauth-settings))
+
+(defun require-bixby-config ()
+  (unless *public-base-url*
+    (error "Bixby add-on requires PUBLIC-BASE-URL configuration"))
+  (unless *redirect-uri*
+    (error "Bixby add-on requires REDIRECT-URI configuration"))
+  t)
+
+(defun bixby-oauth-settings ()
+  "Return the provider values consumed by Samsung capsule configuration."
+  (require-bixby-config)
+  (list :authorize-endpoint
+        (format nil "~a/oauth/authorize" *public-base-url*)
+        :token-endpoint
+        (format nil "~a/oauth/token" *public-base-url*)
+        :redirect-uri *redirect-uri*
+        :read-scopes (copy-list *read-scopes*)
+        :operations-scopes (copy-list *operations-scopes*)))
+
+(defun create-bixby-oauth-client (&key include-operations
+                                       (store star.auth:*credential-store*))
+  "Create one standard core OAuth client for the configured Bixby callback.
+
+The returned secret is intentionally one-time output from STAR.AUTH and must be
+placed in Samsung Developer Center or equivalent secret storage. This function
+is explicit and is never called automatically during add-on load/reload."
+  (require-bixby-config)
+  (star.auth:create-oauth-client
+   (list *redirect-uri*)
+   (remove-duplicates
+    (append (copy-list *read-scopes*)
+            (when include-operations
+              (copy-list *operations-scopes*)))
+    :test #'string=)
+   :store store))
+
+(defun start-bixby-addon ()
+  ;; Loading the add-on must be side-effect-light and reload-safe. Client
+  ;; registration is explicit because it creates secret material.
+  (log:info "StarIntel Bixby add-on loaded; core OAuth remains authoritative")
+  t)
+
+(defun stop-bixby-addon ()
+  (log:info "StarIntel Bixby add-on stopped")
+  t)
+
+(star:register-addon
+ :starintel-bixby
+ :system :starintel-bixby
+ :start #'start-bixby-addon
+ :stop #'stop-bixby-addon)

--- a/addons/bixby/package.lisp
+++ b/addons/bixby/package.lisp
@@ -1,0 +1,10 @@
+(uiop:define-package :star.addons.bixby
+  (:use :cl)
+  (:export
+   #:*public-base-url*
+   #:*redirect-uri*
+   #:*read-scopes*
+   #:*operations-scopes*
+   #:configure-bixby
+   #:bixby-oauth-settings
+   #:create-bixby-oauth-client))

--- a/docs/addons.org
+++ b/docs/addons.org
@@ -44,8 +44,11 @@ finishes loading the system.
 - =load-addon= loads the ASDF system and starts it once.
 - =unload-addon= invokes the stop hook and marks it stopped. Common Lisp code is
   intentionally not claimed to be physically unloaded.
-- =reload-addon= stops the active generation, force-loads the ASDF system, then
-  starts the replacement generation.
+- =reload-addon= stops the active generation, asks ASDF to load the current
+  system, then starts the replacement generation. ASDF rebuilds/reloads changed
+  components normally; the lifecycle does not pass =:force= because nested ASDF
+  operations (including test/tooling operations) reject incompatible force
+  settings.
 - if replacement load/start fails, the previous definition and start hook are
   restored when possible.
 - =addon-status= exposes lifecycle state and generation; =list-addons= returns

--- a/docs/addons.org
+++ b/docs/addons.org
@@ -1,0 +1,89 @@
+#+title: StarIntel Server add-ons
+
+* Contract
+
+StarIntel add-ons are optional ASDF systems loaded by the trusted operator from
+=init.lisp=. The experience stays Lisp-native:
+
+#+begin_src lisp
+(in-package :star)
+
+(load-addon :starintel-bixby)
+
+(uiop:symbol-call
+ :star.addons.bixby
+ :configure-bixby
+ :public-base-url "https://starintel.example"
+ :redirect-uri "https://example-capsule.oauth.aibixby.com/auth/external/cb")
+#+end_src
+
+An add-on is a packaging and lifecycle boundary. It is *not* a sandbox and it
+never bypasses StarIntel authentication/authorization. Loading an add-on has the
+same trust level as evaluating =init.lisp=.
+
+* ASDF package rule
+
+Each add-on is its own ASDF system and depends on =starintel-gserver= rather
+than being added to the core server dependency graph.
+
+During load the system calls:
+
+#+begin_src lisp
+(star:register-addon
+ :my-addon
+ :system :my-addon
+ :start #'start-my-addon
+ :stop #'stop-my-addon)
+#+end_src
+
+Registration is metadata only. =load-addon= starts the lifecycle after ASDF
+finishes loading the system.
+
+* Lifecycle
+
+- =load-addon= loads the ASDF system and starts it once.
+- =unload-addon= invokes the stop hook and marks it stopped. Common Lisp code is
+  intentionally not claimed to be physically unloaded.
+- =reload-addon= stops the active generation, force-loads the ASDF system, then
+  starts the replacement generation.
+- if replacement load/start fails, the previous definition and start hook are
+  restored when possible.
+- =addon-status= exposes lifecycle state and generation; =list-addons= returns
+  registered runtime state.
+
+Add-on start/stop hooks must be idempotent with respect to their own owned
+resources. They must unregister routes/hooks/timers they create before returning
+from stop.
+
+* Bixby boundary
+
+=starintel-bixby= is the first packaged add-on.
+
+Core server owns:
+- StarIntel human users;
+- OAuth client/code/access-token storage;
+- =/oauth/authorize= and =/oauth/token=;
+- PKCE, scope attenuation and bearer authentication;
+- downstream authorization.
+
+The Bixby add-on owns only Samsung-specific configuration such as public OAuth
+endpoint projection, callback URI, and the explicit operator helper that creates
+a normal core OAuth client. It does not create a second identity/token/scope
+system, and reload never creates new client secrets automatically.
+
+* Stable secret rule
+
+Functions that mint credentials or other one-time secret material must never run
+implicitly from add-on =start= or =reload=. For Bixby, client registration is an
+explicit operator action:
+
+#+begin_src lisp
+(multiple-value-bind (client secret)
+    (uiop:symbol-call
+     :star.addons.bixby
+     :create-bixby-oauth-client
+     :include-operations t)
+  ;; Store SECRET in Samsung Developer Center / secret storage immediately.
+  ;; It is not available from metadata later.
+  (values client secret))
+#+end_src

--- a/docs/oauth-provider.org
+++ b/docs/oauth-provider.org
@@ -1,0 +1,64 @@
+#+title: StarIntel OAuth 2 authorization-code provider
+
+* Ownership
+
+OAuth is a built-in StarIntel Server capability. External integrations such as
+Bixby consume it; they do not own alternate identities, token formats, scopes,
+or authorization policy.
+
+* Endpoints
+
+** GET /oauth/authorize
+
+Validates the OAuth protocol request before displaying the StarIntel login form.
+The current provider profile requires:
+
+- =response_type= exactly =code=;
+- registered =client_id=;
+- exact registered HTTPS =redirect_uri=;
+- space-delimited =scope= within the client's registered scope ceiling;
+- PKCE =code_challenge_method=S256=;
+- valid =code_challenge=;
+- opaque =state= is preserved when supplied.
+
+** POST /oauth/authorize
+
+Revalidates the protocol request, authenticates an existing StarIntel human
+user directly, issues a short-lived one-time authorization code, then redirects
+to the exact registered callback with only =code= and =state= query values.
+Password login does not mint an API key.
+
+** POST /oauth/token
+
+Accepts the authorization-code grant with client credentials, exact redirect,
+and PKCE verifier. Successful responses are JSON containing:
+
+#+begin_example
+{
+  "access_token": "<opaque bearer>",
+  "token_type": "Bearer",
+  "expires_in": 900,
+  "scope": "documents:read search:read"
+}
+#+end_example
+
+Token responses include =Cache-Control: no-store= and =Pragma: no-cache=.
+Authorization codes are one-time and replay fails with =invalid_grant=.
+
+The current core does not issue refresh tokens. Clients re-enter the
+authorization-code flow after access-token expiry. Do not fabricate refresh
+semantics in integration packages.
+
+* Security invariants
+
+- exact redirect matching; no wildcard/suffix matching;
+- S256 PKCE only for this profile;
+- client scope ceiling and user scope ceiling both apply;
+- failed user login is generic =access_denied=;
+- failed code/client/redirect/verifier checks never issue a token;
+- passwords, client secrets, authorization codes, verifiers, and bearer tokens
+  must not enter logs or diagnostic payloads;
+- public routability of OAuth protocol endpoints does not imply public access to
+  application data;
+- authenticated bearer requests continue through the existing StarIntel request
+  security context and authorization policy.

--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,20 @@ EOF
         dontStrip = true;
       };
 
+      starintel-bixby = sbcl'.buildASDFSystem {
+        pname = "starintel-bixby";
+        version = "0.1.0";
+        src = ./.;
+
+        lispLibs = with sbcl'.pkgs; [
+          starintel-gserver
+        ];
+
+        systems = [ "starintel-bixby" ];
+        asdFilesToKeep = [ "starintel-bixby.asd" ];
+        dontStrip = true;
+      };
+
       starintel-gserver-tests = sbcl'.buildASDFSystem {
         pname = "starintel-gserver-tests";
         version = "0.1.0";
@@ -158,6 +172,7 @@ EOF
 
         lispLibs = with sbcl'.pkgs; [
           starintel-gserver
+          starintel-bixby
           starintel-gserver-client
           star-cli-lib
           star-ui-lib
@@ -262,7 +277,8 @@ EOF
         dontStrip = true;
       };
 
-      sbcl-wrapped = sbcl'.withPackages (ps: with ps; [ starintel-gserver ]);
+      sbcl-wrapped = sbcl'.withPackages
+        (ps: with ps; [ starintel-gserver starintel-bixby ]);
       sbcl-test-wrapped = sbcl'.withPackages (ps: with ps; [ starintel-gserver-tests ]);
       sbcl-integration-test-wrapped = sbcl'.withPackages
         (ps: with ps; [ starintel-gserver-integration-tests ]);
@@ -524,6 +540,7 @@ PY
         };
 
         starintel-gserver = starintel-gserver;
+        starintel-bixby = starintel-bixby;
         starintel-gserver-tests = starintel-gserver-tests;
         starintel-gserver-integration-tests =
           starintel-gserver-integration-tests;

--- a/source/addons.lisp
+++ b/source/addons.lisp
@@ -1,0 +1,256 @@
+(in-package :star)
+
+(define-condition addon-error (error)
+  ((name :initarg :name :reader addon-error-name)
+   (message :initarg :message :reader addon-error-message)
+   (cause :initarg :cause :initform nil :reader addon-error-cause))
+  (:report
+   (lambda (condition stream)
+     (format stream "Add-on ~a: ~a"
+             (addon-error-name condition)
+             (addon-error-message condition)))))
+
+(defstruct addon-definition
+  name
+  system
+  start
+  stop)
+
+(defstruct addon-state
+  name
+  system
+  (status :registered)
+  (generation 0)
+  started-at
+  stopped-at
+  last-error)
+
+(defvar *addon-definitions* (make-hash-table :test #'equal))
+(defvar *addon-states* (make-hash-table :test #'equal))
+(defvar *addon-lock* (bt:make-lock "starintel-addons"))
+
+(defun canonical-addon-name (name)
+  (string-downcase
+   (etypecase name
+     (string name)
+     (symbol (symbol-name name)))))
+
+(defun canonical-addon-system (system)
+  (canonical-addon-name system))
+
+(defun register-addon (name &key system start stop)
+  "Register a trusted StarIntel add-on lifecycle.
+
+Add-on systems call this while ASDF loads them. START and STOP must be
+zero-argument functions. Registration is metadata only; it does not start the
+add-on and therefore remains safe to repeat during ASDF reload."
+  (let* ((canonical-name (canonical-addon-name name))
+         (canonical-system
+           (canonical-addon-system (or system canonical-name))))
+    (unless (or (null start) (functionp start))
+      (error 'addon-error
+             :name canonical-name
+             :message "START must be a function or NIL"))
+    (unless (or (null stop) (functionp stop))
+      (error 'addon-error
+             :name canonical-name
+             :message "STOP must be a function or NIL"))
+    (bt:with-lock-held (*addon-lock*)
+      (setf (gethash canonical-system *addon-definitions*)
+            (make-addon-definition
+             :name canonical-name
+             :system canonical-system
+             :start start
+             :stop stop))
+      (unless (gethash canonical-system *addon-states*)
+        (setf (gethash canonical-system *addon-states*)
+              (make-addon-state
+               :name canonical-name
+               :system canonical-system))))
+    canonical-name))
+
+(defun addon-definition-for-system (system)
+  (gethash (canonical-addon-system system) *addon-definitions*))
+
+(defun addon-state-for-system (system)
+  (gethash (canonical-addon-system system) *addon-states*))
+
+(defun ensure-addon-definition (system)
+  (or (addon-definition-for-system system)
+      (error 'addon-error
+             :name (canonical-addon-system system)
+             :message "ASDF system loaded but did not register a StarIntel add-on")))
+
+(defun update-addon-state (system &key status generation started-at stopped-at last-error)
+  (let* ((canonical-system (canonical-addon-system system))
+         (state
+           (or (gethash canonical-system *addon-states*)
+               (setf (gethash canonical-system *addon-states*)
+                     (make-addon-state
+                      :name canonical-system
+                      :system canonical-system)))))
+    (when status (setf (addon-state-status state) status))
+    (when generation (setf (addon-state-generation state) generation))
+    (when started-at (setf (addon-state-started-at state) started-at))
+    (when stopped-at (setf (addon-state-stopped-at state) stopped-at))
+    (setf (addon-state-last-error state) last-error)
+    state))
+
+(defun invoke-addon-hook (definition hook-name)
+  (let ((hook
+          (ecase hook-name
+            (:start (addon-definition-start definition))
+            (:stop (addon-definition-stop definition)))))
+    (when hook
+      (funcall hook))))
+
+(defun start-addon-definition (definition)
+  (invoke-addon-hook definition :start)
+  (bt:with-lock-held (*addon-lock*)
+    (let* ((system (addon-definition-system definition))
+           (state (update-addon-state system :status :active
+                                     :started-at (get-universal-time)
+                                     :last-error nil)))
+      (incf (addon-state-generation state))
+      state)))
+
+(defun load-addon (system)
+  "Load SYSTEM through ASDF and start its registered StarIntel lifecycle.
+
+This is the intended init.lisp experience:
+
+  (load-addon :starintel-bixby)
+
+Add-ons are trusted operator code, exactly like init.lisp; this is a lifecycle
+and packaging boundary, not a sandbox or an authorization boundary."
+  (let ((canonical-system (canonical-addon-system system)))
+    (handler-case
+        (progn
+          (asdf:load-system canonical-system)
+          (let ((definition (ensure-addon-definition canonical-system))
+                (state (addon-state-for-system canonical-system)))
+            (if (and state (eq :active (addon-state-status state)))
+                state
+                (start-addon-definition definition))))
+      (error (condition)
+        (bt:with-lock-held (*addon-lock*)
+          (update-addon-state canonical-system
+                              :status :failed
+                              :last-error (princ-to-string condition)))
+        (error 'addon-error
+               :name canonical-system
+               :message "load/start failed"
+               :cause condition)))))
+
+(defun unload-addon (system)
+  "Stop a loaded add-on without pretending Common Lisp code can be unloaded."
+  (let* ((canonical-system (canonical-addon-system system))
+         (definition (addon-definition-for-system canonical-system))
+         (state (addon-state-for-system canonical-system)))
+    (unless definition
+      (error 'addon-error
+             :name canonical-system
+             :message "add-on is not registered"))
+    (when (and state (eq :active (addon-state-status state)))
+      (handler-case
+          (progn
+            (invoke-addon-hook definition :stop)
+            (bt:with-lock-held (*addon-lock*)
+              (update-addon-state canonical-system
+                                  :status :stopped
+                                  :stopped-at (get-universal-time)
+                                  :last-error nil)))
+        (error (condition)
+          (bt:with-lock-held (*addon-lock*)
+            (update-addon-state canonical-system
+                                :status :failed
+                                :last-error (princ-to-string condition)))
+          (error 'addon-error
+                 :name canonical-system
+                 :message "stop failed"
+                 :cause condition))))
+    (addon-state-for-system canonical-system)))
+
+(defun restore-addon-generation (definition system condition)
+  (handler-case
+      (progn
+        (invoke-addon-hook definition :start)
+        (bt:with-lock-held (*addon-lock*)
+          (update-addon-state system
+                              :status :active
+                              :started-at (get-universal-time)
+                              :last-error
+                              (format nil "reload rolled back after: ~a" condition))))
+    (error (rollback-condition)
+      (bt:with-lock-held (*addon-lock*)
+        (update-addon-state system
+                            :status :failed
+                            :last-error
+                            (format nil "reload failed: ~a; rollback failed: ~a"
+                                    condition rollback-condition))))))
+
+(defun reload-addon (system)
+  "Reload one add-on transactionally at the lifecycle boundary.
+
+The old START/STOP function objects are retained until the replacement starts.
+If loading or starting the replacement fails, the old START hook is invoked to
+restore the previous live generation when possible."
+  (let* ((canonical-system (canonical-addon-system system))
+         (old-definition (ensure-addon-definition canonical-system))
+         (old-state (addon-state-for-system canonical-system))
+         (was-active (and old-state (eq :active (addon-state-status old-state)))))
+    (when was-active
+      (invoke-addon-hook old-definition :stop)
+      (bt:with-lock-held (*addon-lock*)
+        (update-addon-state canonical-system
+                            :status :reloading
+                            :stopped-at (get-universal-time)
+                            :last-error nil)))
+    (handler-case
+        (progn
+          (asdf:load-system canonical-system :force t)
+          (start-addon-definition (ensure-addon-definition canonical-system)))
+      (error (condition)
+        (when was-active
+          (restore-addon-generation old-definition canonical-system condition))
+        (unless was-active
+          (bt:with-lock-held (*addon-lock*)
+            (update-addon-state canonical-system
+                                :status :failed
+                                :last-error (princ-to-string condition))))
+        (error 'addon-error
+               :name canonical-system
+               :message "reload failed"
+               :cause condition)))))
+
+(defun addon-status (system)
+  (let ((state (addon-state-for-system system)))
+    (and state (copy-addon-state state))))
+
+(defun list-addons ()
+  (bt:with-lock-held (*addon-lock*)
+    (sort
+     (loop for state being the hash-values of *addon-states*
+           collect (copy-addon-state state))
+     #'string<
+     :key #'addon-state-system)))
+
+(export '(addon-error
+          addon-error-name
+          addon-error-message
+          addon-error-cause
+          addon-state
+          addon-state-name
+          addon-state-system
+          addon-state-status
+          addon-state-generation
+          addon-state-started-at
+          addon-state-stopped-at
+          addon-state-last-error
+          register-addon
+          load-addon
+          unload-addon
+          reload-addon
+          addon-status
+          list-addons)
+        :star)

--- a/source/addons.lisp
+++ b/source/addons.lisp
@@ -230,7 +230,13 @@ operations are serialized so load/stop/reload cannot interleave."
                             :last-error nil)))
     (handler-case
         (progn
-          (asdf:load-system canonical-system :force t)
+          ;; Do not pass :FORCE here. RELOAD-ADDON may run while an enclosing
+          ;; ASDF operation (for example TEST-OP) is active, and ASDF rejects
+          ;; nested OPERATE calls whose FORCE settings differ from the outer
+          ;; operation. LOAD-SYSTEM already rebuilds and reloads components
+          ;; whose source changed, which is the behavior a source-code reload
+          ;; needs without making the lifecycle unusable from tests or tooling.
+          (asdf:load-system canonical-system)
           (start-addon-definition (ensure-addon-definition canonical-system)))
       (error (condition)
         (if was-active

--- a/source/addons.lisp
+++ b/source/addons.lisp
@@ -172,6 +172,8 @@ and packaging boundary, not a sandbox or an authorization boundary."
     (addon-state-for-system canonical-system)))
 
 (defun restore-addon-generation (definition system condition)
+  (bt:with-lock-held (*addon-lock*)
+    (setf (gethash system *addon-definitions*) definition))
   (handler-case
       (progn
         (invoke-addon-hook definition :start)
@@ -193,8 +195,8 @@ and packaging boundary, not a sandbox or an authorization boundary."
   "Reload one add-on transactionally at the lifecycle boundary.
 
 The old START/STOP function objects are retained until the replacement starts.
-If loading or starting the replacement fails, the old START hook is invoked to
-restore the previous live generation when possible."
+If loading or starting the replacement fails, the old definition and START
+hook are restored when possible."
   (let* ((canonical-system (canonical-addon-system system))
          (old-definition (ensure-addon-definition canonical-system))
          (old-state (addon-state-for-system canonical-system))
@@ -211,13 +213,14 @@ restore the previous live generation when possible."
           (asdf:load-system canonical-system :force t)
           (start-addon-definition (ensure-addon-definition canonical-system)))
       (error (condition)
-        (when was-active
-          (restore-addon-generation old-definition canonical-system condition))
-        (unless was-active
-          (bt:with-lock-held (*addon-lock*)
-            (update-addon-state canonical-system
-                                :status :failed
-                                :last-error (princ-to-string condition))))
+        (if was-active
+            (restore-addon-generation old-definition canonical-system condition)
+            (progn
+              (bt:with-lock-held (*addon-lock*)
+                (setf (gethash canonical-system *addon-definitions*) old-definition)
+                (update-addon-state canonical-system
+                                    :status :failed
+                                    :last-error (princ-to-string condition)))))
         (error 'addon-error
                :name canonical-system
                :message "reload failed"

--- a/source/addons.lisp
+++ b/source/addons.lisp
@@ -27,7 +27,8 @@
 
 (defvar *addon-definitions* (make-hash-table :test #'equal))
 (defvar *addon-states* (make-hash-table :test #'equal))
-(defvar *addon-lock* (bt:make-lock "starintel-addons"))
+(defvar *addon-lock* (bt:make-lock "starintel-addon-registry"))
+(defvar *addon-lifecycle-lock* (bt:make-lock "starintel-addon-lifecycle"))
 
 (defun canonical-addon-name (name)
   (string-downcase
@@ -70,10 +71,14 @@ add-on and therefore remains safe to repeat during ASDF reload."
     canonical-name))
 
 (defun addon-definition-for-system (system)
-  (gethash (canonical-addon-system system) *addon-definitions*))
+  (let ((canonical-system (canonical-addon-system system)))
+    (bt:with-lock-held (*addon-lock*)
+      (gethash canonical-system *addon-definitions*))))
 
 (defun addon-state-for-system (system)
-  (gethash (canonical-addon-system system) *addon-states*))
+  (let ((canonical-system (canonical-addon-system system)))
+    (bt:with-lock-held (*addon-lock*)
+      (gethash canonical-system *addon-states*))))
 
 (defun ensure-addon-definition (system)
   (or (addon-definition-for-system system)
@@ -82,6 +87,7 @@ add-on and therefore remains safe to repeat during ASDF reload."
              :message "ASDF system loaded but did not register a StarIntel add-on")))
 
 (defun update-addon-state (system &key status generation started-at stopped-at last-error)
+  "Mutate registry state. Caller must hold *ADDON-LOCK*."
   (let* ((canonical-system (canonical-addon-system system))
          (state
            (or (gethash canonical-system *addon-states*)
@@ -112,23 +118,15 @@ add-on and therefore remains safe to repeat during ASDF reload."
                                      :started-at (get-universal-time)
                                      :last-error nil)))
       (incf (addon-state-generation state))
-      state)))
+      (copy-addon-state state))))
 
-(defun load-addon (system)
-  "Load SYSTEM through ASDF and start its registered StarIntel lifecycle.
-
-This is the intended init.lisp experience:
-
-  (load-addon :starintel-bixby)
-
-Add-ons are trusted operator code, exactly like init.lisp; this is a lifecycle
-and packaging boundary, not a sandbox or an authorization boundary."
+(defun %load-addon (system)
   (let ((canonical-system (canonical-addon-system system)))
     (handler-case
         (progn
           (asdf:load-system canonical-system)
           (let ((definition (ensure-addon-definition canonical-system))
-                (state (addon-state-for-system canonical-system)))
+                (state (addon-status canonical-system)))
             (if (and state (eq :active (addon-state-status state)))
                 state
                 (start-addon-definition definition))))
@@ -142,11 +140,23 @@ and packaging boundary, not a sandbox or an authorization boundary."
                :message "load/start failed"
                :cause condition)))))
 
-(defun unload-addon (system)
-  "Stop a loaded add-on without pretending Common Lisp code can be unloaded."
+(defun load-addon (system)
+  "Load SYSTEM through ASDF and start its registered StarIntel lifecycle.
+
+This is the intended init.lisp experience:
+
+  (load-addon :starintel-bixby)
+
+Add-ons are trusted operator code, exactly like init.lisp; this is a lifecycle
+and packaging boundary, not a sandbox or an authorization boundary. Lifecycle
+operations are serialized so load/stop/reload cannot interleave."
+  (bt:with-lock-held (*addon-lifecycle-lock*)
+    (%load-addon system)))
+
+(defun %unload-addon (system)
   (let* ((canonical-system (canonical-addon-system system))
          (definition (addon-definition-for-system canonical-system))
-         (state (addon-state-for-system canonical-system)))
+         (state (addon-status canonical-system)))
     (unless definition
       (error 'addon-error
              :name canonical-system
@@ -169,7 +179,12 @@ and packaging boundary, not a sandbox or an authorization boundary."
                  :name canonical-system
                  :message "stop failed"
                  :cause condition))))
-    (addon-state-for-system canonical-system)))
+    (addon-status canonical-system)))
+
+(defun unload-addon (system)
+  "Stop a loaded add-on without pretending Common Lisp code can be unloaded."
+  (bt:with-lock-held (*addon-lifecycle-lock*)
+    (%unload-addon system)))
 
 (defun restore-addon-generation (definition system condition)
   (bt:with-lock-held (*addon-lock*)
@@ -191,18 +206,23 @@ and packaging boundary, not a sandbox or an authorization boundary."
                             (format nil "reload failed: ~a; rollback failed: ~a"
                                     condition rollback-condition))))))
 
-(defun reload-addon (system)
-  "Reload one add-on transactionally at the lifecycle boundary.
-
-The old START/STOP function objects are retained until the replacement starts.
-If loading or starting the replacement fails, the old definition and START
-hook are restored when possible."
+(defun %reload-addon (system)
   (let* ((canonical-system (canonical-addon-system system))
          (old-definition (ensure-addon-definition canonical-system))
-         (old-state (addon-state-for-system canonical-system))
+         (old-state (addon-status canonical-system))
          (was-active (and old-state (eq :active (addon-state-status old-state)))))
     (when was-active
-      (invoke-addon-hook old-definition :stop)
+      (handler-case
+          (invoke-addon-hook old-definition :stop)
+        (error (condition)
+          (bt:with-lock-held (*addon-lock*)
+            (update-addon-state canonical-system
+                                :status :failed
+                                :last-error (princ-to-string condition)))
+          (error 'addon-error
+                 :name canonical-system
+                 :message "reload stop phase failed"
+                 :cause condition)))
       (bt:with-lock-held (*addon-lock*)
         (update-addon-state canonical-system
                             :status :reloading
@@ -215,20 +235,31 @@ hook are restored when possible."
       (error (condition)
         (if was-active
             (restore-addon-generation old-definition canonical-system condition)
-            (progn
-              (bt:with-lock-held (*addon-lock*)
-                (setf (gethash canonical-system *addon-definitions*) old-definition)
-                (update-addon-state canonical-system
-                                    :status :failed
-                                    :last-error (princ-to-string condition)))))
+            (bt:with-lock-held (*addon-lock*)
+              (setf (gethash canonical-system *addon-definitions*) old-definition)
+              (update-addon-state canonical-system
+                                  :status :failed
+                                  :last-error (princ-to-string condition))))
         (error 'addon-error
                :name canonical-system
                :message "reload failed"
                :cause condition)))))
 
+(defun reload-addon (system)
+  "Reload one add-on transactionally at the lifecycle boundary.
+
+The old START/STOP function objects are retained until the replacement starts.
+If loading or starting the replacement fails, the old definition and START
+hook are restored when possible. ASDF dependencies own dependency ordering;
+START/STOP hooks must not recursively invoke add-on lifecycle operations."
+  (bt:with-lock-held (*addon-lifecycle-lock*)
+    (%reload-addon system)))
+
 (defun addon-status (system)
-  (let ((state (addon-state-for-system system)))
-    (and state (copy-addon-state state))))
+  (let ((canonical-system (canonical-addon-system system)))
+    (bt:with-lock-held (*addon-lock*)
+      (let ((state (gethash canonical-system *addon-states*)))
+        (and state (copy-addon-state state))))))
 
 (defun list-addons ()
   (bt:with-lock-held (*addon-lock*)

--- a/source/auth/oauth-package.lisp
+++ b/source/auth/oauth-package.lisp
@@ -30,6 +30,8 @@
           oauth-access-token-record-scopes
           oauth-access-token-record-expires-at
           oauth-access-token-record-revoked-at
+          valid-https-redirect-uri-p
+          normalize-oauth-scopes
           create-oauth-client
           oauth-client-metadata-json
           issue-oauth-authorization-code

--- a/source/frontends/http-oauth-provider.lisp
+++ b/source/frontends/http-oauth-provider.lisp
@@ -1,0 +1,275 @@
+(in-package :star.frontends.http-api)
+
+(defun oauth-param (params name &optional required-p)
+  (let ((value (query-value params name)))
+    (when (and required-p
+               (not (non-empty-string-p value)))
+      (star.auth::signal-oauth-error
+       "invalid_request"
+       (format nil "OAuth parameter ~a is required" name)))
+    value))
+
+(defun oauth-scope-list (value)
+  (unless (non-empty-string-p value)
+    (star.auth::signal-oauth-error
+     "invalid_scope"
+     "At least one OAuth scope is required"))
+  (let ((scopes
+          (remove-if
+           (lambda (scope) (zerop (length scope)))
+           (cl-ppcre:split "[[:space:]]+" value))))
+    (unless scopes
+      (star.auth::signal-oauth-error
+       "invalid_scope"
+       "At least one OAuth scope is required"))
+    (star.auth::normalize-oauth-scopes scopes)))
+
+(defun oauth-valid-s256-challenge-p (challenge method)
+  (and (stringp method)
+       (string= method "S256")
+       (stringp challenge)
+       (= 43 (length challenge))
+       (every (lambda (character)
+                (or (alphanumericp character)
+                    (find character "-_")))
+              challenge)))
+
+(defun oauth-provider-authorization-request
+    (params &key (store star.auth:*credential-store*))
+  "Validate an OAuth authorization request before any user authentication.
+
+The returned plist contains only normalized protocol state and can be passed to
+OAUTH-PROVIDER-AUTHORIZE after the user authenticates."
+  (let* ((response-type (oauth-param params "response_type" t))
+         (client-id (oauth-param params "client_id" t))
+         (redirect-uri (oauth-param params "redirect_uri" t))
+         (scope-value (oauth-param params "scope" t))
+         (state (oauth-param params "state" nil))
+         (challenge (oauth-param params "code_challenge" t))
+         (method (oauth-param params "code_challenge_method" t))
+         (client (star.auth::active-oauth-client client-id store))
+         (scopes (oauth-scope-list scope-value)))
+    (unless (string= response-type "code")
+      (star.auth::signal-oauth-error
+       "unsupported_response_type"
+       "Only OAuth authorization-code response type is supported"))
+    (unless (member redirect-uri
+                    (star.auth:oauth-client-record-redirect-uris client)
+                    :test #'string=)
+      (star.auth::signal-oauth-error
+       "invalid_redirect_uri"
+       "OAuth redirect URI is invalid"))
+    (unless (star.auth::scopes-subset-p
+             scopes
+             (star.auth:oauth-client-record-allowed-scopes client))
+      (star.auth::signal-oauth-error
+       "invalid_scope"
+       "Requested OAuth scope is not permitted"))
+    (unless (oauth-valid-s256-challenge-p challenge method)
+      (star.auth::signal-oauth-error
+       "invalid_request"
+       "PKCE S256 is required"))
+    (list :client-id client-id
+          :redirect-uri redirect-uri
+          :scopes scopes
+          :state state
+          :code-challenge challenge
+          :code-challenge-method "S256")))
+
+(defun oauth-percent-encode (value)
+  (let ((octets (babel:string-to-octets (or value "") :encoding :utf-8))
+        (digits "0123456789ABCDEF"))
+    (with-output-to-string (stream)
+      (loop for byte across octets
+            for character = (and (< byte 128) (code-char byte))
+            do (if (and character
+                        (or (alphanumericp character)
+                            (find character "-._~")))
+                   (write-char character stream)
+                   (progn
+                     (write-char #\% stream)
+                     (write-char (char digits (ldb (byte 4 4) byte)) stream)
+                     (write-char (char digits (ldb (byte 4 0) byte)) stream)))))))
+
+(defun oauth-redirect-location (redirect-uri raw-code state)
+  (format nil "~a~:[?~;&~]code=~a~@[&state=~a~]"
+          redirect-uri
+          (not (null (position #\? redirect-uri)))
+          (oauth-percent-encode raw-code)
+          (and state (oauth-percent-encode state))))
+
+(defun oauth-provider-authorize
+    (request username password &key (store star.auth:*credential-store*))
+  "Authenticate an existing StarIntel user and issue a one-time OAuth code.
+
+This path intentionally calls AUTHENTICATE-USER-PASSWORD directly and never
+creates an API key or a second user identity."
+  (let ((user
+          (handler-case
+              (star.auth:authenticate-user-password
+               username password :store store)
+            (star.auth:authentication-error ()
+              (star.auth::signal-oauth-error
+               "access_denied"
+               "OAuth authorization was denied")))))
+    (multiple-value-bind (record raw-code)
+        (star.auth:issue-oauth-authorization-code
+         (getf request :client-id)
+         (getf request :redirect-uri)
+         (star.auth:user-record-username user)
+         (getf request :scopes)
+         (getf request :code-challenge)
+         (getf request :code-challenge-method)
+         :store store)
+      (declare (ignore record))
+      (oauth-redirect-location
+       (getf request :redirect-uri)
+       raw-code
+       (getf request :state)))))
+
+(defun oauth-provider-token-exchange
+    (params &key (store star.auth:*credential-store*))
+  "Exchange one authorization code for one short-lived opaque bearer token."
+  (let ((grant-type (oauth-param params "grant_type" t)))
+    (unless (string= grant-type "authorization_code")
+      (star.auth::signal-oauth-error
+       "unsupported_grant_type"
+       "Only authorization_code grant type is supported"))
+    (let ((raw-code (oauth-param params "code" t))
+          (client-id (oauth-param params "client_id" t))
+          (client-secret (oauth-param params "client_secret" t))
+          (redirect-uri (oauth-param params "redirect_uri" t))
+          (code-verifier (oauth-param params "code_verifier" t)))
+      (multiple-value-bind (record raw-token)
+          (star.auth:exchange-oauth-authorization-code
+           raw-code
+           client-id
+           client-secret
+           redirect-uri
+           code-verifier
+           :store store)
+        (values
+         (jsown:to-json
+          (jsown:new-js
+            ("access_token" raw-token)
+            ("token_type" "Bearer")
+            ("expires_in" star:*oauth-access-token-seconds*)
+            ("scope"
+             (format nil "~{~a~^ ~}"
+                     (star.auth:oauth-access-token-record-scopes record)))))
+         (list :cache-control "no-store"
+               :pragma "no-cache"))))))
+
+(defun oauth-error-status (code)
+  (cond
+    ((string= code "invalid_client") 401)
+    ((string= code "access_denied") 403)
+    (t 400)))
+
+(defun oauth-error-body (condition)
+  (jsown:to-json
+   (jsown:new-js
+     ("error" (star.auth:oauth-error-code condition))
+     ("error_description" (star.auth:oauth-error-message condition)))))
+
+(defun set-oauth-response-headers (&rest headers)
+  (setf (lack.response:response-headers *response*)
+        (append (lack.response:response-headers *response*) headers)))
+
+(defun oauth-html-escape (value)
+  (with-output-to-string (stream)
+    (loop for character across (or value "")
+          do (case character
+               (#\& (write-string "&amp;" stream))
+               (#\< (write-string "&lt;" stream))
+               (#\> (write-string "&gt;" stream))
+               (#\" (write-string "&quot;" stream))
+               (#\' (write-string "&#39;" stream))
+               (otherwise (write-char character stream))))))
+
+(defun oauth-hidden-input (name value)
+  (format nil "<input type=\"hidden\" name=\"~a\" value=\"~a\">"
+          (oauth-html-escape name)
+          (oauth-html-escape value)))
+
+(defun oauth-authorization-form (request)
+  (let ((scope-text (format nil "~{~a~^ ~}" (getf request :scopes))))
+    (format nil
+            "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Authorize StarIntel</title></head><body><main><h1>Authorize StarIntel</h1><p>Requested scopes: <code>~a</code></p><form method=\"post\" action=\"/oauth/authorize\">~a~a~a~a~a~a<label>Username <input name=\"username\" autocomplete=\"username\" required></label><label>Password <input type=\"password\" name=\"password\" autocomplete=\"current-password\" required></label><button type=\"submit\">Authorize</button></form></main></body></html>"
+            (oauth-html-escape scope-text)
+            (oauth-hidden-input "response_type" "code")
+            (oauth-hidden-input "client_id" (getf request :client-id))
+            (oauth-hidden-input "redirect_uri" (getf request :redirect-uri))
+            (oauth-hidden-input "scope" scope-text)
+            (oauth-hidden-input "state" (or (getf request :state) ""))
+            (concatenate
+             'string
+             (oauth-hidden-input "code_challenge" (getf request :code-challenge))
+             (oauth-hidden-input "code_challenge_method" "S256")))))
+
+(defun handle-oauth-authorize-get (params)
+  (handler-case
+      (let ((request (oauth-provider-authorization-request params)))
+        (set-oauth-response-headers
+         :content-type "text/html; charset=utf-8"
+         :cache-control "no-store"
+         :pragma "no-cache"
+         :content-security-policy "default-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'")
+        (oauth-authorization-form request))
+    (star.auth:oauth-error (condition)
+      (setf (lack.response:response-status *response*)
+            (oauth-error-status (star.auth:oauth-error-code condition)))
+      (set-oauth-response-headers
+       :content-type "application/json"
+       :cache-control "no-store"
+       :pragma "no-cache")
+      (oauth-error-body condition))))
+
+(defun handle-oauth-authorize-post (params)
+  (handler-case
+      (let* ((request (oauth-provider-authorization-request params))
+             (username (oauth-param params "username" t))
+             (password (oauth-param params "password" t))
+             (location
+               (oauth-provider-authorize request username password)))
+        (setf (lack.response:response-status *response*) 302)
+        (set-oauth-response-headers
+         :location location
+         :cache-control "no-store"
+         :pragma "no-cache")
+        "")
+    (star.auth:oauth-error (condition)
+      (setf (lack.response:response-status *response*)
+            (oauth-error-status (star.auth:oauth-error-code condition)))
+      (set-oauth-response-headers
+       :content-type "application/json"
+       :cache-control "no-store"
+       :pragma "no-cache")
+      (oauth-error-body condition))))
+
+(defun handle-oauth-token-post (params)
+  (handler-case
+      (multiple-value-bind (body headers)
+          (oauth-provider-token-exchange params)
+        (set-oauth-response-headers
+         :content-type "application/json"
+         :cache-control (getf headers :cache-control)
+         :pragma (getf headers :pragma))
+        body)
+    (star.auth:oauth-error (condition)
+      (setf (lack.response:response-status *response*)
+            (oauth-error-status (star.auth:oauth-error-code condition)))
+      (set-oauth-response-headers
+       :content-type "application/json"
+       :cache-control "no-store"
+       :pragma "no-cache")
+      (oauth-error-body condition))))
+
+(setf (ningle:route *app* "/oauth/authorize" :method :get)
+      #'handle-oauth-authorize-get)
+
+(setf (ningle:route *app* "/oauth/authorize" :method :post)
+      #'handle-oauth-authorize-post)
+
+(setf (ningle:route *app* "/oauth/token" :method :post)
+      #'handle-oauth-token-post)

--- a/source/frontends/http-oauth-provider.lisp
+++ b/source/frontends/http-oauth-provider.lisp
@@ -17,7 +17,7 @@
   (let ((scopes
           (remove-if
            (lambda (scope) (zerop (length scope)))
-           (cl-ppcre:split "[[:space:]]+" value))))
+           (cl-ppcre:split "\\s+" value))))
     (unless scopes
       (star.auth::signal-oauth-error
        "invalid_scope"

--- a/source/gserver-settings.lisp
+++ b/source/gserver-settings.lisp
@@ -130,7 +130,8 @@ STAR_PUBLIC_MODE=false before init loads) for authenticated-only deployments.")
   (environment-integer "STAR_AUTH_LOGIN_SESSION_SECONDS" 86400))
 
 (defparameter *auth-public-paths*
-  '("/health" "/" "/auth/bootstrap" "/auth/login"))
+  '("/health" "/" "/auth/bootstrap" "/auth/login"
+    "/oauth/authorize" "/oauth/token"))
 
 ;;;; RabbitMQ
 (defparameter *rabbit-address*

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -53,6 +53,7 @@
    (:file "authorization/policy")
    (:file "authorization/quota-policy")
    (:file "authorization/services")
+   (:file "addons")
    (:file "init-loader")
    (:file "actors")
    (:file "actors/couchdb-service")

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -71,6 +71,7 @@
    (:file "frontends/http-boundary-core")
    (:file "frontends/http-capabilities")
    (:file "frontends/http-auth")
+   (:file "frontends/http-oauth-provider")
    (:file "frontends/http-authorization")
    (:file "frontends/http-bulk-jobs")
    (:file "frontends/http-boundary-routes")

--- a/starintel-bixby.asd
+++ b/starintel-bixby.asd
@@ -1,0 +1,13 @@
+(asdf:defsystem :starintel-bixby
+  :version "0.1.0"
+  :description "Optional Samsung Bixby integration package for StarIntel Server."
+  :author "nsaspy@airmail.cc"
+  :license "GPL-3.0-or-later"
+  :serial t
+  :depends-on (#:starintel-gserver)
+  :components
+  ((:module "addons/bixby"
+    :serial t
+    :components
+    ((:file "package")
+     (:file "bixby")))))

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -6,6 +6,7 @@
   :serial t
   :depends-on
   (#:starintel-gserver
+   #:starintel-bixby
    #:starintel-gserver-client
    #:star-cli
    #:star-ui

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -38,6 +38,7 @@
      (:file "oauth-authorization-code-test")
      (:file "oauth-http-bearer-test")
      (:file "oauth-http-provider-test")
+     (:file "addon-system-test")
      (:file "http-auth-oracle-test")
      (:file "http-auth-immutability-test")
      (:file "authorization-policy-test")

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -37,6 +37,7 @@
      (:file "auth-users-test")
      (:file "oauth-authorization-code-test")
      (:file "oauth-http-bearer-test")
+     (:file "oauth-http-provider-test")
      (:file "http-auth-oracle-test")
      (:file "http-auth-immutability-test")
      (:file "authorization-policy-test")

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -6,7 +6,6 @@
   :serial t
   :depends-on
   (#:starintel-gserver
-   #:starintel-bixby
    #:starintel-gserver-client
    #:star-cli
    #:star-ui

--- a/t/addon-system-test.lisp
+++ b/t/addon-system-test.lisp
@@ -1,0 +1,52 @@
+(in-package :star-server-tests)
+
+(def-suite addon-system-tests
+  :description "ASDF add-on lifecycle and Bixby package boundary")
+
+(in-suite addon-system-tests)
+
+(test bixby-is-an-optional-asdf-addon-over-core-oauth
+  (let ((before (star:addon-status :starintel-bixby)))
+    (when (and before
+               (eq :active (star:addon-state-status before)))
+      (star:unload-addon :starintel-bixby)))
+  (let* ((loaded (star:load-addon :starintel-bixby))
+         (generation (star:addon-state-generation loaded)))
+    (is (eq :active (star:addon-state-status loaded)))
+    (is (string= "starintel-bixby" (star:addon-state-system loaded)))
+    (star.addons.bixby:configure-bixby
+     :public-base-url "https://api.starintel.example/"
+     :redirect-uri "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+    (let ((settings (star.addons.bixby:bixby-oauth-settings)))
+      (is (string= "https://api.starintel.example/oauth/authorize"
+                   (getf settings :authorize-endpoint)))
+      (is (string= "https://api.starintel.example/oauth/token"
+                   (getf settings :token-endpoint)))
+      (is (equal '("documents:read" "search:read")
+                 (getf settings :read-scopes))))
+    (let ((reloaded (star:reload-addon :starintel-bixby)))
+      (is (eq :active (star:addon-state-status reloaded)))
+      (is (> (star:addon-state-generation reloaded) generation)))
+    (let ((stopped (star:unload-addon :starintel-bixby)))
+      (is (eq :stopped (star:addon-state-status stopped))))))
+
+(test bixby-client-registration-uses-standard-oauth-client-store
+  (let* ((star:*auth-pepper* "bixby-addon-test-pepper")
+         (store (make-oauth-test-world)))
+    (star:load-addon :starintel-bixby)
+    (star.addons.bixby:configure-bixby
+     :public-base-url "https://api.starintel.example"
+     :redirect-uri "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb"
+     :read-scopes '("documents:read" "search:read")
+     :operations-scopes '("targets:dispatch"))
+    (multiple-value-bind (client secret)
+        (star.addons.bixby:create-bixby-oauth-client
+         :include-operations t
+         :store store)
+      (is (plusp (length secret)))
+      (is (equal '("documents:read" "search:read" "targets:dispatch")
+                 (star.auth:oauth-client-record-allowed-scopes client)))
+      (is (equal
+           '("https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+           (star.auth:oauth-client-record-redirect-uris client))))
+    (star:unload-addon :starintel-bixby)))

--- a/t/addon-system-test.lisp
+++ b/t/addon-system-test.lisp
@@ -16,6 +16,14 @@
              (or (star:addon-error-cause condition)
                  condition)))))
 
+(defun reload-bixby-addon-or-report-cause ()
+  (handler-case
+      (star:reload-addon :starintel-bixby)
+    (star:addon-error (condition)
+      (error "Bixby add-on reload failed: ~a"
+             (or (star:addon-error-cause condition)
+                 condition)))))
+
 (test bixby-is-an-optional-asdf-addon-over-core-oauth
   (let ((before (star:addon-status :starintel-bixby)))
     (when (and before
@@ -36,7 +44,7 @@
                    (getf settings :token-endpoint)))
       (is (equal '("documents:read" "search:read")
                  (getf settings :read-scopes))))
-    (let ((reloaded (star:reload-addon :starintel-bixby)))
+    (let ((reloaded (reload-bixby-addon-or-report-cause)))
       (is (eq :active (star:addon-state-status reloaded)))
       (is (> (star:addon-state-generation reloaded) generation)))
     (let ((settings-after-reload (call-bixby :bixby-oauth-settings)))

--- a/t/addon-system-test.lisp
+++ b/t/addon-system-test.lisp
@@ -31,6 +31,11 @@
     (let ((reloaded (star:reload-addon :starintel-bixby)))
       (is (eq :active (star:addon-state-status reloaded)))
       (is (> (star:addon-state-generation reloaded) generation)))
+    (let ((settings-after-reload (call-bixby :bixby-oauth-settings)))
+      (is (string= "https://api.starintel.example/oauth/authorize"
+                   (getf settings-after-reload :authorize-endpoint)))
+      (is (string= "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb"
+                   (getf settings-after-reload :redirect-uri))))
     (let ((stopped (star:unload-addon :starintel-bixby)))
       (is (eq :stopped (star:addon-state-status stopped))))))
 

--- a/t/addon-system-test.lisp
+++ b/t/addon-system-test.lisp
@@ -8,12 +8,20 @@
 (defun call-bixby (name &rest arguments)
   (apply #'uiop:symbol-call :star.addons.bixby name arguments))
 
+(defun load-bixby-addon-or-report-cause ()
+  (handler-case
+      (star:load-addon :starintel-bixby)
+    (star:addon-error (condition)
+      (error "Bixby add-on load failed: ~a"
+             (or (star:addon-error-cause condition)
+                 condition)))))
+
 (test bixby-is-an-optional-asdf-addon-over-core-oauth
   (let ((before (star:addon-status :starintel-bixby)))
     (when (and before
                (eq :active (star:addon-state-status before)))
       (star:unload-addon :starintel-bixby)))
-  (let* ((loaded (star:load-addon :starintel-bixby))
+  (let* ((loaded (load-bixby-addon-or-report-cause))
          (generation (star:addon-state-generation loaded)))
     (is (eq :active (star:addon-state-status loaded)))
     (is (string= "starintel-bixby" (star:addon-state-system loaded)))
@@ -42,7 +50,7 @@
 (test bixby-client-registration-uses-standard-oauth-client-store
   (let* ((star:*auth-pepper* "bixby-addon-test-pepper")
          (store (make-oauth-test-world)))
-    (star:load-addon :starintel-bixby)
+    (load-bixby-addon-or-report-cause)
     (call-bixby
      :configure-bixby
      :public-base-url "https://api.starintel.example"

--- a/t/addon-system-test.lisp
+++ b/t/addon-system-test.lisp
@@ -5,6 +5,9 @@
 
 (in-suite addon-system-tests)
 
+(defun call-bixby (name &rest arguments)
+  (apply #'uiop:symbol-call :star.addons.bixby name arguments))
+
 (test bixby-is-an-optional-asdf-addon-over-core-oauth
   (let ((before (star:addon-status :starintel-bixby)))
     (when (and before
@@ -14,10 +17,11 @@
          (generation (star:addon-state-generation loaded)))
     (is (eq :active (star:addon-state-status loaded)))
     (is (string= "starintel-bixby" (star:addon-state-system loaded)))
-    (star.addons.bixby:configure-bixby
+    (call-bixby
+     :configure-bixby
      :public-base-url "https://api.starintel.example/"
      :redirect-uri "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
-    (let ((settings (star.addons.bixby:bixby-oauth-settings)))
+    (let ((settings (call-bixby :bixby-oauth-settings)))
       (is (string= "https://api.starintel.example/oauth/authorize"
                    (getf settings :authorize-endpoint)))
       (is (string= "https://api.starintel.example/oauth/token"
@@ -34,13 +38,15 @@
   (let* ((star:*auth-pepper* "bixby-addon-test-pepper")
          (store (make-oauth-test-world)))
     (star:load-addon :starintel-bixby)
-    (star.addons.bixby:configure-bixby
+    (call-bixby
+     :configure-bixby
      :public-base-url "https://api.starintel.example"
      :redirect-uri "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb"
      :read-scopes '("documents:read" "search:read")
      :operations-scopes '("targets:dispatch"))
     (multiple-value-bind (client secret)
-        (star.addons.bixby:create-bixby-oauth-client
+        (call-bixby
+         :create-bixby-oauth-client
          :include-operations t
          :store store)
       (is (plusp (length secret)))

--- a/t/oauth-http-provider-test.lisp
+++ b/t/oauth-http-provider-test.lisp
@@ -1,0 +1,281 @@
+(in-package :star-server-tests)
+
+(in-suite oauth-authorization-code-tests)
+
+(defun provider-params (&rest pairs)
+  (loop for (key value) on pairs by #'cddr
+        collect (cons key value)))
+
+(test oauth-provider-routes-are-public-but-protocol-validates-clients
+  (is (member "/oauth/authorize" star:*auth-public-paths* :test #'string=))
+  (is (member "/oauth/token" star:*auth-public-paths* :test #'string=)))
+
+(test oauth-provider-validates-authorization-request-before-login
+  (let* ((star:*auth-pepper* "oauth-provider-test-pepper")
+         (store (make-oauth-test-world))
+         (redirect "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+         (challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"))
+    (multiple-value-bind (client secret)
+        (star.auth:create-oauth-client
+         (list redirect)
+         '("documents:read" "search:read")
+         :store store)
+      (declare (ignore secret))
+      (let* ((client-id (star.auth:oauth-client-record-id client))
+             (request
+               (star.frontends.http-api::oauth-provider-authorization-request
+                (provider-params
+                 "response_type" "code"
+                 "client_id" client-id
+                 "redirect_uri" redirect
+                 "scope" "documents:read search:read"
+                 "state" "state value"
+                 "code_challenge" challenge
+                 "code_challenge_method" "S256")
+                :store store)))
+        (is (string= client-id (getf request :client-id)))
+        (is (string= redirect (getf request :redirect-uri)))
+        (is (equal '("documents:read" "search:read") (getf request :scopes)))
+        (is (string= "state value" (getf request :state)))))))
+
+(test oauth-provider-rejects-open-redirect-and-pkce-downgrade-before-user-auth
+  (let* ((star:*auth-pepper* "oauth-provider-test-pepper")
+         (store (make-oauth-test-world))
+         (redirect "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+         (challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"))
+    (multiple-value-bind (client secret)
+        (star.auth:create-oauth-client (list redirect) '("documents:read") :store store)
+      (declare (ignore secret))
+      (let ((client-id (star.auth:oauth-client-record-id client)))
+        (is (string= "invalid_redirect_uri"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-authorization-request
+                         (provider-params
+                          "response_type" "code"
+                          "client_id" client-id
+                          "redirect_uri" "https://evil.example/cb"
+                          "scope" "documents:read"
+                          "state" "opaque"
+                          "code_challenge" challenge
+                          "code_challenge_method" "S256")
+                         :store store)))))
+        (is (string= "invalid_request"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-authorization-request
+                         (provider-params
+                          "response_type" "code"
+                          "client_id" client-id
+                          "redirect_uri" redirect
+                          "scope" "documents:read"
+                          "state" "opaque"
+                          "code_challenge" challenge
+                          "code_challenge_method" "plain")
+                         :store store)))))))))
+
+(test oauth-provider-rejects-response-type-and-scope-escalation-before-login
+  (let* ((star:*auth-pepper* "oauth-provider-test-pepper")
+         (store (make-oauth-test-world))
+         (redirect "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+         (challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"))
+    (multiple-value-bind (client secret)
+        (star.auth:create-oauth-client (list redirect) '("documents:read") :store store)
+      (declare (ignore secret))
+      (let ((client-id (star.auth:oauth-client-record-id client)))
+        (is (string= "unsupported_response_type"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-authorization-request
+                         (provider-params
+                          "response_type" "token"
+                          "client_id" client-id
+                          "redirect_uri" redirect
+                          "scope" "documents:read"
+                          "state" "opaque"
+                          "code_challenge" challenge
+                          "code_challenge_method" "S256")
+                         :store store)))))
+        (is (string= "invalid_scope"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-authorization-request
+                         (provider-params
+                          "response_type" "code"
+                          "client_id" client-id
+                          "redirect_uri" redirect
+                          "scope" "documents:read targets:dispatch"
+                          "state" "opaque"
+                          "code_challenge" challenge
+                          "code_challenge_method" "S256")
+                         :store store)))))))))
+
+(test oauth-provider-authorization-authenticates-existing-user-and-preserves-state
+  (let* ((star:*auth-pepper* "oauth-provider-test-pepper")
+         (store (make-oauth-test-world))
+         (redirect "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+         (challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"))
+    (multiple-value-bind (client secret)
+        (star.auth:create-oauth-client (list redirect) '("documents:read") :store store)
+      (declare (ignore secret))
+      (let* ((request
+               (star.frontends.http-api::oauth-provider-authorization-request
+                (provider-params
+                 "response_type" "code"
+                 "client_id" (star.auth:oauth-client-record-id client)
+                 "redirect_uri" redirect
+                 "scope" "documents:read"
+                 "state" "state value"
+                 "code_challenge" challenge
+                 "code_challenge_method" "S256")
+                :store store))
+             (location
+               (star.frontends.http-api::oauth-provider-authorize
+                request
+                "alice"
+                "correct-horse-battery-staple"
+                :store store)))
+        (is (search (concatenate 'string redirect "?code=") location))
+        (is (search "state=state%20value" location))
+        (is (null (search "correct-horse-battery-staple" location)))))))
+
+(test oauth-provider-wrong-password-fails-closed-without-secret-reflection
+  (let* ((star:*auth-pepper* "oauth-provider-test-pepper")
+         (store (make-oauth-test-world))
+         (redirect "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+         (challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"))
+    (multiple-value-bind (client secret)
+        (star.auth:create-oauth-client (list redirect) '("documents:read") :store store)
+      (declare (ignore secret))
+      (let ((request
+              (star.frontends.http-api::oauth-provider-authorization-request
+               (provider-params
+                "response_type" "code"
+                "client_id" (star.auth:oauth-client-record-id client)
+                "redirect_uri" redirect
+                "scope" "documents:read"
+                "state" "opaque"
+                "code_challenge" challenge
+                "code_challenge_method" "S256")
+               :store store)))
+        (is (string= "access_denied"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-authorize
+                         request "alice" "definitely-wrong-password"
+                         :store store)))))
+        (handler-case
+            (star.frontends.http-api::oauth-provider-authorize
+             request "alice" "definitely-wrong-password" :store store)
+          (star.auth:oauth-error (condition)
+            (is (null (search "definitely-wrong-password"
+                              (princ-to-string condition)))))))))))
+
+(test oauth-provider-token-exchange-is-no-store-bearer-json-and-one-time
+  (let* ((star:*auth-pepper* "oauth-provider-test-pepper")
+         (star.auth:*auth-clock* (lambda () 1000000))
+         (store (make-oauth-test-world))
+         (redirect "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+         (verifier "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+         (challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"))
+    (multiple-value-bind (client client-secret)
+        (star.auth:create-oauth-client (list redirect) '("documents:read") :store store)
+      (multiple-value-bind (code raw-code)
+          (star.auth:issue-oauth-authorization-code
+           (star.auth:oauth-client-record-id client)
+           redirect "alice" '("documents:read") challenge "S256" :store store)
+        (declare (ignore code))
+        (multiple-value-bind (body headers)
+            (star.frontends.http-api::oauth-provider-token-exchange
+             (provider-params
+              "grant_type" "authorization_code"
+              "code" raw-code
+              "client_id" (star.auth:oauth-client-record-id client)
+              "client_secret" client-secret
+              "redirect_uri" redirect
+              "code_verifier" verifier)
+             :store store)
+          (let ((json (jsown:parse body)))
+            (is (string= "Bearer" (jsown:val json "token_type")))
+            (is (search "star_at_v1_" (jsown:val json "access_token")))
+            (is (= star:*oauth-access-token-seconds* (jsown:val json "expires_in"))))
+          (is (string= "no-store" (getf headers :cache-control)))
+          (is (string= "no-cache" (getf headers :pragma)))
+          (is (null (search client-secret body)))
+          (is (string= "invalid_grant"
+                       (captured-oauth-code
+                        (lambda ()
+                          (star.frontends.http-api::oauth-provider-token-exchange
+                           (provider-params
+                            "grant_type" "authorization_code"
+                            "code" raw-code
+                            "client_id" (star.auth:oauth-client-record-id client)
+                            "client_secret" client-secret
+                            "redirect_uri" redirect
+                            "code_verifier" verifier)
+                           :store store))))))))))
+
+(test oauth-provider-token-endpoint-rejects-client-redirect-pkce-and-grant-substitution
+  (let* ((star:*auth-pepper* "oauth-provider-test-pepper")
+         (star.auth:*auth-clock* (lambda () 1000000))
+         (store (make-oauth-test-world))
+         (redirect "https://playground-starIntelIntelligence.oauth.aibixby.com/auth/external/cb")
+         (verifier "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+         (challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"))
+    (multiple-value-bind (client client-secret)
+        (star.auth:create-oauth-client (list redirect) '("documents:read") :store store)
+      (flet ((new-code ()
+               (nth-value
+                1
+                (star.auth:issue-oauth-authorization-code
+                 (star.auth:oauth-client-record-id client)
+                 redirect "alice" '("documents:read") challenge "S256"
+                 :store store))))
+        (is (string= "unsupported_grant_type"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-token-exchange
+                         (provider-params
+                          "grant_type" "client_credentials"
+                          "code" (new-code)
+                          "client_id" (star.auth:oauth-client-record-id client)
+                          "client_secret" client-secret
+                          "redirect_uri" redirect
+                          "code_verifier" verifier)
+                         :store store)))))
+        (is (string= "invalid_client"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-token-exchange
+                         (provider-params
+                          "grant_type" "authorization_code"
+                          "code" (new-code)
+                          "client_id" (star.auth:oauth-client-record-id client)
+                          "client_secret" "wrong-secret"
+                          "redirect_uri" redirect
+                          "code_verifier" verifier)
+                         :store store)))))
+        (is (string= "invalid_grant"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-token-exchange
+                         (provider-params
+                          "grant_type" "authorization_code"
+                          "code" (new-code)
+                          "client_id" (star.auth:oauth-client-record-id client)
+                          "client_secret" client-secret
+                          "redirect_uri" "https://evil.example/cb"
+                          "code_verifier" verifier)
+                         :store store)))))
+        (is (string= "invalid_grant"
+                     (captured-oauth-code
+                      (lambda ()
+                        (star.frontends.http-api::oauth-provider-token-exchange
+                         (provider-params
+                          "grant_type" "authorization_code"
+                          "code" (new-code)
+                          "client_id" (star.auth:oauth-client-record-id client)
+                          "client_secret" client-secret
+                          "redirect_uri" redirect
+                          "code_verifier" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                         :store store)))))))))

--- a/t/oauth-http-provider-test.lisp
+++ b/t/oauth-http-provider-test.lisp
@@ -169,7 +169,7 @@
              request "alice" "definitely-wrong-password" :store store)
           (star.auth:oauth-error (condition)
             (is (null (search "definitely-wrong-password"
-                              (princ-to-string condition)))))))))))
+                              (princ-to-string condition))))))))))
 
 (test oauth-provider-token-exchange-is-no-store-bearer-json-and-one-time
   (let* ((star:*auth-pepper* "oauth-provider-test-pepper")

--- a/t/run-tests.lisp
+++ b/t/run-tests.lisp
@@ -16,6 +16,7 @@
     http-auth-tests
     auth-users-tests
     oauth-authorization-code-tests
+    addon-system-tests
     authorization-policy-tests
     gserver-client-tests
     runtime-lifecycle-tests))


### PR DESCRIPTION
Continues #111 from current `master` after closing stale PR #117.

Architecture boundary:
- OAuth 2 authorization-code provider is a standard built-in StarIntel Server capability.
- Samsung/Bixby-specific configuration is an optional Common Lisp ASDF add-on consuming the core OAuth/authz APIs.
- Bixby does not own a second token, scope, identity, or authorization system.

This candidate adds:
- public `/oauth/authorize` and `/oauth/token` protocol paths;
- strict exact redirect validation, requested-scope subset checks, S256 PKCE, state preservation, existing-user password authentication, one-time code exchange, bearer JSON, and no-store/no-cache responses;
- a generic ASDF add-on registry with explicit start/stop lifecycle and reload rollback at the hook boundary;
- optional `starintel-bixby` system with init-file configuration and explicit core OAuth client registration;
- regression tests for the OAuth provider contract and add-on loading/reloading/client-registration boundary.

No Samsung/Bixby-specific auth semantics are added to core OAuth. Add-on loading remains trusted operator code, like `init.lisp`; it is a packaging/lifecycle boundary, not a sandbox.