### PR TITLE
feat: enforce canonical StarIntel v0.9 runtime boundaries

### DIFF
--- a/docs/document-spec.org
+++ b/docs/document-spec.org
@@ -10,10 +10,10 @@ StarIntel Server currently sits between two document generations:
 2. *Legacy flat 0.8.0*: Common Lisp classes and constructors still used by parts
    of this server and its actor examples.
 
-The server reports the =star-cl= document version from =GET /=, but the HTTP and
-RabbitMQ ingest handlers do not currently call the strict 0.9 validator. A
-=document= with a non-empty =dtype= can reach CouchDB even when it does not
-conform to 0.9.
+The server reports the =star-cl= document version from =GET /=. Canonical HTTP
+document, bulk, and update boundaries and RabbitMQ ingest/update consumers call
+the strict 0.9 validator before mutation. The historical target adapter is the
+only document ingress exception and is explicitly non-strict.
 
 ** StarIntel 0.9 envelope
 

--- a/docs/http-api-docs.org
+++ b/docs/http-api-docs.org
@@ -104,8 +104,17 @@ compatibility while they are migrated.
 | GET | =/targets/:actor= | Read persisted targets for an actor |
 | GET | =/search= | Full-text search |
 
-Document write routes validate bounded JSON input, required StarIntel document
-fields, and the supported document schema version before dispatch.
+Canonical document write routes validate bounded JSON input, required StarIntel
+document fields, the supported document schema version, and the canonical
+StarIntel 0.9 schema before dispatch. =PUT /document/:id= authorizes against
+the current document, deep-merges the patch, validates the merged candidate,
+and only then persists it. Invalid candidates return =422
+invalid_document_schema= and do not invoke persistence.
+
+The historical =POST /new/target/:actor= adapter is the exception. It retains
+transport identity checks, skips strict schema validation, and publishes
+directly to =documents.new.target.<actor>= so legacy target envelopes do not
+enter canonical ingest.
 
 * View query routes
 

--- a/docs/messaging.org
+++ b/docs/messaging.org
@@ -24,6 +24,13 @@ The target wildcard currently equals =documents.new.target.#=. A normal target
 is published to =documents.ingest.target=, persisted, republished as
 =documents.new.target=, then consumed by the target router.
 
+The legacy =POST /new/target/:actor= adapter is intentionally narrower: it
+skips strict document-schema validation and publishes directly to
+=documents.new.target.<actor>=. This keeps legacy target envelopes away from
+canonical ingest while preserving the target consumer's durable acceptance and
+dispatch handling. New canonical target producers should use
+=documents.ingest.target=.
+
 ** Events exchange
 
 Actor events can also enter through a separate exchange and queue:

--- a/docs/v09-runtime.org
+++ b/docs/v09-runtime.org
@@ -1,0 +1,41 @@
+#+title: StarIntel v0.9 runtime boundary
+#+options: toc:2
+
+* Canonical mutation boundaries
+
+The following mutation paths validate a complete document with the canonical
+=star-cl= v0.9 validator before persistence or publication:
+
+- =POST /new/document/:dtype=
+- =POST /documents/bulk=
+- =PUT /document/:id=
+- RabbitMQ =documents.ingest.#=
+- RabbitMQ =documents.update.#=
+
+The schema revision is =schema_version="0.9.0"=. The independent document
+revision is the integer =version= field. A missing or unsupported schema version
+is rejected as =422 schema_version_required= or =422
+unsupported_schema_version=; a structurally invalid canonical document is
+=422 invalid_document_schema=.
+
+* Target compatibility
+
+=POST /new/target/:actor= and the target RabbitMQ consumer are explicit legacy
+compatibility adapters. They retain transport identity checks but skip strict
+schema validation. The HTTP adapter publishes directly to
+=documents.new.target.<actor>=, so a legacy target cannot enter the canonical
+ingest queue accidentally. The target consumer still performs its normal
+durable acceptance and dispatch processing.
+
+* Update ordering
+
+HTTP updates deep-merge the patch with the current document, preserve CouchDB
+revision and server-owned outbox fields, validate the merged candidate, and
+only then call the CouchDB save function. Validation failures do not invoke the
+save function. The route requires =documents:write= and authorizes the current
+document before the upsert.
+
+* Dependency lock
+
+The server's Nix and QLot locks converge on canonical =star-cl= revision
+=b8dfbe2f9f56065ace8c3313b92ca748a115cdfa=.

--- a/flake.lock
+++ b/flake.lock
@@ -30,7 +30,7 @@
       },
       "locked": {
         "lastModified": 1786244418,
-        "narHash": "sha256-0E7FePwBhT5QqRGa29m4OnNhXgsEaSwbEXwkh+kgsx8=",
+        "narHash": "sha256-WO/qeIgw7nvRDYeM21Iuwb5HUGttVPMOXj69Ghfmlj4=",
         "owner": "lost-rob0t",
         "repo": "star-cl",
         "rev": "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa",

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769361023,
-        "narHash": "sha256-CJMDv+FVsrSTIolKxOS7DIRrPxI70uE/YRvoDBtucAY=",
+        "lastModified": 1786244418,
+        "narHash": "sha256-0E7FePwBhT5QqRGa29m4OnNhXgsEaSwbEXwkh+kgsx8=",
         "owner": "lost-rob0t",
         "repo": "star-cl",
-        "rev": "36c88aabcbe43a02c189e5b7704a1f063461c888",
+        "rev": "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa",
         "type": "github"
       },
       "original": {

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -65,7 +65,7 @@
 ("star-cl" .
  (:class qlot/source/github:source-github
   :initargs (:repos "lost-rob0t/star-cl" :ref nil :branch nil :tag nil)
-  :version "github-4065d8689ad118dc93fc95688ca1bf63973e3c0d"))
+  :version "github-b8dfbe2f9f56065ace8c3313b92ca748a115cdfa"))
 ("cl-couch" .
  (:class qlot/source/github:source-github
   :initargs (:repos "lost-rob0t/cl-couch" :ref nil :branch nil :tag nil)

--- a/source/authorization/package.lisp
+++ b/source/authorization/package.lisp
@@ -53,6 +53,7 @@
    #:authorize-document!
    #:authorized-fetch-document
    #:authorized-delete-document
+   #:authorized-update-document
    #:authorized-publish-document
    #:authorize-bulk-documents!
    #:authorized-target-documents

--- a/source/authorization/services.lisp
+++ b/source/authorization/services.lisp
@@ -45,17 +45,34 @@
     raw))
 
 (defun authorized-delete-document (document-id fetch-fn delete-fn
-                                   &key principal metadata)
+                                    &key principal metadata)
   "Fetch, authorize, and delete one document through explicit injected I/O."
   (let* ((raw (funcall fetch-fn document-id))
          (document (parse-document-value raw))
          (revision (jsown:val document "_rev")))
-    (authorize-document!
+   (authorize-document!
      "documents:delete"
      document
      :principal principal
      :metadata metadata)
     (funcall delete-fn document-id revision)))
+
+(defun authorized-update-document (document-id patch fetch-fn update-fn
+                                   &key principal metadata)
+  "Authorize an update against the current document before persistence.
+
+FETCH-FN returns the current document or NIL for an insert candidate. UPDATE-FN
+receives PATCH only after the resource decision has been made."
+  (let* ((raw (funcall fetch-fn document-id))
+         (document (parse-document-value (or raw patch)))
+         (decision
+           (authorize-document!
+            (document-action document)
+            document
+            :principal principal
+            :metadata metadata)))
+    (let ((*current-authorization-decision* decision))
+      (funcall update-fn patch))))
 
 (defun document-action (document &optional requested-action)
   (or requested-action

--- a/source/databases/document-update-package.lisp
+++ b/source/databases/document-update-package.lisp
@@ -5,8 +5,10 @@
    document-update-outcome-status
    document-update-outcome-document
    document-update-outcome-attempts
+   document-update-outcome-code
    document-update-outcome-reason
    document-update-validation-error
+   document-update-validation-code
    document-update-validation-reason
    document-update-store-conflict
    merge-document-update

--- a/source/databases/document-update.lisp
+++ b/source/databases/document-update.lisp
@@ -2,19 +2,25 @@
 
 (defstruct (document-update-outcome
              (:constructor make-document-update-outcome
-                 (status &key document attempts reason)))
+                 (status &key document attempts reason code)))
   status
   document
   (attempts 0 :type (integer 0 *))
-  reason)
+  reason
+  code)
 
 (define-condition document-update-validation-error (error)
-  ((reason
+  ((code
+    :initarg :code
+    :initform "invalid_document_update"
+    :reader document-update-validation-code)
+   (reason
     :initarg :reason
     :reader document-update-validation-reason))
   (:report
    (lambda (condition stream)
-     (format stream "Document update validation failed: ~a"
+     (format stream "Document update validation failed (~a): ~a"
+             (document-update-validation-code condition)
              (document-update-validation-reason condition)))))
 
 (define-condition document-update-store-conflict (error) ())
@@ -119,10 +125,23 @@ fields remain controlled by persistence."
 
 (defun validated-document-update (candidate)
   (handler-case
-      (star.documents:ensure-document candidate)
-    (error (condition)
+      (progn
+        ;; Validate the merged candidate before ensure-document can normalize it.
+        (star.documents:validate-v09-document candidate)
+        (star.documents:ensure-document candidate))
+    (star.documents:document-schema-validation-error (condition)
       (error 'document-update-validation-error
-             :reason (princ-to-string condition)))))
+             :code "invalid_document_schema"
+             :reason
+             (format nil "~a: ~a"
+                     (star.documents:document-schema-validation-category
+                      condition)
+                     (star.documents:document-schema-validation-reason
+                      condition))))
+    (error (condition)
+       (error 'document-update-validation-error
+              :code "invalid_document_update"
+              :reason (princ-to-string condition)))))
 
 (defun document-update-wire-equal-p (left right)
   (string= (jsown:to-json left) (jsown:to-json right)))
@@ -153,6 +172,7 @@ fields remain controlled by persistence."
    :validation-failed
    :document existing
    :attempts attempt
+   :code (document-update-validation-code condition)
    :reason (document-update-validation-reason condition)))
 
 (defun upsert-document-update
@@ -225,13 +245,15 @@ when its CouchDB revision loses a compare-and-swap race."
 
 (defun document-update-outcome-json (outcome)
   (let ((object (jsown:empty-object)))
-    (setf (jsown:val object "status")
-          (string-downcase
-           (symbol-name (document-update-outcome-status outcome)))
-          (jsown:val object "attempts")
-          (document-update-outcome-attempts outcome)
-          (jsown:val object "reason")
-          (or (document-update-outcome-reason outcome) :null)
-          (jsown:val object "document")
-          (or (document-update-outcome-document outcome) :null))
+     (setf (jsown:val object "status")
+           (string-downcase
+            (symbol-name (document-update-outcome-status outcome)))
+           (jsown:val object "attempts")
+           (document-update-outcome-attempts outcome)
+           (jsown:val object "code")
+           (or (document-update-outcome-code outcome) :null)
+           (jsown:val object "reason")
+           (or (document-update-outcome-reason outcome) :null)
+           (jsown:val object "document")
+           (or (document-update-outcome-document outcome) :null))
     object))

--- a/source/document-access-package.lisp
+++ b/source/document-access-package.lisp
@@ -1,6 +1,9 @@
 (uiop:define-package :star.documents
   (:use :cl)
   (:export
+   #:document-schema-validation-error
+   #:document-schema-validation-category
+   #:document-schema-validation-reason
    #:object-has-key-p
    #:object-value
    #:object-keys
@@ -15,6 +18,7 @@
    #:document-date-added
    #:document-date-updated
    #:document-transient-p
+   #:validate-v09-document
    #:ensure-document
    #:document-json
    #:utc-now))

--- a/source/document-access.lisp
+++ b/source/document-access.lisp
@@ -1,5 +1,21 @@
 (in-package :star.documents)
 
+(define-condition document-schema-validation-error (error)
+  ((category
+    :initarg :category
+    :reader document-schema-validation-category)
+   (reason
+    :initarg :reason
+    :reader document-schema-validation-reason))
+  (:report
+   (lambda (condition stream)
+     (format stream "StarIntel v0.9 validation failed (~a): ~a"
+             (document-schema-validation-category condition)
+             (document-schema-validation-reason condition)))))
+
+(defvar *v09-schema* nil)
+(defvar *v09-schema-lock* (bt:make-lock "starintel-v09-schema"))
+
 (defun object-has-key-p (object key)
   (and object
        (handler-case
@@ -81,11 +97,46 @@
   (let ((value (document-value document "transient" nil)))
     (or (eq value t) (eq value :true))))
 
-(defun ensure-document (document &key route-dtype)
-  "Parse DOCUMENT and enforce the transport-level identity invariants.
+(defun v09-schema-path ()
+  "Return the schema path shipped with the loaded STARINTEL ASDF system."
+  (merge-pathnames
+   "../schemas/starintel-doc-v0.9.0.schema.json"
+   (asdf:system-source-directory :starintel)))
 
-Schema validation remains owned by star-cl. This accessor only guarantees a
-JSON object, a stable _id, and a route-compatible dtype."
+(defun load-v09-schema ()
+  (let ((path (v09-schema-path)))
+    (unless (probe-file path)
+      (error "StarIntel v0.9 schema not found: ~a" path))
+    (com.inuoe.jzon:parse (pathname path))))
+
+(defun v09-schema ()
+  (or *v09-schema*
+      (bt:with-lock-held (*v09-schema-lock*)
+        (or *v09-schema*
+            (setf *v09-schema* (load-v09-schema))))))
+
+(defun validate-v09-document (document)
+  "Validate DOCUMENT with star-cl's canonical StarIntel v0.9 validator.
+
+The server owns only schema discovery, JSOWN-to-Jzon conversion, and a stable
+condition. The schema rules and validator remain owned by star-cl."
+  (let* ((object (parse-document-object document))
+         (jzon-object
+           (com.inuoe.jzon:parse (jsown:to-json object))))
+    (handler-case
+        (progn
+          (starintel::validate-v090-document jzon-object (v09-schema))
+          object)
+      (starintel::starintel-validation-error (condition)
+        (error 'document-schema-validation-error
+               :category (starintel::validation-category condition)
+               :reason (starintel::validation-message condition))))))
+
+(defun ensure-document (document &key route-dtype)
+  "Parse DOCUMENT and enforce transport-level identity invariants.
+
+Strict canonical validation is an explicit boundary operation so legacy target
+compatibility adapters can opt out without weakening canonical ingest."
   (let* ((object (parse-document-object document))
          (dtype (document-dtype object))
          (route (and route-dtype (canonical-dtype route-dtype))))

--- a/source/frontends/http-authorization-routes.lisp
+++ b/source/frontends/http-authorization-routes.lisp
@@ -31,10 +31,14 @@
            (document (require-json-object (parse-json-request))))
       (setf (jsown:val document "dtype") "target"
             (jsown:val document "actor") actor)
-      (validate-document-input document :path-dtype "target")
+      ;; Keep the historical target envelope as an explicit narrow exception.
+      (validate-document-input
+       document
+       :path-dtype "target"
+       :strict-schema-p nil)
       (star.authorization:authorized-publish-document
        document
-       #'publish-document-unchecked
+       #'publish-target-document-unchecked
        :principal (current-publish-service-context)
        :actor-name actor
        :action "targets:dispatch"
@@ -143,7 +147,31 @@
            (route-policy-metadata "/document/:id" "DELETE"))
           (status-msg
            (format nil "Document ~a deleted" document-id)
-           'success))))))
+            'success))))))
+
+(defun handle-authorized-document-update-route (params)
+  (with-http-boundary ()
+    (let* ((document-id (require-path-string params "id"))
+           (patch (request-json-body)))
+      (couchdb-handler (client *couchdb-pool*)
+        (star.authorization:authorized-update-document
+         document-id
+         patch
+         (lambda (id)
+           (handler-case
+               (cl-couch:get-document
+                client star:*couchdb-default-database* id)
+             (dex:http-request-not-found () nil)))
+         (lambda (candidate)
+           (document-update-response
+            (star.databases.couchdb:couchdb-upsert-document-update
+             client
+             star:*couchdb-default-database*
+             document-id
+             candidate)))
+         :principal (current-policy-principal)
+         :metadata
+         (route-policy-metadata "/document/:id" "PUT"))))))
 
 (defun handle-authorized-targets-route (params)
   (with-http-boundary ()
@@ -323,7 +351,9 @@
 (setf (ningle:route *app* "/search" :method :get)
       #'handle-authorized-search-route)
 (setf (ningle:route *app* "/document/:id" :method :get)
-      #'handle-authorized-document-get-route)
+       #'handle-authorized-document-get-route)
+(setf (ningle:route *app* "/document/:id" :method :put)
+      #'handle-authorized-document-update-route)
 (setf (ningle:route *app* "/document/:id" :method :delete)
       #'handle-authorized-document-delete-route)
 (setf (ningle:route *app* "/targets/:actor" :method :get)

--- a/source/frontends/http-authorization.lisp
+++ b/source/frontends/http-authorization.lisp
@@ -31,6 +31,7 @@
     ((path-prefix-p "/document/" path)
      (case method
        (:get "documents:read")
+       (:put "documents:write")
        (:delete "documents:delete")
        (otherwise nil)))
     ((and (eq method :post)

--- a/source/frontends/http-boundary-core.lisp
+++ b/source/frontends/http-boundary-core.lisp
@@ -185,26 +185,42 @@
     value))
 
 (defun validate-schema-version (document &key index)
-  (let ((version (jsown:val-safe document "version"))
+  (let ((schema-version (jsown:val-safe document "schema_version"))
         (expected starintel:+starintel-doc-version+))
-    (unless version
+    (unless schema-version
       (signal-http-input-error
        422
        "schema_version_required"
        (if index
-           (format nil "Document at index ~d requires a version field" index)
-           "Document requires a version field")))
-    (unless (string= (princ-to-string version)
-                     (princ-to-string expected))
+           (format nil "Document at index ~d requires a schema_version field" index)
+           "Document requires a schema_version field")))
+    (unless (and (stringp schema-version)
+                 (string= schema-version expected))
       (signal-http-input-error
        422
        "unsupported_schema_version"
        "Document schema version is not supported"
-       (jsown:new-js ("expected" (princ-to-string expected))
-                     ("received" (princ-to-string version))
+       (jsown:new-js ("expected" expected)
+                     ("received" (princ-to-string schema-version))
                      ("index" (or index :null)))))))
 
-(defun validate-document-input (document &key path-dtype index)
+(defun validate-document-schema (document &key index)
+  (handler-case
+      (star.documents:validate-v09-document document)
+    (star.documents:document-schema-validation-error (condition)
+      (signal-http-input-error
+       422
+       "invalid_document_schema"
+       "Document does not conform to the StarIntel v0.9 schema"
+       (jsown:new-js
+         ("category"
+          (star.documents:document-schema-validation-category condition))
+         ("reason"
+          (star.documents:document-schema-validation-reason condition))
+         ("index" (or index :null)))))))
+
+(defun validate-document-input
+    (document &key path-dtype index (strict-schema-p t))
   (unless (json-object-p document)
     (signal-http-input-error
      422
@@ -223,8 +239,10 @@
        "Document dtype does not match the route dtype"
        (jsown:new-js ("path_dtype" path-dtype)
                      ("document_dtype" dtype))))
-    (validate-schema-version document :index index)
-    document))
+     (when strict-schema-p
+       (validate-schema-version document :index index)
+       (validate-document-schema document :index index))
+     document))
 
 (defun query-value (params name)
   (or (cdr (assoc name params :test #'string=))

--- a/source/frontends/http-boundary-routes.lisp
+++ b/source/frontends/http-boundary-routes.lisp
@@ -24,8 +24,13 @@
          "Route actor is required"))
       (setf (jsown:val document "dtype") "target"
             (jsown:val document "actor") actor)
-      (validate-document-input document :path-dtype "target")
-      (publish-document document)
+      ;; This route is the historical target compatibility adapter. Canonical
+      ;; document and bulk routes remain strict by default.
+      (validate-document-input
+       document
+       :path-dtype "target"
+       :strict-schema-p nil)
+      (publish-target-document-unchecked document)
       (jsown:to-json document))))
 
 (defun handle-bulk-route (params)

--- a/source/frontends/http-bulk-jobs.lisp
+++ b/source/frontends/http-bulk-jobs.lisp
@@ -104,6 +104,22 @@
       context
       star.authorization:*current-authorization-decision*))))
 
+(defun publish-target-document-unchecked (document)
+  "Publish a legacy target directly to the target compatibility consumer."
+  (let* ((actor (jsown:val document "actor"))
+         (routing-key
+           (star.actors:compatibility-target-ingress-routing-key actor))
+         (context (current-publish-service-context)))
+    (star.actors:publish
+     star.actors:*producer-agent*
+     :body (jsown:to-json document)
+     :routing-key routing-key
+     :properties
+     (service-context-properties
+      "target"
+      context
+      star.authorization:*current-authorization-decision*))))
+
 (defun publish-document (document)
   "Authorize at the embedded publish boundary before any Rabbit side effect."
   (star.authorization:authorized-publish-document
@@ -279,5 +295,6 @@
             bulk-ingest-job-succeeded
             bulk-ingest-job-failed
             service-context-properties
-            publish-document)
+            publish-document
+            publish-target-document-unchecked)
           :star.frontends.http-api))

--- a/source/frontends/http-document-update.lisp
+++ b/source/frontends/http-document-update.lisp
@@ -1,28 +1,46 @@
 (in-package :star.frontends.http-api)
 
 (defun request-json-body ()
-  (jsown:with-injective-reader
-    (jsown:parse
-     (babel:octets-to-string
-      (lack.request:request-content (ningle:context :request))
-      :encoding :utf-8))))
+  (require-json-object (parse-json-request)))
+
+(defun document-update-id (params)
+  (let ((document-id (query-value params "id")))
+    (unless (non-empty-string-p document-id)
+      (signal-http-input-error
+       400
+       "missing_path_parameter"
+       "Route parameter id is required"))
+    document-id))
+
+(defun document-update-response (outcome)
+  (if (eq :validation-failed
+          (star.databases.couchdb:document-update-outcome-status outcome))
+      (progn
+        (setf (lack.response:response-status *response*) 422)
+        (status-msg
+         "Invalid document update request"
+         'error
+         :code
+         (or (star.databases.couchdb:document-update-outcome-code outcome)
+             "invalid_document_update")
+         :info
+         (jsown:new-js
+           ("reason"
+            (star.databases.couchdb:document-update-outcome-reason outcome)))))
+      (jsown:to-json
+       (star.databases.couchdb:document-update-outcome-json outcome))))
+
+(defun handle-document-update-route (params)
+  (with-http-boundary ()
+    (let ((document-id (document-update-id params))
+          (patch (request-json-body)))
+      (couchdb-handler (client *couchdb-pool*)
+        (document-update-response
+         (star.databases.couchdb:couchdb-upsert-document-update
+          client
+          star:*couchdb-default-database*
+          document-id
+          patch))))))
 
 (setf (ningle:route *app* "/document/:id" :method :put)
-      (lambda (params)
-        (set-default-headers)
-        (let ((document-id (cdr (assoc :id params :test #'string=))))
-          (handler-case
-              (let ((patch (request-json-body)))
-                (couchdb-handler (client *couchdb-pool*)
-                  (jsown:to-json
-                   (star.databases.couchdb:document-update-outcome-json
-                    (star.databases.couchdb:couchdb-upsert-document-update
-                     client
-                     star:*couchdb-default-database*
-                     document-id
-                     patch)))))
-            (error (condition)
-              (status-msg
-               "Invalid document update request"
-               'error
-               :info (princ-to-string condition)))))))
+      #'handle-document-update-route)

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -374,11 +374,12 @@
    #:invalid-target-dispatch
    #:invalid-target-dispatch-reason
    #:target-ingress-overloaded
-   #:target-ingress-overloaded-reason
-   #:target-destination-unavailable
-   #:target-destination-unavailable-reason
+    #:target-ingress-overloaded-reason
+    #:target-destination-unavailable
+    #:target-destination-unavailable-reason
    #:canonical-target-routing-key
    #:compatibility-target-routing-keys
+   #:compatibility-target-ingress-routing-key
    #:resolve-target-destination
    #:validate-target-dispatch-record
    #:make-target-dispatch-envelope

--- a/source/rabbit.lisp
+++ b/source/rabbit.lisp
@@ -63,12 +63,19 @@
    :password password
    :vhost vhost))
 
-(defun decode-rabbit-document (message &key route-dtype)
-  "Parse one Rabbit delivery and convert malformed payloads to permanent errors."
+(defun decode-rabbit-document
+    (message &key route-dtype (strict-schema-p t))
+  "Parse one Rabbit delivery and classify malformed payloads permanently.
+
+Canonical document mutation queues validate before transport normalization.
+Legacy target adapters must opt out explicitly."
   (handler-case
-      (star.documents:ensure-document
-       (car message)
-       :route-dtype route-dtype)
+      (progn
+        (when strict-schema-p
+          (star.documents:validate-v09-document (car message)))
+        (star.documents:ensure-document
+         (car message)
+         :route-dtype route-dtype))
     (star.consumers:delivery-processing-error (condition)
       (error condition))
     (error (condition)
@@ -116,20 +123,24 @@
      #'publish-raw-message
      :corrected-body corrected-body)))
 
-(defun process-rabbit-document-mutation (message operation)
+(defun persist-rabbit-document-mutation (document operation)
+  (anypool:with-connection
+      (client star.databases.couchdb:*couchdb-pool*)
+    (star.databases.couchdb:couchdb-process-outbox-mutation
+     client
+     star:*couchdb-default-database*
+     #'publish-outbox-event
+     document
+     operation)))
+
+(defun process-rabbit-document-mutation
+    (message operation &key (persist-fn #'persist-rabbit-document-mutation))
   (let ((document (decode-rabbit-document message)))
     (if (star.documents:document-transient-p document)
         (settlement-filtered-ack
          "transient document intentionally not persisted")
         (progn
-          (anypool:with-connection
-              (client star.databases.couchdb:*couchdb-pool*)
-            (star.databases.couchdb:couchdb-process-outbox-mutation
-             client
-             star:*couchdb-default-database*
-             #'publish-outbox-event
-             document
-             operation))
+          (funcall persist-fn document operation)
           (settlement-ack
            "durable mutation and publication completed")))))
 
@@ -150,8 +161,9 @@
      #'publish-outbox-event)))
 
 (defun transient-p (message)
+  "Inspect transport metadata without weakening canonical mutation validation."
   (star.documents:document-transient-p
-   (decode-rabbit-document message)))
+   (decode-rabbit-document message :strict-schema-p nil)))
 
 (defun target-outcome-settlement (outcome)
   (case (star.actors:target-dispatch-outcome-status outcome)
@@ -182,7 +194,10 @@
   (target-outcome-settlement
    (star.actors:accept-target-delivery
     consumer
-    (decode-rabbit-document message :route-dtype "target"))))
+    (decode-rabbit-document
+     message
+     :route-dtype "target"
+     :strict-schema-p nil))))
 
 (defun consumer-retry-options ()
   (list

--- a/source/starintel-gserver.asd
+++ b/source/starintel-gserver.asd
@@ -61,16 +61,16 @@
    (:file "target-recovery")
    (:file "target-dispatch")
    (:file "target-dispatch-fixes")
-   (:file "actor-systems/event-actor")
-   (:file "actor-systems/matcher-actor")
-   (:file "rabbit")
-   (:file "frontends/http-api")
-   (:file "couchdb-session-hardening")
-   (:file "frontends/http-document-update")
-   (:file "frontends/http-view-registry")
-   (:file "frontends/http-status-message")
-   (:file "frontends/http-boundary-core")
-   (:file "frontends/http-capabilities")
+    (:file "actor-systems/event-actor")
+    (:file "actor-systems/matcher-actor")
+    (:file "rabbit")
+    (:file "frontends/http-api")
+    (:file "couchdb-session-hardening")
+    (:file "frontends/http-boundary-core")
+    (:file "frontends/http-document-update")
+    (:file "frontends/http-view-registry")
+    (:file "frontends/http-status-message")
+    (:file "frontends/http-capabilities")
    (:file "frontends/http-auth")
    (:file "frontends/http-oauth-provider")
    (:file "frontends/http-authorization")
@@ -88,6 +88,7 @@
    (:file "authorization/services-final"))
   :depends-on
   (#:starintel
+   #:com.inuoe.jzon
    #:cl-couch
    #:serapeum
    #:alexandria

--- a/source/target-dispatch.lisp
+++ b/source/target-dispatch.lisp
@@ -75,6 +75,13 @@
 (defun compatibility-target-routing-keys (actor-name)
   (list (format nil "actors.~a.new.target" (string-downcase actor-name))))
 
+(defun compatibility-target-ingress-routing-key (actor-name)
+  "Return the routing key used by the legacy HTTP target adapter."
+  (unless (valid-target-actor-name-p actor-name)
+    (error 'invalid-target-dispatch
+           :reason (format nil "invalid actor identity ~s" actor-name)))
+  (format nil "documents.new.target.~a" (string-downcase actor-name)))
+
 (defun resolve-target-destination (actor-name &key (resolver #'get-dest-actor))
   "Resolve ACTOR-NAME into an explicit local or Rabbit component handle."
   (unless (valid-target-actor-name-p actor-name)

--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -32,6 +32,7 @@
      (:file "couchdb-view-request-test")
      (:file "lease-store-contract-test")
      (:file "http-boundary-test")
+     (:file "v09-runtime-test")
      (:file "http-capabilities-test")
      (:file "http-auth-test")
      (:file "auth-users-test")

--- a/t/authorization-policy-test.lisp
+++ b/t/authorization-policy-test.lisp
@@ -398,6 +398,47 @@
     (signals star.authorization:authorization-error
       (star.authorization:authorize!
        "unmapped:http-route" :principal principal)))
-  (is (null
-       (star.frontends.http-api::route-action
-        :post "/not/a/registered/route"))))
+   (is (null
+        (star.frontends.http-api::route-action
+         :post "/not/a/registered/route"))))
+
+(test document-update-route-requires-write-capability
+  (is (string= "documents:write"
+               (star.frontends.http-api::route-action
+                :put "/document/document-1"))))
+
+(test update-service-authorizes-before-side-effect
+  (let* ((document (policy-document :dataset "dataset-a"))
+         (patch (jsown:new-js ("data" (jsown:new-js ("value" "updated")))))
+         (updated nil)
+         (reader
+           (make-policy-principal
+            "update-reader"
+            '("documents:read" "tenant:default" "dataset:dataset-a")))
+         (writer
+           (make-policy-principal
+            "update-writer"
+            '("documents:write" "tenant:default" "dataset:dataset-a"))))
+    (signals star.authorization:authorization-error
+      (star.authorization:authorized-update-document
+       "doc-1"
+       patch
+       (lambda (document-id)
+         (declare (ignore document-id))
+         document)
+       (lambda (candidate)
+         (declare (ignore candidate))
+         (setf updated t))
+       :principal reader))
+    (is-false updated)
+    (is-true
+     (star.authorization:authorized-update-document
+      "doc-1"
+      patch
+      (lambda (document-id)
+        (declare (ignore document-id))
+        document)
+      (lambda (candidate)
+        (setf updated candidate))
+      :principal writer))
+    (is-true updated)))

--- a/t/http-api-test.lisp
+++ b/t/http-api-test.lisp
@@ -245,6 +245,25 @@ instead of being mistaken for an expected broker failure."
     (spec:ulid-id doc)
     (spec:encode doc)))
 
+;; The view endpoints still read the legacy flat document shape until the
+;; versioned CouchDB view migration is implemented. Keep that compatibility
+;; explicit instead of weakening canonical HTTP fixtures.
+(defun legacy-view-key (key)
+  (cond
+    ((string= key "record_type") "recordType")
+    ((string= key "resolved_addresses") "resolvedAddresses")
+    (t key)))
+
+(defun make-legacy-view-document (document)
+  "Flatten a canonical DOCUMENT for a legacy CouchDB view fixture."
+  (let* ((object (jsown:parse (jsown:to-json document)))
+         (data (jsown:val object "data")))
+    (jsown:remkey object "data")
+    (when (and (consp data) (eq (first data) :obj))
+      (jsown:do-json-keys (key value) data
+        (setf (jsown:val object (legacy-view-key key)) value)))
+    object))
+
 
 
 ;;; Test document creation helpers for BBP/network/web types
@@ -260,16 +279,16 @@ instead of being mistaken for an expected broker failure."
     (spec:encode doc)))
 
 
-(defun make-test-email (&key (id nil) (user "testuser") (domain "example.com") (password nil))
+(defun make-test-email (&key (id nil) (user "testuser") (domain "example.com"))
   "Create a test email document. If id is provided, use it; otherwise generate ULID."
   (let ((doc (spec:new-email "testing" :user user :domain domain)))
     (if id
         (setf (spec:doc-id doc) id)
         (spec:ulid-id doc))
-    ;; Add password if provided for with_password view
-    (when password
-      (setf (spec:email-password doc) password))
-    (spec:encode doc)))
+    ;; Password is a legacy flat-view field, not part of the v0.9 email schema.
+    (let ((encoded (spec:encode doc)))
+      (jsown:remkey (jsown:val encoded "data") "password")
+      encoded)))
 
 
 (defun make-test-domain (&key (id nil) (record "example.com") (resolved '("1.2.3.4" "5.6.7.8")))
@@ -319,6 +338,33 @@ instead of being mistaken for an expected broker failure."
         (setf (spec:doc-id doc) id)
         (spec:ulid-id doc))
     (spec:encode doc)))
+
+(defun make-test-legacy-host (&rest args)
+  (make-legacy-view-document (apply #'make-test-host args)))
+
+(defun make-test-legacy-email (&key (id nil) (user "testuser")
+                                    (domain "example.com") (password nil))
+  (let ((document
+          (make-legacy-view-document
+           (make-test-email :id id :user user :domain domain))))
+    (when password
+      (setf (jsown:val document "password") password))
+    document))
+
+(defun make-test-legacy-domain (&rest args)
+  (make-legacy-view-document (apply #'make-test-domain args)))
+
+(defun make-test-legacy-user (&rest args)
+  (make-legacy-view-document (apply #'make-test-user args)))
+
+(defun make-test-legacy-network (&rest args)
+  (make-legacy-view-document (apply #'make-test-network args)))
+
+(defun make-test-legacy-url-doc (&rest args)
+  (make-legacy-view-document (apply #'make-test-url-doc args)))
+
+(defun make-test-legacy-breach (&rest args)
+  (make-legacy-view-document (apply #'make-test-breach args)))
 
 (defun make-test-email-message (&key (id nil) (from "sender@example.com") (to "recipient@example.com"))
   "Create a test email-message document. If id is provided, use it; otherwise generate ULID."
@@ -405,8 +451,8 @@ instead of being mistaken for an expected broker failure."
 (test test-hosts-by-ip
       "Test GET /documents/hosts/by-ip endpoint."
       (dbg "TEST: test-hosts-by-ip")
-      (insert-test-document (make-test-host :id "host-test-3" :ip "192.168.1.100"))
-      (insert-test-document (make-test-host :id "host-test-5" :ip "192.168.1.101"))
+      (insert-test-document (make-test-legacy-host :id "host-test-3" :ip "192.168.1.100"))
+      (insert-test-document (make-test-legacy-host :id "host-test-5" :ip "192.168.1.101"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/hosts/by-ip?ip=192.168.1.100"))
              (response (dex:get url)))
@@ -420,7 +466,7 @@ instead of being mistaken for an expected broker failure."
 (test test-hosts-by-port
       "Test GET /documents/hosts/by-port endpoint."
       (dbg "TEST: test-hosts-by-port")
-      (insert-test-document (make-test-host :id "host-test-1" :ip "192.168.1.100"))
+      (insert-test-document (make-test-legacy-host :id "host-test-1" :ip "192.168.1.100"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/hosts/by-port?port=22"))
              (response (dex:get url)))
@@ -432,7 +478,7 @@ instead of being mistaken for an expected broker failure."
 (test test-hosts-by-service
       "Test GET /documents/hosts/by-service endpoint."
       (dbg "TEST: test-hosts-by-service")
-      (insert-test-document (make-test-host :id "host-test-4" :ip "192.168.1.100"))
+      (insert-test-document (make-test-legacy-host :id "host-test-4" :ip "192.168.1.100"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/hosts/by-service?service=ssh"))
              (response (dex:get url)))
@@ -446,7 +492,7 @@ instead of being mistaken for an expected broker failure."
 (test test-emails-by-email
       "Test GET /documents/emails/by-email endpoint."
       (dbg "TEST: test-emails-by-email")
-      (insert-test-document (make-test-email :id "email-test-1" :user "testuser" :domain "example.com"))
+      (insert-test-document (make-test-legacy-email :id "email-test-1" :user "testuser" :domain "example.com"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/emails/by-email?email=testuser@example.com"))
              (response (dex:get url)))
@@ -461,9 +507,9 @@ instead of being mistaken for an expected broker failure."
 (test test-emails-by-domain
       "Test GET /documents/emails/by-domain endpoint."
       (dbg "TEST: test-emails-by-domain")
-      (insert-test-document (make-test-email :id "email-test-2" :user "user1" :domain "example.com"))
-      (insert-test-document (make-test-email :id "email-test-3" :user "user2" :domain "example.com"))
-      (insert-test-document (make-test-email :id "email-test-4" :user "user3" :domain "other.com"))
+      (insert-test-document (make-test-legacy-email :id "email-test-2" :user "user1" :domain "example.com"))
+      (insert-test-document (make-test-legacy-email :id "email-test-3" :user "user2" :domain "example.com"))
+      (insert-test-document (make-test-legacy-email :id "email-test-4" :user "user3" :domain "other.com"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/emails/by-domain?domain=example.com"))
              (response (dex:get url)))
@@ -475,7 +521,7 @@ instead of being mistaken for an expected broker failure."
 (test test-emails-with-password
       "Test GET /documents/emails/with-password endpoint."
       (dbg "TEST: test-emails-with-password")
-      (insert-test-document (make-test-email :id "email-test-5" :user "testuser" :domain "example.com" :password "secretpass123"))
+      (insert-test-document (make-test-legacy-email :id "email-test-5" :user "testuser" :domain "example.com" :password "secretpass123"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/emails/with-password"))
              (response (dex:get url)))
@@ -489,7 +535,7 @@ instead of being mistaken for an expected broker failure."
 (test test-domains-by-record
       "Test GET /documents/domains/by-record endpoint."
       (dbg "TEST: test-domains-by-record")
-      (insert-test-document (make-test-domain :id "domain-test-1" :record "example.com"))
+      (insert-test-document (make-test-legacy-domain :id "domain-test-1" :record "example.com"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/domains/by-record?record=example.com"))
              (response (dex:get url)))
@@ -503,7 +549,7 @@ instead of being mistaken for an expected broker failure."
 (test test-domains-by-resolved-address
       "Test GET /documents/domains/by-resolved-address endpoint."
       (dbg "TEST: test-domains-by-resolved-address")
-      (insert-test-document (make-test-domain :id "domain-test-2" :record "example.com"))
+      (insert-test-document (make-test-legacy-domain :id "domain-test-2" :record "example.com"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/domains/by-resolved-address?ip=1.2.3.4"))
              (response (dex:get url)))
@@ -517,7 +563,7 @@ instead of being mistaken for an expected broker failure."
 (test test-users-by-name
       "Test GET /documents/users/by-name endpoint."
       (dbg "TEST: test-users-by-name")
-      (insert-test-document (make-test-user :id "user-test-1" :name "testuser" :platform "github"))
+      (insert-test-document (make-test-legacy-user :id "user-test-1" :name "testuser" :platform "github"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/users/by-name?name=testuser"))
              (response (dex:get url)))
@@ -531,9 +577,9 @@ instead of being mistaken for an expected broker failure."
 (test test-users-by-platform
       "Test GET /documents/users/by-platform endpoint."
       (dbg "TEST: test-users-by-platform")
-      (insert-test-document (make-test-user :id "user-test-4" :name "user1" :platform "github"))
-      (insert-test-document (make-test-user :id "user-test-2" :name "user2" :platform "github"))
-      (insert-test-document (make-test-user :id "user-test-3" :name "user3" :platform "twitter"))
+      (insert-test-document (make-test-legacy-user :id "user-test-4" :name "user1" :platform "github"))
+      (insert-test-document (make-test-legacy-user :id "user-test-2" :name "user2" :platform "github"))
+      (insert-test-document (make-test-legacy-user :id "user-test-3" :name "user3" :platform "twitter"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/users/by-platform?platform=github"))
              (response (dex:get url)))
@@ -547,7 +593,7 @@ instead of being mistaken for an expected broker failure."
 (test test-networks-by-asn
       "Test GET /documents/networks/by-asn endpoint."
       (dbg "TEST: test-networks-by-asn")
-      (insert-test-document (make-test-network :id "network-test-1" :asn 12345))
+      (insert-test-document (make-test-legacy-network :id "network-test-1" :asn 12345))
       (sleep 2)
       (let* ((url (make-test-url "/documents/networks/by-asn?asn=12345"))
              (response (dex:get url)))
@@ -561,7 +607,7 @@ instead of being mistaken for an expected broker failure."
 (test test-networks-by-org
       "Test GET /documents/networks/by-org endpoint."
       (dbg "TEST: test-networks-by-org")
-      (insert-test-document (make-test-network :id "network-test-2" :asn 12345))
+      (insert-test-document (make-test-legacy-network :id "network-test-2" :asn 12345))
       (sleep 2)
       (let* ((url (make-test-url "/documents/networks/by-org?org=Test%20Organization"))
              (response (dex:get url)))
@@ -575,7 +621,7 @@ instead of being mistaken for an expected broker failure."
 (test test-urls-by-url
       "Test GET /documents/urls/by-url endpoint."
       (dbg "TEST: test-urls-by-url")
-      (insert-test-document (make-test-url-doc :id "url-test-1" :url "https://example.com/test"))
+      (insert-test-document (make-test-legacy-url-doc :id "url-test-1" :url "https://example.com/test"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/urls/by-url?url=https://example.com/test"))
              (response (dex:get url)))
@@ -589,7 +635,7 @@ instead of being mistaken for an expected broker failure."
 (test test-urls-by-domain
       "Test GET /documents/urls/by-domain endpoint."
       (dbg "TEST: test-urls-by-domain")
-      (insert-test-document (make-test-url-doc :id "url-test-2" :url "https://example.com/test"))
+      (insert-test-document (make-test-legacy-url-doc :id "url-test-2" :url "https://example.com/test"))
       (sleep 2)
       (let* ((url (make-test-url "/documents/urls/by-domain?domain=example.com"))
              (response (dex:get url)))
@@ -603,8 +649,8 @@ instead of being mistaken for an expected broker failure."
 (test test-breaches-by-size
       "Test GET /documents/breaches/by-size endpoint."
       (dbg "TEST: test-breaches-by-size")
-      (insert-test-document (make-test-breach :id "breach-test-1" :total 10000))
-      (insert-test-document (make-test-breach :id "breach-test-2" :total 50000))
+      (insert-test-document (make-test-legacy-breach :id "breach-test-1" :total 10000))
+      (insert-test-document (make-test-legacy-breach :id "breach-test-2" :total 50000))
       (sleep 2)
       (let* ((url (make-test-url "/documents/breaches/by-size?descending=true&limit=10"))
              (response (dex:get url)))

--- a/t/http-boundary-test.lisp
+++ b/t/http-boundary-test.lisp
@@ -6,13 +6,20 @@
 (in-suite http-boundary-tests)
 
 (defun make-boundary-document (&key (dtype "host")
-                                    (version starintel:+starintel-doc-version+)
+                                    (schema-version starintel:+starintel-doc-version+)
+                                    (version 1)
                                     (id "boundary-doc-1"))
-  (jsown:new-js
-    ("_id" id)
-    ("dataset" "boundary-tests")
-    ("dtype" dtype)
-    ("version" version)))
+  (let ((document
+          (starintel:encode
+           (starintel:new-host
+            "boundary-tests"
+            :ip "192.0.2.10"
+            :os "linux"))))
+    (setf (jsown:val document "_id") id
+          (jsown:val document "dtype") dtype
+          (jsown:val document "schema_version") schema-version
+          (jsown:val document "version") version)
+    document))
 
 (defun capture-http-input-error (thunk)
   (handler-case
@@ -92,20 +99,91 @@
              (star.frontends.http-api:http-input-error-status
               mismatch-condition)))
       (is (string= "dtype_mismatch"
-                   (star.frontends.http-api:http-input-error-code
-                    mismatch-condition))))))
+                    (star.frontends.http-api:http-input-error-code
+                     mismatch-condition))))))
+
+(test canonical-v09-document-passes-strict-validation
+  (let ((document (make-boundary-document)))
+    (is (eq document
+            (star.frontends.http-api:validate-document-input
+             document
+             :path-dtype "host")))))
+
+(test document-revision-is-independent-from-schema-revision
+  (let ((document (make-boundary-document :version 7)))
+    (is (eq document
+            (star.frontends.http-api:validate-document-input
+             document
+             :path-dtype "host")))
+    (is (= 7 (jsown:val document "version")))
+    (is (string= "0.9.0" (jsown:val document "schema_version")))))
+
+(test version-string-does-not-substitute-for-schema-version
+  (let ((document (make-boundary-document)))
+    (jsown:remkey document "schema_version")
+    (setf (jsown:val document "version") "0.9.0")
+    (let ((condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:validate-document-input
+                document
+                :path-dtype "host")))))
+      (is (= 422
+             (star.frontends.http-api:http-input-error-status condition)))
+      (is (string= "schema_version_required"
+                   (star.frontends.http-api:http-input-error-code condition))))))
 
 (test unsupported-schema-version-is-rejected
   (let ((condition
           (capture-http-input-error
            (lambda ()
              (star.frontends.http-api:validate-document-input
-              (make-boundary-document :version "999.0")
+              (make-boundary-document :schema-version "999.0")
               :path-dtype "host")))))
     (is (= 422
            (star.frontends.http-api:http-input-error-status condition)))
     (is (string= "unsupported_schema_version"
                  (star.frontends.http-api:http-input-error-code condition)))))
+
+(test undeclared-top-level-field-is-rejected
+  (let ((document (make-boundary-document)))
+    (setf (jsown:val document "legacy_flat_field") "not-v09")
+    (let ((condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:validate-document-input
+                document
+                :path-dtype "host")))))
+      (is (= 422
+             (star.frontends.http-api:http-input-error-status condition)))
+      (is (string= "invalid_document_schema"
+                   (star.frontends.http-api:http-input-error-code condition))))))
+
+(test dtype-data-schema-mismatch-is-rejected
+  (let ((document (make-boundary-document :dtype "email")))
+    (let ((condition
+            (capture-http-input-error
+             (lambda ()
+               (star.frontends.http-api:validate-document-input document)))))
+      (is (= 422
+             (star.frontends.http-api:http-input-error-status condition)))
+      (is (string= "invalid_document_schema"
+                   (star.frontends.http-api:http-input-error-code condition))))))
+
+(test target-compatibility-adapter-can-skip-strict-schema
+  (let ((document (make-boundary-document :dtype "target")))
+    (jsown:remkey document "schema_version")
+    (setf (jsown:val document "legacy_flat_field") "allowed-at-adapter")
+    (is (eq document
+            (star.frontends.http-api:validate-document-input
+             document
+              :path-dtype "target"
+              :strict-schema-p nil)))))
+
+(test put-document-route-requires-write-capability
+  (is (string= "documents:write"
+               (star.frontends.http-api::route-action
+                :put "/document/example"))))
 
 (test client-status-envelopes-never-expose-tracebacks
   (let* ((star.frontends.http-api::*http-correlation-id* "corr-test")

--- a/t/run-tests.lisp
+++ b/t/run-tests.lisp
@@ -13,6 +13,7 @@
     couchdb-view-request-tests
     lease-store-contract-tests
     http-boundary-tests
+    v09-runtime-tests
     http-auth-tests
     auth-users-tests
     oauth-authorization-code-tests

--- a/t/v09-runtime-test.lisp
+++ b/t/v09-runtime-test.lisp
@@ -1,0 +1,122 @@
+(in-package :star-server-tests)
+
+(def-suite v09-runtime-tests
+  :description "Canonical StarIntel v0.9 validator and Rabbit mutation boundary")
+
+(in-suite v09-runtime-tests)
+
+(defun v09-test-host-document ()
+  (starintel:encode
+   (starintel:new-host
+    "v09-runtime-tests"
+    :ip "192.0.2.20"
+    :os "linux")))
+
+(defun capture-schema-invalid (thunk)
+  (handler-case
+      (progn
+        (funcall thunk)
+        nil)
+    (star.consumers:schema-invalid-delivery-error (condition)
+      condition)))
+
+(defun invalid-rabbit-delivery ()
+  (cons
+   (jsown:to-json
+    (jsown:new-js
+      ("_id" "invalid-rabbit-document")
+      ("dataset" "v09-runtime-tests")
+      ("dtype" "host")
+      ("version" 7)))
+   1))
+
+(test canonical-starintel-encoding-passes-server-validator
+  (let ((document (v09-test-host-document)))
+    (is (eq document (star.documents:validate-v09-document document)))
+    (is (string= "0.9.0" (jsown:val document "schema_version")))
+    (is (= 1 (jsown:val document "version")))))
+
+(test rabbit-ingest-invalid-schema-cannot-reach-persistence
+  (let ((persisted nil))
+    (let ((condition
+            (capture-schema-invalid
+             (lambda ()
+               (star.rabbit::process-rabbit-document-mutation
+                (invalid-rabbit-delivery)
+                :new
+                :persist-fn
+                (lambda (document operation)
+                  (declare (ignore document operation))
+                  (setf persisted t)))))))
+      (is-true condition)
+      (is (typep condition 'star.consumers:schema-invalid-delivery-error))
+      (is-false persisted))))
+
+(test rabbit-update-invalid-schema-cannot-reach-persistence
+  (let ((persisted nil))
+    (let ((condition
+            (capture-schema-invalid
+             (lambda ()
+               (star.rabbit::process-rabbit-document-mutation
+                (invalid-rabbit-delivery)
+                :updated
+                :persist-fn
+                (lambda (document operation)
+                  (declare (ignore document operation))
+                  (setf persisted t)))))))
+      (is-true condition)
+      (is (typep condition 'star.consumers:schema-invalid-delivery-error))
+      (is-false persisted))))
+
+(test target-rabbit-adapter-explicitly-skips-strict-schema
+  (let* ((message
+           (cons
+            (jsown:to-json
+             (jsown:new-js
+               ("_id" "legacy-target")
+               ("dtype" "target")
+               ("actor" "nmap")
+               ("legacy_flat_field" "compatibility")))
+            1))
+         (document
+           (star.rabbit:decode-rabbit-document
+            message
+            :route-dtype "target"
+            :strict-schema-p nil)))
+    (is (string= "legacy-target" (jsown:val document "_id")))
+    (is (string= "target" (jsown:val document "dtype")))))
+
+(test rabbit-strict-validation-is-default
+  (is-true
+   (capture-schema-invalid
+    (lambda ()
+      (star.rabbit:decode-rabbit-document (invalid-rabbit-delivery))))))
+
+(test target-compatibility-routing-key-is-isolated
+  (is (string= "documents.new.target.nmap"
+               (star.actors:compatibility-target-ingress-routing-key "Nmap")))
+  (signals star.actors:invalid-target-dispatch
+    (star.actors:compatibility-target-ingress-routing-key "nmap.#")))
+
+(test http-update-schema-validation-precedes-save
+  (let* ((existing (v09-test-host-document))
+         (patch (jsown:new-js
+                  ("legacy_flat_field" "must-not-persist")))
+         (saved nil)
+         (outcome
+           (star.databases.couchdb:upsert-document-update
+            (lambda (document-id)
+              (declare (ignore document-id))
+              existing)
+            (lambda (candidate)
+              (setf saved candidate))
+            (jsown:val existing "_id")
+            patch)))
+    (is (eq :validation-failed
+            (star.databases.couchdb:document-update-outcome-status outcome)))
+    (is (string= "invalid_document_schema"
+                 (star.databases.couchdb:document-update-outcome-code outcome)))
+    (is-false saved)))
+
+(defun run-v09-runtime-tests ()
+  (run! 'v09-runtime-tests))

--- a/tests/test_v09_runtime_contract.py
+++ b/tests/test_v09_runtime_contract.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STAR_CL_V09 = "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa"
+
+
+class V09RuntimeContractTests(unittest.TestCase):
+    def text(self, relative: str) -> str:
+        return (ROOT / relative).read_text(encoding="utf-8")
+
+    def test_schema_and_dependency_locks_converge_exactly(self) -> None:
+        schema_lock = json.loads(self.text("schema/starintel-schema.lock.json"))
+        flake_lock = json.loads(self.text("flake.lock"))
+        qlot_lock = self.text("qlfile.lock")
+
+        self.assertEqual(schema_lock["schema_version"], "0.9.0")
+        self.assertEqual(
+            flake_lock["nodes"]["star-cl"]["locked"]["rev"], STAR_CL_V09
+        )
+        match = re.search(r'\("star-cl".*?github-([0-9a-f]{40})', qlot_lock, re.S)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), STAR_CL_V09)
+
+    def test_http_boundary_uses_schema_version_and_canonical_validator(self) -> None:
+        boundary = self.text("source/frontends/http-boundary-core.lisp")
+        self.assertIn('(jsown:val-safe document "schema_version")', boundary)
+        self.assertIn("star.documents:validate-v09-document", boundary)
+        self.assertIn('"invalid_document_schema"', boundary)
+        self.assertNotIn('(jsown:val-safe document "version")', boundary)
+
+    def test_update_boundary_validates_before_persistence_and_is_authorized(self) -> None:
+        update = self.text("source/databases/document-update.lisp")
+        auth = self.text("source/frontends/http-authorization.lisp")
+        routes = self.text("source/frontends/http-authorization-routes.lisp")
+        system = self.text("source/starintel-gserver.asd")
+        self.assertIn("star.documents:validate-v09-document candidate", update)
+        self.assertIn("document-update-validation-code", update)
+        self.assertIn('(:put "documents:write")', auth)
+        self.assertIn("authorized-update-document", routes)
+        self.assertLess(
+            system.index('(:file "frontends/http-boundary-core")'),
+            system.index('(:file "frontends/http-document-update")'),
+        )
+
+    def test_canonical_validator_is_reused_not_forked(self) -> None:
+        access = self.text("source/document-access.lisp")
+        package = self.text("source/document-access-package.lisp")
+        system = self.text("source/starintel-gserver.asd")
+        self.assertIn("starintel::validate-v090-document", access)
+        self.assertIn("starintel-doc-v0.9.0.schema.json", access)
+        self.assertIn("document-schema-validation-error", package)
+        self.assertIn("#:com.inuoe.jzon", system)
+        self.assertNotIn("defun validate-v090-value", access)
+
+    def test_rabbit_mutations_are_strict_and_targets_are_explicit(self) -> None:
+        rabbit = self.text("source/rabbit.lisp")
+        self.assertIn("(strict-schema-p t)", rabbit)
+        self.assertIn("star.documents:validate-v09-document", rabbit)
+        self.assertIn(":strict-schema-p nil", rabbit)
+        self.assertIn(':route-dtype "target"', rabbit)
+        self.assertIn("persist-rabbit-document-mutation", rabbit)
+
+    def test_target_compatibility_is_direct_and_narrow(self) -> None:
+        target = self.text("source/frontends/http-bulk-jobs.lisp")
+        routes = self.text("source/frontends/http-authorization-routes.lisp")
+        self.assertIn("compatibility-target-ingress-routing-key", target)
+        self.assertIn("publish-target-document-unchecked", routes)
+        self.assertIn(
+            '"documents.new.target.~a"',
+            self.text("source/target-dispatch.lisp"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR supersedes stale PR #116 against current master.

- Reuse star-cl SHA `b8dfbe2f9f56065ace8c3313b92ca748a115cdfa` and its canonical v0.9 validator.
- Enforce strict schema validation before mutation for canonical HTTP and Rabbit boundaries, including document updates.
- Keep only the explicit target compatibility adapters non-strict and route legacy HTTP targets directly to `documents.new.target.<actor>`.
- Authorize `PUT /document/:id` before persistence and return stable 422 schema errors.
- Add Prolog contract coverage, focused Lisp/Python tests, documentation, and converged Nix/QLot locks.

## Verification

- Python contract tests: 18 passed.
- Lisp unit suites: all passed; HTTP boundary 29/29, v0.9 runtime 7/7, authorization policy 20/20.
- Schema lock check: passed.
- `nix flake check --show-trace`: passed with an isolated cache using Nix 2.35.2.
- `nix build .#default --no-link --print-build-logs`: passed with an isolated cache.
- `docker compose config --quiet`: passed.
- `./scripts/stack-test.sh`: passed with an isolated cache, including authenticated scoped denial, FTS, restart persistence, and credential persistence.
- V4 quality gate `nix develop --command bash scripts/check`: passed.
- Prolog `verify/0`: passed against commit `2d6d88dbc188f64fcf76b53a8411b576b62c6a44`.

The initial GitHub jobs failed before test execution because a warmed runner cache rejected the old `star-cl` NAR hash. The lock was corrected to the clean Nix 2.35.2 value and the branch was repushed. The standalone `nix run .#star-integration-tests --show-trace` runner also cannot run its CouchDB suite because it provisions Valkey only; the Compose-backed stack test exercises CouchDB successfully. The V4-prescribed `scripts/sync.py --check` is unavailable because that script is not present in the workspace.