### PR TITLE
test: re-prove strict trailing-comma rejection on current master

### DIFF
--- a/starintel-gserver-tests.asd
+++ b/starintel-gserver-tests.asd
@@ -32,6 +32,7 @@
      (:file "couchdb-view-request-test")
      (:file "lease-store-contract-test")
      (:file "http-boundary-test")
+     (:file "http-strict-json-regression-test")
      (:file "v09-runtime-test")
      (:file "http-capabilities-test")
      (:file "http-auth-test")

--- a/t/http-strict-json-regression-test.lisp
+++ b/t/http-strict-json-regression-test.lisp
@@ -17,3 +17,17 @@
            (star.frontends.http-api:http-input-error-status condition)))
     (is (string= "malformed_json"
                  (star.frontends.http-api:http-input-error-code condition)))))
+
+(test trailing-comma-json-array-is-a-400-client-error
+  "Prove the same permissive-parser defect applies to JSON arrays, not just objects."
+  (let ((condition
+          (capture-http-input-error
+           (lambda ()
+             (star.frontends.http-api:parse-json-octets
+              (babel:string-to-octets "[1,]" :encoding :utf-8)
+              "application/json")))))
+    (is-true condition)
+    (is (= 400
+           (star.frontends.http-api:http-input-error-status condition)))
+    (is (string= "malformed_json"
+                 (star.frontends.http-api:http-input-error-code condition)))))

--- a/t/http-strict-json-regression-test.lisp
+++ b/t/http-strict-json-regression-test.lisp
@@ -1,0 +1,19 @@
+(in-package :star-server-tests)
+
+(in-suite http-boundary-tests)
+
+(test trailing-comma-json-is-a-400-client-error
+  "Re-prove the exact malformed-JSON shape observed by security PR #105 on current master."
+  (let ((condition
+          (capture-http-input-error
+           (lambda ()
+             (star.frontends.http-api:parse-json-octets
+              (babel:string-to-octets
+               "{\"_id\":\"security-json-comma\",\"dataset\":\"security-a\",\"dtype\":\"note\",\"schema_version\":\"0.9.0\",}"
+               :encoding :utf-8)
+              "application/json")))))
+    (is-true condition)
+    (is (= 400
+           (star.frontends.http-api:http-input-error-status condition)))
+    (is (string= "malformed_json"
+                 (star.frontends.http-api:http-input-error-code condition)))))


### PR DESCRIPTION
Evidence-only RAGE/TDD freshness transaction for #105 and the strict-JSON research transaction in `lost-rob0t/starintel-auto-research#142`.

Starting commit: `52948721d8981e9aa5ccad4efd77185e52af845b` (current master after #119).

This adds the smallest hermetic regression for the exact malformed shape previously observed by ZAP: a JSON object with a trailing comma. It requires `parse-json-octets` to signal HTTP 400 / `malformed_json`. A later control fixture also proves `[1,]` is rejected in the resolved StarIntel runtime, so the deterministic RED is specifically the object-member trailing-comma case.

Current exact head: `a2368ba58d0347af8f85efd85aba7b021ded65b5`.

Exact-head result: Smoke #423 is RED on the object trailing-comma regression; Container Stack #424, Canonical schema lock #308, and Operational salvage #253 are GREEN. Preserve the failing regression unchanged.

## Control-plane identity — reconciled

The authoritative research identity is now `STAR-RESEARCH-060 Strict JSON HTTP Boundary` in `lost-rob0t/starintel-auto-research`.

Historical comments on this PR used STAR-RESEARCH-041 and STAR-RESEARCH-042 while the Auto-Research corpus had ID collisions. Those identifiers are transaction history only. Auto-Research PR #142 was reconciled and merged to `main` as `50b0d6ad70da54af1420943b1f137b0a78e09b58`; canonical `adard.research-approval.v1` metadata was then landed on `main` at exact head `dd01622f2e1acbafb7d929f824167492b7bef0e8`. The exact-head Org-roam Pages workflow for `dd01622...` completed successfully.

Publication and green CI do **not** change authority. Operator research approval for STAR-RESEARCH-060 remains PENDING. Research approval would authorize design/adversarial review only, and parser implementation remains blocked until a later canonical design receives separate explicit operator design approval.

No product implementation is changed and no assertion is weakened.