### PR TITLE
feat: Emacs client v2 async contract layer with hermetic ERT suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@
 # @version 0.1
 
 LISP ?= sbcl
+EMACS ?= emacs
 
-.PHONY: all test integration-test images load-images compose-config stack-test
+.PHONY: all test integration-test test-emacs images load-images compose-config stack-test
 
 all: test
 
@@ -16,6 +17,9 @@ test:
 
 integration-test:
 	nix run .#star-integration-tests
+
+test-emacs:
+	$(EMACS) -Q --batch -L . -l client-test.el -f ert-run-tests-batch-and-exit
 
 images:
 	nix build .#star-server-image .#couchdb-image .#clouseau-image .#rabbitmq-image

--- a/client-test.el
+++ b/client-test.el
@@ -1,0 +1,840 @@
+;;; client-test.el --- Hermetic ERT tests for the StarIntel Emacs client -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026
+
+;; Author: nsaspy
+;; Version: 2.0.0
+;; Package-Requires: ((emacs "27.1"))
+;; Keywords: tools, processes
+
+;; Commentary:
+
+;; Hermetic ERT tests for client.el.  All tests run against a fake HTTP
+;; transport; no live StarIntel server is required.
+
+;; Run from the repository root:
+;;
+;;   emacs -Q --batch -L . -l client-test.el -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'json)
+
+(let ((dir (file-name-directory (or load-file-name buffer-file-name))))
+  (add-to-list 'load-path dir))
+
+(require 'client)
+
+;;; ------------------------------------------------------------------
+;;; Fake HTTP transport
+;;; ------------------------------------------------------------------
+
+(defvar starintel-test--requests nil
+  "Requests recorded by the fake transport, newest first.")
+
+(defvar starintel-test--responses nil
+  "Canned responses returned by the fake transport, in order.
+Each entry is a plist like (:status N :headers ALIST :body STRING),
+or (:timeout t).")
+
+(defvar starintel-test--response-function nil
+  "When non-nil, a function called instead of popping canned responses.")
+
+(defvar starintel-test--deferred nil
+  "Pending deferred requests, oldest first.
+Each entry is a plist like (:url U :callback C) awaiting manual
+completion by `starintel-test--release'.")
+
+(defun starintel-test-fake-transport (_method url headers _body timeout-ms callback)
+  "Fake synchronous StarIntel HTTP transport recording every call.
+Calls CALLBACK immediately with the canned response, mirroring the
+async transport contract without any waiting."
+  (push (list :method 'req :url url :headers headers :timeout-ms timeout-ms)
+        starintel-test--requests)
+  (funcall callback
+           (cond
+            (starintel-test--response-function
+             (funcall starintel-test--response-function))
+            ((null starintel-test--responses)
+             (error "fake transport: unexpected request to %s" url))
+            (t (pop starintel-test--responses)))))
+
+(defun starintel-test-deferred-transport (_method url _headers _body _timeout-ms callback)
+  "Fake fully-async transport: park CALLBACK until released by the test."
+  (setq starintel-test--deferred
+        (append starintel-test--deferred
+                (list (list :url url :callback callback)))))
+
+(defun starintel-test--release (response)
+  "Complete the oldest deferred request with RESPONSE plist.
+Returns the released request entry so tests can assert on its URL."
+  (let* ((entry (car starintel-test--deferred)))
+    (setq starintel-test--deferred (cdr starintel-test--deferred))
+    (funcall (plist-get entry :callback) response)
+    entry))
+
+(defun starintel-test--deferred-urls ()
+  "Return the URLs of pending deferred requests, oldest first."
+  (mapcar (lambda (entry) (plist-get entry :url)) starintel-test--deferred))
+
+(defun starintel-test-last-request ()
+  "Return the most recently recorded request plist."
+  (car starintel-test--requests))
+
+(defun starintel-test-request-count ()
+  "Return the number of recorded requests."
+  (length starintel-test--requests))
+
+(defun starintel-test-header (request name)
+  "Return header NAME from recorded REQUEST, case-insensitively."
+  (cdr (assoc-string name (plist-get request :headers) t)))
+
+(defconst starintel-test-token "star_sk_v1_secret-token-1234"
+  "Bearer token used across secret-handling tests.")
+
+(defmacro starintel-test-with-client (&rest body)
+  "Run BODY with the modern client pointed at a fake transport."
+  `(let ((starintel-test--requests nil)
+         (starintel-test--responses nil)
+         (starintel-test--response-function nil)
+         (starintel-test--deferred nil)
+         (starintel-api-base-url "http://starintel.test:5000")
+         (starintel-api-token starintel-test-token)
+         (starintel-api-transport-function #'starintel-test-fake-transport)
+         (starintel-api--capabilities-cache nil))
+     ,@body))
+
+(defmacro starintel-test-with-deferred-client (&rest body)
+  "Run BODY with a transport that never completes requests itself."
+  `(let ((starintel-test--requests nil)
+         (starintel-test--responses nil)
+         (starintel-test--response-function nil)
+         (starintel-test--deferred nil)
+         (starintel-api-base-url "http://starintel.test:5000")
+         (starintel-api-token starintel-test-token)
+         (starintel-api-transport-function #'starintel-test-deferred-transport)
+         (starintel-api--capabilities-cache nil))
+     ,@body))
+
+;;; ------------------------------------------------------------------
+;;; Capability fixtures
+;;; ------------------------------------------------------------------
+
+(defun starintel-test--endpoint (id method path &optional legacy)
+  "Build one advertised endpoint alist for fixtures."
+  `((id . ,id)
+    (method . ,method)
+    (path . ,path)
+    (legacy . ,(if legacy t :json-false))
+    (authority . ,(if legacy "authenticated" "public"))
+    (scopes . ,(if legacy ["documents:read"] nil))))
+
+(cl-defun starintel-test--capabilities-json (&key endpoints legacy-routes)
+  "Return a capabilities response body.
+ENDPOINTS is a list of endpoint alists; LEGACY-ROUTES controls the
+compatibility advertisement."
+  (json-encode
+   `((status . "ok")
+     (data .
+           ((build . ((service . "starintel-gserver")
+                      (version . "0.9.4")))
+            (schema_revisions . ((api . "v1") (document . "0.9.7")))
+            (transports . ["http"])
+            (authentication . ((modes . ["api-key"])
+                               (public_mode . :json-false)
+                               (capabilities_endpoint_requires_auth . :json-false)))
+            (features . ((documents . t)
+                         (search . t)
+                         (stats . t)
+                         (targets . t)
+                         (target_leases . :json-false)
+                         (streams . :json-false)
+                         (openapi . t)))
+            (limits . ((bulk_documents . 500)
+                       (public_search_results . 50)
+                       (default_request_timeout_ms . 30000)
+                       (max_request_timeout_ms . 120000)))
+            (endpoints . ,(vconcat
+                           (or endpoints
+                               (list
+                                (starintel-test--endpoint
+                                 "capabilities" "GET" "/api/v1/capabilities")
+                                (starintel-test--endpoint
+                                 "public_search" "GET" "/api/v1/search")
+                                (starintel-test--endpoint
+                                 "stats" "GET" "/api/v1/stats")
+                                (starintel-test--endpoint
+                                 "document_read" "GET" "/document/:id" t)
+                                (starintel-test--endpoint
+                                 "search" "GET" "/search" t)))))
+            (compatibility .
+                            ((legacy_routes .
+                                            ,(if legacy-routes t :json-false))
+                             (legacy_routes_deprecated . :json-false))))))))
+
+(cl-defun starintel-test--queue-capabilities (&key (endpoints nil) (legacy-routes nil))
+  "Queue one capabilities response built from ENDPOINTS and LEGACY-ROUTES."
+  (push (list :status 200
+              :headers '(("Content-Type" . "application/json"))
+              :body (starintel-test--capabilities-json
+                     :endpoints endpoints
+                     :legacy-routes legacy-routes))
+        starintel-test--responses))
+
+(defconst starintel-test--search-body
+  (json-encode
+   '((total_rows . 1)
+     (bookmark . "bm-1")
+     (rows . [((id . "doc-1")
+               (order . [1.0])
+               (doc . ((_id . "doc-1")
+                       (dtype . "host")
+                       (dataset . "default"))))]))))
+
+;;; ------------------------------------------------------------------
+;;; Capability discovery
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-capability-discovery-success ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities)
+   (let ((caps (starintel-api-capabilities)))
+     (should (equal "starintel-gserver"
+                    (alist-get 'service (alist-get 'build caps))))
+     (should (equal "v1" (alist-get 'api (alist-get 'schema_revisions caps))))
+     (should (equal "0.9.7"
+                    (alist-get 'document (alist-get 'schema_revisions caps))))
+     (should (equal '("api-key")
+                    (alist-get 'modes (alist-get 'authentication caps))))
+     (should (alist-get 'endpoints caps)))))
+
+(ert-deftest starintel-test-capability-discovery-uses-versioned-path ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities)
+   (starintel-api-capabilities)
+   (should (equal "http://starintel.test:5000/api/v1/capabilities"
+                  (plist-get (starintel-test-last-request) :url)))))
+
+(ert-deftest starintel-test-capability-discovery-caches ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities)
+   (starintel-api-capabilities)
+   (should (= 1 (starintel-test-request-count)))
+   ;; Second call must be served from the cache without a new request.
+   (starintel-api-capabilities)
+   (should (= 1 (starintel-test-request-count)))
+   ;; REFRESH forces a new request.
+   (starintel-test--queue-capabilities)
+   (starintel-api-capabilities :refresh t)
+   (should (= 2 (starintel-test-request-count)))))
+
+(ert-deftest starintel-test-capability-missing-endpoints-is-bad-response ()
+  (starintel-test-with-client
+   (push `(:status 200
+                   :headers '(("Content-Type" . "application/json"))
+                   :body ,(json-encode '((status . "ok") (data . ((build . nil))))))
+         starintel-test--responses)
+   (should-error (starintel-api-capabilities)
+                 :type 'starintel-api-bad-response-error)))
+
+;;; ------------------------------------------------------------------
+;;; Authentication and secret safety
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-auth-header-sent-when-token-configured ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities)
+   (starintel-api-capabilities)
+   (should (equal (concat "Bearer " starintel-test-token)
+                  (starintel-test-header (starintel-test-last-request)
+                                         "Authorization")))))
+
+(ert-deftest starintel-test-no-auth-header-without-token ()
+  (starintel-test-with-client
+   (let ((starintel-api-token nil))
+     (starintel-test--queue-capabilities)
+     (starintel-api-capabilities)
+     (should-not (starintel-test-header (starintel-test-last-request)
+                                        "Authorization")))))
+
+(ert-deftest starintel-test-token-never-appears-in-url ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities)
+   (starintel-api-capabilities)
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body starintel-test--search-body)
+         starintel-test--responses)
+   (starintel-api-search "alice")
+   (dolist (request starintel-test--requests)
+     (should-not (string-match-p (regexp-quote starintel-test-token)
+                                 (plist-get request :url))))))
+
+(ert-deftest starintel-test-timeout-signals-typed-error-with-redaction ()
+  (starintel-test-with-client
+   (let ((starintel-test--response-function
+          (lambda ()
+            (signal 'starintel-api-timeout-error
+                    (list (format "deadline exceeded for %s"
+                                  starintel-test-token))))))
+     (let ((err (should-error (starintel-api-capabilities)
+                              :type 'starintel-api-timeout-error)))
+       (should (eq 'starintel-api-timeout-error (car err)))
+       (should-not (string-match-p (regexp-quote starintel-test-token)
+                                   (plist-get (nth 1 err) :message)))))))
+
+(ert-deftest starintel-test-timeout-return-normalized ()
+  (starintel-test-with-client
+   (let ((starintel-test--responses '((:timeout t))))
+     (should-error (starintel-api-health)
+                   :type 'starintel-api-timeout-error))))
+
+(ert-deftest starintel-test-transport-error-redacted-and-typed ()
+  (starintel-test-with-client
+   (let ((starintel-test--response-function
+          (lambda ()
+            (error "connection refused while authenticating %s"
+                   starintel-test-token))))
+     (let ((err (should-error (starintel-api-health)
+                              :type 'starintel-api-connection-error)))
+       (should (eq 'starintel-api-connection-error (car err)))
+       (should-not (string-match-p (regexp-quote starintel-test-token)
+                                   (plist-get (nth 1 err) :message)))))))
+
+;;; ------------------------------------------------------------------
+;;; Request metadata: correlation ID and deadline
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-correlation-and-deadline-headers ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities)
+   (starintel-api-capabilities)
+   (let* ((request (starintel-test-last-request))
+          (correlation (starintel-test-header request "X-Correlation-ID"))
+          (deadline (starintel-test-header request "X-Request-Timeout-Ms")))
+     (should correlation)
+     (should (<= (length correlation) 128))
+     (should (string-match-p "^[A-Za-z0-9_.:-]+$" correlation))
+     (should (equal "30000" deadline)))))
+
+;;; ------------------------------------------------------------------
+;;; Response decoding and structured errors
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-malformed-json-signals-bad-response ()
+  (starintel-test-with-client
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body "{\"status\": \"ok\", oops")
+         starintel-test--responses)
+   (let ((err (should-error (starintel-api-health)
+                            :type 'starintel-api-bad-response-error)))
+     (should-not (string-match-p (regexp-quote starintel-test-token)
+                                 (plist-get (nth 1 err) :message))))))
+
+(ert-deftest starintel-test-401-signals-auth-error ()
+  (starintel-test-with-client
+   (push (list :status 401
+               :headers '(("Content-Type" . "application/json")
+                          ("X-Correlation-ID" . "corr-401"))
+               :body (json-encode
+                      '((status . "error")
+                        (code . "invalid_credential")
+                        (msg . "Authentication failed")
+                        (correlation_id . "corr-401"))))
+         starintel-test--responses)
+   (let ((err (should-error (starintel-api-health)
+                            :type 'starintel-api-auth-error)))
+     (should (eq 'starintel-api-auth-error (car err)))
+     (should (equal 401 (plist-get (nth 1 err) :http-status)))
+     (should (equal "invalid_credential" (plist-get (nth 1 err) :code)))
+     (should (equal "corr-401" (plist-get (nth 1 err) :correlation-id)))
+     (should (string-match-p "invalid_credential"
+                             (plist-get (nth 1 err) :message))))))
+
+(ert-deftest starintel-test-403-signals-authorization-error ()
+  (starintel-test-with-client
+   (push (list :status 403
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode
+                      '((status . "error")
+                        (code . "access_denied")
+                        (msg . "Access denied")
+                        (correlation_id . "corr-403"))))
+         starintel-test--responses)
+   (let ((err (should-error (starintel-api-health)
+                            :type 'starintel-api-forbidden-error)))
+     (should (eq 'starintel-api-forbidden-error (car err)))
+     (should (equal "access_denied" (plist-get (nth 1 err) :code))))))
+
+(ert-deftest starintel-test-structured-error-response ()
+  (starintel-test-with-client
+   (push (list :status 422
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode
+                      '((status . "error")
+                        (code . "invalid_document_schema")
+                        (msg . "Document does not conform to the canonical schema")
+                        (correlation_id . "corr-422"))))
+         starintel-test--responses)
+   (let ((err (should-error (starintel-api-health)
+                            :type 'starintel-api-validation-error)))
+     (should (equal 422 (plist-get (nth 1 err) :http-status)))
+     (should (equal "invalid_document_schema" (plist-get (nth 1 err) :code)))
+     (should (string-match-p "corr-422" (plist-get (nth 1 err) :message)))
+     (should-not (string-match-p (regexp-quote starintel-test-token)
+                                 (plist-get (nth 1 err) :message))))))
+
+(ert-deftest starintel-test-5xx-signals-server-error ()
+  (starintel-test-with-client
+   (push (list :status 503
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode
+                      '((status . "error")
+                        (code . "unavailable")
+                        (msg . "Upstream store unavailable"))))
+         starintel-test--responses)
+   (should-error (starintel-api-health)
+                 :type 'starintel-api-server-error)))
+
+(ert-deftest starintel-test-2xx-error-envelope-signals-error ()
+  (starintel-test-with-client
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode
+                      '((status . "error")
+                        (code . "legacy_error")
+                        (msg . "boom"))))
+         starintel-test--responses)
+   (let ((err (should-error (starintel-api-health)
+                            :type 'starintel-api-error)))
+     (should-not (eq 'starintel-api-http-error (car err)))
+     (should (equal "legacy_error" (plist-get (nth 1 err) :code))))))
+
+(ert-deftest starintel-test-404-signals-not-found ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities :legacy-routes t)
+   (starintel-api-capabilities)
+   (push (list :status 404
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode
+                      '((status . "error")
+                        (code . "not_found")
+                        (msg . "missing"))))
+         starintel-test--responses)
+   (should-error (starintel-api-get-document "nope")
+                 :type 'starintel-api-not-found-error)))
+
+;;; ------------------------------------------------------------------
+;;; Health and server info
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-health-ok ()
+  (starintel-test-with-client
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json")
+                          ("X-Correlation-ID" . "corr-h"))
+               :body (json-encode
+                      '((status . "ok")
+                        (msg . "OK")
+                        (correlation_id . "corr-h"))))
+         starintel-test--responses)
+   (let* ((result (starintel-api-health))
+          (data (plist-get result :data)))
+     (should (equal "OK" (alist-get 'msg data)))
+     (should (equal "corr-h" (plist-get result :correlation-id)))
+     (should (equal "http://starintel.test:5000/health"
+                    (plist-get (starintel-test-last-request) :url))))))
+
+(ert-deftest starintel-test-server-info-ok ()
+  (starintel-test-with-client
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode
+                      '((doc_spec_version . "0.9.7")
+                        (server . "starintel-gserver")
+                        (version . "0.9.4")
+                        (openapi . "/openapi.json")
+                        (client_manifest . "/client-manifest.json"))))
+         starintel-test--responses)
+   (let ((data (plist-get (starintel-api-server-info) :data)))
+     (should (equal "0.9.7" (alist-get 'doc_spec_version data)))
+     (should (equal "starintel-gserver" (alist-get 'server data))))))
+
+;;; ------------------------------------------------------------------
+;;; Search endpoint resolution
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-search-uses-versioned-endpoint ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities)
+   (starintel-api-capabilities)
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body starintel-test--search-body)
+         starintel-test--responses)
+   (let ((result (starintel-api-search "alice bob" :limit 10)))
+     (should (equal "http://starintel.test:5000/api/v1/search?q=alice%20bob&limit=10"
+                    (plist-get (starintel-test-last-request) :url)))
+     (should (equal 1 (alist-get 'total_rows result)))
+     (should (= 1 (length (alist-get 'rows result))))
+     (should (equal "host"
+                    (alist-get 'dtype
+                               (alist-get 'doc (car (alist-get 'rows result)))))))))
+
+(ert-deftest starintel-test-search-unavailable-capability ()
+  (starintel-test-with-client
+   ;; No public_search endpoint and no legacy compatibility advertisement.
+   (starintel-test--queue-capabilities
+    :endpoints (list (starintel-test--endpoint
+                      "capabilities" "GET" "/api/v1/capabilities"))
+    :legacy-routes nil)
+   (let ((err (should-error (starintel-api-search "alice")
+                            :type 'starintel-api-unavailable-capability)))
+     ;; Only the capability discovery request may have happened.
+     (should (= 1 (starintel-test-request-count)))
+     (should (string-match-p "search"
+                             (plist-get (nth 1 err) :message))))))
+
+(ert-deftest starintel-test-search-legacy-fallback-when-advertised ()
+  (starintel-test-with-client
+   ;; No versioned public_search endpoint, but legacy routes are
+   ;; explicitly advertised as compatible.
+   (starintel-test--queue-capabilities
+    :endpoints (list
+                (starintel-test--endpoint
+                 "capabilities" "GET" "/api/v1/capabilities")
+                (starintel-test--endpoint "search" "GET" "/search" t))
+    :legacy-routes t)
+   (starintel-api-capabilities)
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body starintel-test--search-body)
+         starintel-test--responses)
+   (starintel-api-search "alice")
+   (should (equal "http://starintel.test:5000/search?q=alice&limit=25"
+                  (plist-get (starintel-test-last-request) :url)))))
+
+(ert-deftest starintel-test-search-legacy-endpoint-ignored-without-compatibility ()
+  (starintel-test-with-client
+   ;; The legacy search endpoint is advertised but compatibility is off.
+   (starintel-test--queue-capabilities
+    :endpoints (list
+                (starintel-test--endpoint
+                 "capabilities" "GET" "/api/v1/capabilities")
+                (starintel-test--endpoint "search" "GET" "/search" t))
+    :legacy-routes nil)
+   (should-error (starintel-api-search "alice")
+                 :type 'starintel-api-unavailable-capability)))
+
+(ert-deftest starintel-test-search-prefers-versioned-over-legacy ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities :legacy-routes t)
+   (starintel-api-capabilities)
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body starintel-test--search-body)
+         starintel-test--responses)
+   (starintel-api-search "alice")
+   (should (string-match-p "/api/v1/search"
+                           (plist-get (starintel-test-last-request) :url)))))
+
+;;; ------------------------------------------------------------------
+;;; Document lookup endpoint resolution
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-document-lookup-via-advertised-legacy-endpoint ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities :legacy-routes t)
+   (starintel-api-capabilities)
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode
+                      '((id . "doc-1")
+                        (dtype . "host")
+                        (dataset . "default"))))
+         starintel-test--responses)
+   (let ((doc (starintel-api-get-document "doc 1")))
+     (should (equal "http://starintel.test:5000/document/doc%201"
+                    (plist-get (starintel-test-last-request) :url)))
+     (should (equal "host" (alist-get 'dtype doc))))))
+
+(ert-deftest starintel-test-document-lookup-uses-versioned-endpoint-when-advertised ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities
+    :endpoints (list
+                (starintel-test--endpoint
+                 "capabilities" "GET" "/api/v1/capabilities")
+                (starintel-test--endpoint
+                 "document_read" "GET" "/api/v1/documents/:id"))
+    :legacy-routes nil)
+   (starintel-api-capabilities)
+   (push (list :status 200
+               :headers '(("Content-Type" . "application/json"))
+               :body (json-encode '((_id . "doc-1") (dtype . "host"))))
+         starintel-test--responses)
+   (starintel-api-get-document "doc-1")
+   (should (equal "http://starintel.test:5000/api/v1/documents/doc-1"
+                  (plist-get (starintel-test-last-request) :url)))))
+
+(ert-deftest starintel-test-document-lookup-unavailable-without-compatibility ()
+  (starintel-test-with-client
+   ;; Only the legacy document_read endpoint is advertised and
+   ;; compatibility is explicitly off.
+   (starintel-test--queue-capabilities :legacy-routes nil)
+   (should-error (starintel-api-get-document "doc-1")
+                 :type 'starintel-api-unavailable-capability)))
+
+(ert-deftest starintel-test-document-capability-predicate ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities :legacy-routes t)
+   (should (starintel-api-document-lookup-available-p)))
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities :legacy-routes nil)
+   (starintel-api-capabilities)
+   (should-not (starintel-api-document-lookup-available-p))))
+
+;;; ------------------------------------------------------------------
+;;; Interactive command surface
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-search-command-gated-on-capability ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities
+    :endpoints (list (starintel-test--endpoint
+                      "capabilities" "GET" "/api/v1/capabilities"))
+    :legacy-routes nil)
+   (let ((err (should-error (starintel-search "alice")
+                            :type 'user-error)))
+     (should (string-match-p "search" (error-message-string err))))))
+
+(ert-deftest starintel-test-document-command-gated-on-capability ()
+  (starintel-test-with-client
+   (starintel-test--queue-capabilities :legacy-routes nil)
+   (let ((err (should-error (starintel-document "doc-1")
+                            :type 'user-error)))
+     (should (string-match-p "document" (error-message-string err))))))
+
+(ert-deftest starintel-test-search-command-renders-results-buffer ()
+  (starintel-test-with-client
+   (let ((starintel-ui-buffer-name "*StarIntel Test Results*"))
+     (starintel-test--queue-capabilities)
+     (starintel-api-capabilities)
+     (push (list :status 200
+                 :headers '(("Content-Type" . "application/json"))
+                 :body starintel-test--search-body)
+           starintel-test--responses)
+     (starintel-search "alice")
+     (with-current-buffer (get-buffer starintel-ui-buffer-name)
+       (goto-char (point-min))
+       (should (search-forward "doc-1" nil t)))
+     (when (get-buffer starintel-ui-buffer-name)
+       (kill-buffer starintel-ui-buffer-name)))))
+
+(ert-deftest starintel-test-status-command-renders-info-buffer ()
+  (starintel-test-with-client
+   (let ((starintel-ui-buffer-name "*StarIntel Test Status*"))
+     (starintel-test--queue-capabilities)
+     (push (list :status 200
+                 :headers '(("Content-Type" . "application/json")
+                            ("X-Correlation-ID" . "corr-h"))
+                 :body (json-encode
+                        '((status . "ok") (msg . "OK") (correlation_id . "corr-h"))))
+           starintel-test--responses)
+     (push (list :status 200
+                 :headers '(("Content-Type" . "application/json"))
+                 :body (json-encode
+                        '((doc_spec_version . "0.9.7")
+                          (server . "starintel-gserver")
+                          (version . "0.9.4"))))
+           starintel-test--responses)
+     (starintel-status)
+     (with-current-buffer (get-buffer starintel-ui-buffer-name)
+       (goto-char (point-min))
+       (should (search-forward "starintel-gserver" nil t))
+       (should (search-forward "0.9.7" nil t))
+       (should (search-forward "OK" nil t)))
+     (when (get-buffer starintel-ui-buffer-name)
+       (kill-buffer starintel-ui-buffer-name)))))
+
+(ert-deftest starintel-test-connect-configures-session ()
+  (starintel-test-with-client
+   (let ((starintel-ui-buffer-name "*StarIntel Test Connect*"))
+     ;; status order: server-info, health, capabilities
+     (starintel-test--queue-capabilities)
+     (push (list :status 200
+                 :headers '(("Content-Type" . "application/json"))
+                 :body (json-encode
+                        '((status . "ok") (msg . "OK"))))
+           starintel-test--responses)
+     (push (list :status 200
+                 :headers '(("Content-Type" . "application/json"))
+                 :body (json-encode
+                        '((server . "starintel-gserver")
+                          (version . "0.9.4")
+                          (doc_spec_version . "0.9.7"))))
+           starintel-test--responses)
+     (starintel-connect "http://starintel.test:5000" "star_sk_v1_secret-token-1234")
+     (should (equal "http://starintel.test:5000" starintel-api-base-url))
+     (should (equal starintel-test-token starintel-api-token))
+     (should (assq 'endpoints starintel-api--capabilities-cache))
+     (should (= 3 (starintel-test-request-count)))
+     ;; Empty token selects anonymous operation; status runs again.
+     (starintel-test--queue-capabilities)
+     (push (list :status 200
+                 :headers '(("Content-Type" . "application/json"))
+                 :body (json-encode '((status . "ok") (msg . "OK"))))
+           starintel-test--responses)
+     (push (list :status 200
+                 :headers '(("Content-Type" . "application/json"))
+                 :body (json-encode '((server . "starintel-gserver")
+                                      (version . "0.9.4")
+                                      (doc_spec_version . "0.9.7"))))
+           starintel-test--responses)
+     (starintel-connect "http://starintel.test:5000" "")
+     (should-not starintel-api-token)
+     (when (get-buffer starintel-ui-buffer-name)
+       (kill-buffer starintel-ui-buffer-name)))))
+
+(ert-deftest starintel-test-legacy-async-search-still-works ()
+  "The legacy callback API remains available for existing callers."
+  (starintel-test-with-client
+   ;; The legacy path goes through starintel-search-legacy, which uses
+   ;; the legacy request.el surface; here we only assert the shim
+   ;; exists and delegates when a callback is supplied.
+   (should (fboundp 'starintel-search-legacy))))
+
+;;; ------------------------------------------------------------------
+;;; Async dispatch (deferred transport)
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-async-request-delivers-success-later ()
+  (starintel-test-with-deferred-client
+   (let ((got nil))
+     (starintel-api-health :on-success (lambda (result) (setq got result)))
+     ;; Nothing delivered until the transport completes.
+     (should-not got)
+     (should (equal '("http://starintel.test:5000/health")
+                    (starintel-test--deferred-urls)))
+     (starintel-test--release
+      (list :status 200
+            :headers '(("Content-Type" . "application/json")
+                       ("X-Correlation-ID" . "c-async"))
+            :body (json-encode '((status . "ok") (msg . "OK")))))
+     (should got)
+     (should (equal "OK" (cdr (assq 'msg (plist-get got :data)))))
+     (should (equal "c-async" (plist-get got :correlation-id))))))
+
+(ert-deftest starintel-test-async-error-delivered-to-on-error ()
+  (starintel-test-with-deferred-client
+   (let ((got-error nil) (got-success nil))
+     (starintel-api-health
+      :on-success (lambda (_result) (setq got-success t))
+      :on-error (lambda (condition plist)
+                  (setq got-error (cons condition plist))))
+     (should-not got-error)
+     (starintel-test--release
+      (list :status 401
+            :headers '(("Content-Type" . "application/json"))
+            :body (json-encode
+                   '((status . "error")
+                     (code . "invalid_credential")
+                     (msg . "Authentication failed")))))
+     (should-not got-success)
+     (should (eq 'starintel-api-auth-error (car got-error)))
+     (should (equal 401 (plist-get (cdr got-error) :http-status))))))
+
+(ert-deftest starintel-test-async-error-without-callback-routed-to-handler ()
+  (starintel-test-with-deferred-client
+   (let ((reported nil))
+     (let ((starintel-api-async-error-function
+            (lambda (condition _plist) (setq reported condition))))
+       (starintel-api-health :on-success (lambda (_r) (setq reported 'success)))
+       (starintel-test--release
+        (list :status 503
+              :headers '(("Content-Type" . "application/json"))
+              :body (json-encode
+                     '((status . "error")
+                       (code . "unavailable")
+                       (msg . "down")))))
+       (should (eq 'starintel-api-server-error reported))))))
+
+(ert-deftest starintel-test-async-search-chains-capabilities-then-search ()
+  (starintel-test-with-deferred-client
+   (let ((got nil))
+     (starintel-api-search "alice" :on-success (lambda (data) (setq got data)))
+     ;; Capability discovery is requested first; no search yet.
+     (should (equal '("http://starintel.test:5000/api/v1/capabilities")
+                    (starintel-test--deferred-urls)))
+     (starintel-test--release
+      (list :status 200
+            :headers '(("Content-Type" . "application/json"))
+            :body (starintel-test--capabilities-json)))
+     (should-not got)
+     ;; Now the search itself is pending on the versioned endpoint.
+     (should (equal '("http://starintel.test:5000/api/v1/search?q=alice&limit=25")
+                    (starintel-test--deferred-urls)))
+     (starintel-test--release
+      (list :status 200
+            :headers '(("Content-Type" . "application/json"))
+            :body starintel-test--search-body))
+     (should got)
+     (should (= 1 (length (cdr (assq 'rows got))))))))
+
+(ert-deftest starintel-test-async-unavailable-capability-reaches-on-error ()
+  (starintel-test-with-deferred-client
+   (let ((failure nil))
+     (starintel-api-search "alice"
+       :on-success (lambda (_d) (setq failure 'unexpected-success))
+       :on-error (lambda (condition plist)
+                   (setq failure (cons condition plist))))
+     (starintel-test--release
+      (list :status 200
+            :headers '(("Content-Type" . "application/json"))
+            :body (starintel-test--capabilities-json
+                   :endpoints (list (starintel-test--endpoint
+                                     "capabilities" "GET" "/api/v1/capabilities"))
+                   :legacy-routes nil)))
+     (should (eq 'starintel-api-unavailable-capability (car failure)))
+     ;; No search request was made.
+     (should-not starintel-test--deferred))))
+
+(ert-deftest starintel-test-async-capabilities-cached-across-operations ()
+  (starintel-test-with-deferred-client
+   (let ((got nil))
+     (starintel-api-search "alice" :on-success (lambda (data) (setq got data)))
+     (starintel-test--release
+      (list :status 200
+            :headers '(("Content-Type" . "application/json"))
+            :body (starintel-test--capabilities-json)))
+     (starintel-test--release
+      (list :status 200
+            :headers '(("Content-Type" . "application/json"))
+            :body starintel-test--search-body))
+     (should got)
+     ;; A second search reuses the cache: only the search is requested.
+     (setq got nil)
+     (starintel-api-search "bob" :on-success (lambda (data) (setq got data)))
+     (should (equal '("http://starintel.test:5000/api/v1/search?q=bob&limit=25")
+                    (starintel-test--deferred-urls))))))
+
+;;; ------------------------------------------------------------------
+;;; Legacy helper preservation
+;;; ------------------------------------------------------------------
+
+(ert-deftest starintel-test-legacy-helpers-preserved ()
+  (dolist (fn '(starintel-get-server-info
+                starintel-health-check
+                starintel-get-document
+                starintel-create-target
+                starintel-get-targets
+                starintel-create-document
+                starintel-hosts-by-ip
+                starintel-dataset-size
+                starintel-format-document))
+    (should (fboundp fn))))
+
+(provide 'client-test)
+;;; client-test.el ends here

--- a/client.el
+++ b/client.el
@@ -2,23 +2,61 @@
 
 ;; Copyright (C) 2024
 
-;; Author: unseen
-;; Version: 1.0.0
-;; Package-Requires: ((emacs "27.1") (request "0.3.2") (json "1.5") (starintel-doc "0.7.3"))
+;; Author: nsaspy
+;; Version: 2.0.0
+;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: tools, processes
-;; URL: https://github.com/nsaspy/starintel
+;; URL: https://github.com/lost-rob0t/starintel-server
 
 ;;; Commentary:
 
-;; A fully-featured Emacs client for the StarIntel server API.
-;; Provides functions to interact with all StarIntel HTTP endpoints.
+;; An Emacs client for the StarIntel server.
+;;
+;; The client is an adapter over the StarIntel public HTTP contract:
+;;
+;; - `starintel-connect' configures the server base URL and bearer
+;;   credential, discovers `GET /api/v1/capabilities', and verifies
+;;   health.  Interactive commands: `starintel-connect',
+;;   `starintel-status', `starintel-search', `starintel-document'.
+;;
+;; - The `starintel-api-*' layer is a fully asynchronous pure
+;;   transport/contract layer and returns plain data.  Every operation
+;;   accepts `:on-success'/`:on-error' callbacks and dispatches without
+;;   blocking Emacs; without callbacks the same operations run through
+;;   a bounded synchronous facade for scripts and tests.  The layer
+;;   performs capability discovery, bearer authentication through
+;;   headers only, explicit request deadlines (X-Request-Timeout-Ms
+;;   plus local enforcement), correlation IDs, and secret-safe typed
+;;   errors.  Later integrations (Hackmode, Nyxt bridges) should
+;;   consume these functions directly.
+;;
+;; - The `starintel-ui-*' layer renders results into the *StarIntel*
+;;   buffer.  Capability discovery decides which interactive commands
+;;   are usable; unsupported operations fail fast with a clear message
+;;   instead of probing routes.
+;;
+;; - Versioned endpoints advertised by the server are preferred.  Legacy
+;;   routes are only used when the server capability document
+;;   explicitly advertises `compatibility.legacy_routes'.
+;;
+;; The legacy callback API (starintel-get-document, starintel-search
+;; with a CALLBACK argument, the view-query helpers, and
+;; starintel-create-target/-document) is preserved for compatibility
+;; and still requires the third-party `request' package at runtime.
+;; The legacy document-construction helpers additionally require the
+;; `starintel-doc' library.  The modern layer needs neither.
 
 ;;; Code:
 
-(require 'request)
 (require 'json)
+(require 'url)
 (require 'url-util)
-(require 'starintel-doc)
+(require 'let-alist)
+(require 'cl-lib)
+;; Legacy dependencies are soft: the modern contract layer is
+;; self-contained on top of built-in libraries.
+(require 'request nil t)
+(require 'starintel-doc nil t)
 
 ;;; Customization
 
@@ -48,9 +86,766 @@
   :group 'starintel)
 
 (defcustom starintel-request-timeout 30
-  "Timeout for API requests in seconds."
+  "Timeout for legacy API requests in seconds."
   :type 'integer
   :group 'starintel)
+
+;;; ------------------------------------------------------------------
+;;; Modern contract layer (API v1)
+;;; ------------------------------------------------------------------
+
+(defgroup starintel-api nil
+  "Capability-discovered StarIntel HTTP contract for Emacs."
+  :group 'starintel
+  :prefix "starintel-api-")
+
+(defcustom starintel-api-base-url nil
+  "Base URL of the StarIntel server, e.g. \"http://127.0.0.1:5000\".
+When nil it is derived from the legacy `starintel-host' and
+`starintel-port' settings."
+  :type '(choice (const :tag "Derive from legacy host settings" nil)
+                 string)
+  :group 'starintel-api)
+
+(defvar starintel-api-token nil
+  "Session bearer token for the StarIntel API.
+Set it with `starintel-connect' (or `setq'); it is never persisted
+through Customize and never embedded in URLs, buffers, or errors.")
+
+(defcustom starintel-api-token-function nil
+  "Function returning the bearer token for each request, or nil.
+Use this to fetch credentials from `auth-source' or another secret
+provider.  The return value is used exactly like `starintel-api-token'."
+  :type '(choice (const nil) function)
+  :group 'starintel-api)
+
+(defcustom starintel-api-timeout-ms 30000
+  "Per-request deadline in milliseconds.
+Sent as X-Request-Timeout-Ms and enforced locally by the transport."
+  :type 'natnum
+  :group 'starintel-api)
+
+(defcustom starintel-api-user-agent "starintel-emacs-client/2.0"
+  "User-Agent header for modern contract requests."
+  :type 'string
+  :group 'starintel-api)
+
+(defvar starintel-api-transport-function #'starintel-api-url-transport
+  "Async transport function used by the modern contract layer.
+Called as (METHOD URL HEADERS BODY TIMEOUT-MS CALLBACK).  It must
+arrange for CALLBACK to be funcalled exactly once with a response
+plist: (:status N :headers ALIST :body STRING) once the HTTP exchange
+finished, (:timeout t [:error TEXT]) when the deadline expired, or
+(:error TEXT) for connection-level failures.  The callback may run
+synchronously (before the transport returns) or asynchronously;
+transports must not signal across the boundary.  Tests substitute a
+fake transport here.")
+
+(defcustom starintel-api-async-error-function #'starintel-api-message-error
+  "Handler for async StarIntel errors that have no ON-ERROR callback.
+Called with the typed error condition symbol and its plist.  The
+default messages the redacted error without interrupting Emacs."
+  :type 'function
+  :group 'starintel-api)
+
+;;;; Typed errors
+
+(define-error 'starintel-api-error "StarIntel API error")
+(define-error 'starintel-api-transport-error "StarIntel transport failure"
+  'starintel-api-error)
+(define-error 'starintel-api-connection-error "StarIntel connection failure"
+  'starintel-api-transport-error)
+(define-error 'starintel-api-timeout-error "StarIntel request deadline exceeded"
+  'starintel-api-transport-error)
+(define-error 'starintel-api-bad-response-error "Malformed StarIntel server response"
+  'starintel-api-error)
+(define-error 'starintel-api-unavailable-capability "StarIntel capability not advertised"
+  'starintel-api-error)
+(define-error 'starintel-api-http-error "StarIntel HTTP error response"
+  'starintel-api-error)
+(define-error 'starintel-api-auth-error "StarIntel authentication failed"
+  'starintel-api-http-error)
+(define-error 'starintel-api-forbidden-error "StarIntel authorization denied"
+  'starintel-api-http-error)
+(define-error 'starintel-api-not-found-error "StarIntel resource not found"
+  'starintel-api-http-error)
+(define-error 'starintel-api-validation-error "StarIntel rejected request input"
+  'starintel-api-http-error)
+(define-error 'starintel-api-server-error "StarIntel server error"
+  'starintel-api-http-error)
+
+(defun starintel-api--token ()
+  "Resolve the current bearer token, or nil.
+The token is only ever used to build the Authorization header and to
+scrub error text."
+  (let ((token (or (and (stringp starintel-api-token)
+                        (not (string= starintel-api-token ""))
+                        starintel-api-token)
+                   (and (functionp starintel-api-token-function)
+                        (ignore-errors
+                          (let ((value (funcall starintel-api-token-function)))
+                            (and (stringp value)
+                                 (not (string= value ""))
+                                 value)))))))
+    token))
+
+(defun starintel-api--redact (string)
+  "Return STRING with bearer credentials removed."
+  (let ((result (if (stringp string) string (format "%s" string)))
+        (token (starintel-api--token)))
+    (when (and token (not (string= token "")))
+      (setq result
+            (replace-regexp-in-string (regexp-quote token) "REDACTED"
+                                      result t t)))
+    (setq result
+          (replace-regexp-in-string "Bearer[ \t]+[A-Za-z0-9._~+/=-]+"
+                                    "Bearer REDACTED" result t t))
+    result))
+
+(defun starintel-api--error-text (err)
+  "Return a redacted description of a raw signaled error ERR."
+  (starintel-api--redact
+   (condition-case nil
+       (error-message-string err)
+     (error (format "%S" err)))))
+
+(defun starintel-api--signal (condition plist)
+  "Signal CONDITION with PLIST after redacting its :message."
+  (let ((message (plist-get plist :message)))
+    (when message
+      (setq plist (plist-put plist :message (starintel-api--redact message)))))
+  (signal condition (list plist)))
+
+(defun starintel-api-error-message (err)
+  "Return the redacted message of a starintel-api error ERR.
+ERR is the condition data as captured by `condition-case' or
+`should-error': (SYMBOL . DATA)."
+  (let ((data (cdr err)))
+    (cond
+     ((and (listp data) data (plist-member (car data) :message))
+      (plist-get (car data) :message))
+     ((stringp data) (starintel-api--redact data))
+     (t (starintel-api--redact (format "%S" data))))))
+
+;;;; URL construction
+
+(defun starintel-api--base-url ()
+  "Return the normalized server base URL."
+  (let ((url (or starintel-api-base-url (starintel--base-url))))
+    (if (and (stringp url) (string-match-p "\\`https?://" url))
+        (replace-regexp-in-string "/+\\'" "" url)
+      (starintel-api--signal
+       'starintel-api-error
+       `(:message ,(format "Invalid StarIntel server base URL: %S" url))))))
+
+(defun starintel-api--url (path &optional query)
+  "Build the absolute URL for PATH with QUERY parameter alist."
+  (let ((url (concat (starintel-api--base-url) path)))
+    (when query
+      (setq url
+            (concat url "?"
+                    (mapconcat
+                     (lambda (pair)
+                       (format "%s=%s"
+                               (url-hexify-string (symbol-name (car pair)))
+                               (url-hexify-string (format "%s" (cdr pair)))))
+                     query "&"))))
+    url))
+
+(defun starintel-api--expand-path (path path-params)
+  "Substitute :name parameters in advertised PATH from PATH-PARAMS.
+Values are URL-encoded; unmatched :name segments are left untouched."
+  (let ((segments (split-string path "/" t)))
+    (concat (and (string-prefix-p "/" path) "/")
+            (mapconcat
+             (lambda (segment)
+               (if (string-prefix-p ":" segment)
+                   (let ((cell (assoc-string (substring segment 1)
+                                             path-params t)))
+                     (if cell
+                         (url-hexify-string (format "%s" (cdr cell)))
+                       segment))
+                 segment))
+             segments "/"))))
+
+;;;; Request plumbing
+
+(defun starintel-api--new-correlation-id ()
+  "Return a fresh correlation ID the server contract accepts.
+Correlation IDs are bounded to 1..128 chars of [A-Za-z0-9_.:-]."
+  (format "emacs-%d-%06d" (floor (float-time)) (random 999999)))
+
+(defun starintel-api--auth-headers ()
+  "Return the Authorization header when a token is configured."
+  (let ((token (starintel-api--token)))
+    (when token
+      `(("Authorization" . ,(concat "Bearer " token))))))
+
+(defun starintel-api--call-transport (method url headers body timeout-ms callback)
+  "Invoke the configured async transport for one exchange.
+The transport may complete CALLBACK synchronously (before returning)
+or asynchronously.  A transport that signals has its failure
+converted into an error response so nothing escapes the boundary:
+`starintel-api-timeout-error' becomes (:timeout t ...) and any other
+error becomes (:error TEXT).  Responses completed while the transport
+is still on the stack are delivered only after it returns, so errors
+raised by CALLBACK are never mistaken for transport failures.
+Returns non-nil when CALLBACK already ran."
+  (let* ((ran nil)
+         (completed nil)
+         (pending nil)
+         (oneway (lambda (response)
+                   (unless ran
+                     (setq ran t)
+                     (if completed
+                         (funcall callback response)
+                       (setq pending response))))))
+    (condition-case err
+        (funcall starintel-api-transport-function
+                 method url headers body timeout-ms oneway)
+      (starintel-api-timeout-error
+       (unless ran
+         (setq ran t)
+         (setq pending (list :timeout t
+                             :error (starintel-api--error-text err)))))
+      (error
+       (unless ran
+         (setq ran t)
+         (setq pending (list :error (starintel-api--error-text err))))))
+    (setq completed t)
+    (when pending
+      (funcall callback pending))
+    ran))
+
+(defun starintel-api--sync (timeout-ms run)
+  "Run RUN, a function of (ON-SUCCESS ON-ERROR), to completion.
+This is the synchronous facade over the async machinery: when the
+transport completes synchronously the value is returned immediately;
+otherwise blocks in `accept-process-output' until the exchange
+completes, bounded by TIMEOUT-MS (plus slack).  Returns the success
+value, or signals the typed error delivered to ON-ERROR."
+  (let* ((done nil)
+         (value nil)
+         (failure nil)
+         (deadline (+ (float-time) (/ (+ timeout-ms 2000) 1000.0))))
+    (funcall run
+             (lambda (v) (setq done t value v))
+             (lambda (condition plist)
+               (setq done t failure (cons condition plist))))
+    (while (and (not done) (< (float-time) deadline))
+      (accept-process-output nil 0.05))
+    (cond
+     (failure (signal (car failure) (list (cdr failure))))
+     (done value)
+     (t (signal 'starintel-api-timeout-error
+                `(:message ,(format "request did not complete within %d ms"
+                                    timeout-ms)))))))
+
+(defun starintel-api--request-async (method path query body timeout-ms
+                                            on-success on-error)
+  "Dispatch one async request; never blocks, never signals.
+ON-SUCCESS receives the result plist; ON-ERROR (when present)
+receives a typed condition symbol and its plist."
+  (let* ((timeout (or timeout-ms starintel-api-timeout-ms))
+         (correlation-id (starintel-api--new-correlation-id))
+         (url (starintel-api--url path query))
+         (headers `(("Accept" . "application/json")
+                    ("User-Agent" . ,starintel-api-user-agent)
+                    ("X-Correlation-ID" . ,correlation-id)
+                    ("X-Request-Timeout-Ms" . ,(number-to-string timeout))
+                    ,@(when body '(("Content-Type" . "application/json")))
+                    ,@(starintel-api--auth-headers))))
+    (starintel-api--call-transport
+     method url headers (when body (json-encode body)) timeout
+     (lambda (response)
+       (starintel-api--finish response on-success on-error method path)))))
+
+(cl-defun starintel-api--request (method path &key query body timeout-ms on-success on-error)
+  "Perform one request against the StarIntel contract.
+Async when ON-SUCCESS is non-nil: dispatches, returns nil, and later
+delivers the result plist to ON-SUCCESS or a typed error to ON-ERROR
+(or `starintel-api-async-error-function' when ON-ERROR is nil).
+Without ON-SUCCESS, blocks until completion and returns the result
+plist, signaling typed errors.
+
+The result plist has the shape (:status :headers :body :data
+:correlation-id)."
+  (if on-success
+      (starintel-api--request-async method path query body timeout-ms
+                                    on-success on-error)
+    (starintel-api--sync (or timeout-ms starintel-api-timeout-ms)
+      (lambda (on-ok on-err)
+        (starintel-api--request-async method path query body timeout-ms
+                                      on-ok on-err)))))
+
+;;;; Response handling
+
+(defun starintel-api--response-header (headers name)
+  "Look up NAME in response HEADERS alist, case-insensitively."
+  (cdr (assoc-string name headers t)))
+
+(defun starintel-api--decode-json-safe (text context)
+  "Decode JSON TEXT for CONTEXT without signaling.
+Returns (:ok DATA) or (:error MESSAGE)."
+  (if (string-match-p "\\`[[:space:]]*\\'" (or text ""))
+      '(:ok nil)
+    (let ((json-object-type 'alist)
+          (json-array-type 'list)
+          (json-false :json-false))
+      (condition-case nil
+          `(:ok ,(json-read-from-string text))
+        (error
+         `(:error ,(format "Malformed JSON in %s response: %s"
+                           context
+                           (substring text 0 (min (length text) 120)))))))))
+
+(defun starintel-api--error-envelope-p (data)
+  "Return non-nil when decoded DATA is a StarIntel error envelope."
+  (and (listp data)
+       (not (vectorp data))
+       (equal "error" (cdr (assq 'status data)))))
+
+(defun starintel-api--http-error-condition (status)
+  "Map HTTP STATUS to a typed client error condition."
+  (cond ((= status 401) 'starintel-api-auth-error)
+        ((= status 403) 'starintel-api-forbidden-error)
+        ((= status 404) 'starintel-api-not-found-error)
+        ((= status 429) 'starintel-api-http-error)
+        ((and (>= status 400) (< status 500))
+         'starintel-api-validation-error)
+        ((>= status 500) 'starintel-api-server-error)
+        (t 'starintel-api-http-error)))
+
+(defun starintel-api--error-result (condition message &rest keys)
+  "Build an (:error CONDITION PLIST) result with a redacted MESSAGE."
+  `(:error ,condition
+    ,(apply #'list :message (starintel-api--redact message) keys)))
+
+(defun starintel-api--validate-response (response method path)
+  "Validate a transport RESPONSE; never signals.
+Returns (:ok RESULT-PLIST) or (:error CONDITION PLIST)."
+  (let ((context (format "%s %s" method path)))
+    (cond
+     ((and (plist-get response :timeout) (not (plist-get response :status)))
+      (starintel-api--error-result
+       'starintel-api-timeout-error
+       (or (plist-get response :error)
+           (format "StarIntel request deadline exceeded for %s" context))))
+     ((plist-get response :error)
+      (starintel-api--error-result
+       'starintel-api-connection-error
+       (plist-get response :error)))
+     ((not (natnump (plist-get response :status)))
+      (starintel-api--error-result
+       'starintel-api-bad-response-error
+       "StarIntel transport returned no HTTP status"))
+     (t
+      (let* ((status (plist-get response :status))
+             (headers (plist-get response :headers))
+             (body (or (plist-get response :body) ""))
+             (correlation-id (starintel-api--response-header
+                              headers "X-Correlation-ID"))
+             (decoded (starintel-api--decode-json-safe body context)))
+        (cond
+         ((plist-get decoded :error)
+          (starintel-api--error-result
+           'starintel-api-bad-response-error
+           (plist-get decoded :error)))
+         ((and (<= 200 status) (< status 300))
+          (let ((data (plist-get decoded :ok)))
+            (if (starintel-api--error-envelope-p data)
+                (starintel-api--error-result
+                 'starintel-api-error
+                 (format "%s returned an error envelope: %s %s"
+                         context
+                         (or (cdr (assq 'code data)) "error")
+                         (or (cdr (assq 'msg data)) ""))
+                 :http-status status
+                 :code (cdr (assq 'code data))
+                 :correlation-id (or correlation-id
+                                     (cdr (assq 'correlation_id data))))
+               `(:ok (:status ,status
+                      :headers ,headers
+                      :body ,body
+                      :data ,data
+                      :correlation-id ,correlation-id)))))
+         (t
+          (let* ((data (plist-get decoded :ok))
+                 (code (cdr (assq 'code data)))
+                 (msg (or (cdr (assq 'msg data))
+                          (cdr (assq 'message data))
+                          (cdr (assq 'detail data))))
+                 (corr (or correlation-id (cdr (assq 'correlation_id data)))))
+            (starintel-api--error-result
+             (starintel-api--http-error-condition status)
+             (concat (format "HTTP %d" status)
+                     (and code (format " (%s)" code))
+                     ": "
+                     (or msg (format "%s request rejected" context))
+                     (and corr (format " [correlation %s]" corr)))
+             :http-status status
+             :code code
+             :correlation-id corr)))))))))
+
+(defun starintel-api--deliver-error (on-error condition plist)
+  "Deliver a typed error to ON-ERROR, or the default async handler."
+  (if on-error
+      (funcall on-error condition plist)
+    (funcall starintel-api-async-error-function condition plist)))
+
+(defun starintel-api--finish (response on-success on-error method path)
+  "Validate RESPONSE and deliver it to ON-SUCCESS/ON-ERROR."
+  (let ((result (starintel-api--validate-response response method path)))
+    (if (plist-get result :ok)
+        (funcall on-success (plist-get result :ok))
+      (starintel-api--deliver-error
+       on-error
+       (plist-get result :error)
+       (nth 2 result)))))
+
+(defun starintel-api-message-error (condition plist)
+  "Default async error handler: message the redacted error."
+  (message "StarIntel: %s"
+           (starintel-api-error-message (cons condition (list plist)))))
+
+;;;; Default url.el transport
+
+(defun starintel-api--parse-http-headers ()
+  "Collect HTTP header lines into an alist; move point to the body."
+  (let ((headers nil))
+    (catch 'done
+      (while t
+        (when (eobp) (throw 'done nil))
+        (let ((start (line-beginning-position))
+              (end (line-end-position)))
+          (if (= start end)
+              (progn (forward-line 1) (throw 'done nil))
+            (let ((line (buffer-substring-no-properties start end)))
+              (when (string-match "^\\([^:]+\\):[ \t]*\\(.*\\)" line)
+                (push (cons (match-string 1 line)
+                            (replace-regexp-in-string "\r\\'" ""
+                                                      (match-string 2 line)))
+                      headers))
+              (forward-line 1))))))
+    (nreverse headers)))
+
+(defun starintel-api--parse-http-buffer (buffer)
+  "Parse HTTP response BUFFER into (:status :headers :body)."
+  (with-current-buffer buffer
+    (goto-char (point-min))
+    (if (not (re-search-forward "\\`HTTP/[0-9.]+[ \t]+\\([0-9]+\\)" nil t))
+        (signal 'starintel-api-connection-error
+                '("server response did not contain an HTTP status line"))
+      (let* ((status (string-to-number (match-string 1)))
+             (headers (starintel-api--parse-http-headers))
+             (body (buffer-substring-no-properties (point) (point-max))))
+        `(:status ,status
+          :headers ,headers
+          :body ,(decode-coding-string body 'utf-8))))))
+
+(defun starintel-api--kill-response-buffer (buffer)
+  "Silently dispose of a url.el response BUFFER.
+The process sentinel and filter are detached before deletion so that
+truncated-response parsing inside url.el can neither prompt nor
+signal past the transport boundary."
+  (when (buffer-live-p buffer)
+    (let ((process (get-buffer-process buffer)))
+      (when (process-live-p process)
+        (set-process-sentinel process #'ignore)
+        (set-process-filter process #'ignore)
+        (delete-process process)))
+    (let ((kill-buffer-query-functions nil)
+          (kill-buffer-hook nil))
+      (kill-buffer buffer))))
+
+(defun starintel-api-url-transport (method url headers body timeout-ms callback)
+  "Default asynchronous transport built on url.el with a hard deadline.
+METHOD, URL, HEADERS and BODY make up the request; TIMEOUT-MS bounds
+the whole exchange.  Calls CALLBACK exactly once with (:status
+:headers :body), (:timeout t :error TEXT), or (:error TEXT); it never
+signals across the async boundary."
+  (let* ((url-request-method method)
+         (url-request-extra-headers headers)
+         (url-request-data (and body (encode-coding-string body 'utf-8)))
+         (done nil)
+         (buffer nil)
+         (timer nil)
+         (finish
+          (lambda (response)
+            (when timer (cancel-timer timer))
+            (ignore-errors (starintel-api--kill-response-buffer buffer))
+            (unless done
+              (setq done t)
+              (funcall callback response))))
+         (report
+          (lambda (&rest _)
+            (setq buffer (if (buffer-live-p buffer)
+                             buffer
+                           (current-buffer)))
+            (let ((parsed
+                   (when (buffer-live-p buffer)
+                     (ignore-errors
+                       (starintel-api--parse-http-buffer buffer)))))
+              (funcall finish
+                       (or parsed
+                           (list :error
+                                 (format "invalid HTTP response from %s %s"
+                                         method url))))))))
+    (let ((response-buffer
+           (condition-case err
+               (url-retrieve url report)
+             (error
+              (funcall finish
+                       (list :error
+                             (format "url-retrieve failed for %s %s: %s"
+                                     method url (error-message-string err))))
+              nil))))
+      (setq buffer (or buffer response-buffer))
+      (when (and (not buffer) (not done))
+        (funcall finish (list :error "url-retrieve returned no buffer"))))
+    (unless done
+      (setq timer
+            (run-at-time
+             (/ (max timeout-ms 1) 1000.0) nil
+             (lambda ()
+               (funcall finish
+                        (list :timeout t
+                              :error (format
+                                      "deadline of %d ms exceeded for %s %s"
+                                      timeout-ms method url)))))))
+    nil))
+
+;;;; Capability discovery
+
+(defconst starintel-api--capabilities-path "/api/v1/capabilities"
+  "Server capability discovery path.")
+
+(defvar starintel-api--capabilities-cache nil
+  "Cached capability document data from GET /api/v1/capabilities.")
+
+(defun starintel-api-clear-capabilities ()
+  "Drop the cached capability document."
+  (interactive)
+  (setq starintel-api--capabilities-cache nil))
+
+(defun starintel-api--capabilities-extract (result)
+  "Extract capability data from a capabilities RESULT plist.
+Returns (:ok DATA) or (:error CONDITION PLIST)."
+  (let* ((envelope (plist-get result :data))
+         (data (cdr (assq 'data envelope))))
+    (if (and (listp data) (assq 'endpoints data))
+        `(:ok ,data)
+      '(:error starintel-api-bad-response-error
+        (:message "capabilities response did not advertise any endpoints")))))
+
+(defun starintel-api--capabilities-async (on-success on-error)
+  "Fetch, validate and cache capabilities; deliver DATA to ON-SUCCESS."
+  (starintel-api--request
+   "GET" starintel-api--capabilities-path
+   :on-success
+   (lambda (result)
+     (let ((extracted (starintel-api--capabilities-extract result)))
+       (if (plist-get extracted :ok)
+           (progn
+             (setq starintel-api--capabilities-cache
+                   (plist-get extracted :ok))
+             (funcall on-success (plist-get extracted :ok)))
+         (starintel-api--deliver-error
+          on-error
+          (plist-get extracted :error)
+          (nth 2 extracted)))))
+   :on-error on-error))
+
+(cl-defun starintel-api-capabilities (&key refresh on-success on-error)
+  "Return the advertised server capability data, caching the result.
+With REFRESH non-nil, re-fetch even when a cached document exists.
+
+Async when ON-SUCCESS is given (called with the capability data);
+otherwise blocks and returns the data, signaling typed errors."
+  (cond
+   ((and (not refresh) starintel-api--capabilities-cache)
+    (let ((caps starintel-api--capabilities-cache))
+      (if on-success (funcall on-success caps) caps)))
+   (on-success
+    (starintel-api--capabilities-async on-success on-error))
+   (t
+    (let* ((result (starintel-api--request
+                    "GET" starintel-api--capabilities-path))
+           (extracted (starintel-api--capabilities-extract result)))
+      (if (plist-get extracted :ok)
+          (setq starintel-api--capabilities-cache
+                (plist-get extracted :ok))
+        (starintel-api--signal (plist-get extracted :error)
+                               (nth 2 extracted)))))))
+
+(defun starintel-api--endpoints (&optional caps)
+  "Return the advertised endpoint list from CAPS (default: cache)."
+  (cdr (assq 'endpoints (or caps starintel-api--capabilities-cache))))
+
+(defun starintel-api-endpoint-by-id (id &optional caps)
+  "Return the advertised endpoint with ID, or nil."
+  (seq-find (lambda (endpoint)
+              (equal id (cdr (assq 'id endpoint))))
+            (starintel-api--endpoints caps)))
+
+(defun starintel-api--endpoint-legacy-p (endpoint)
+  "Return non-nil when ENDPOINT is explicitly marked as legacy."
+  (eq t (cdr (assq 'legacy endpoint))))
+
+(defun starintel-api-legacy-compatible-p (&optional caps)
+  "Return non-nil when legacy-route compatibility is explicitly advertised."
+  (eq t (cdr (assq 'legacy_routes
+                   (assq 'compatibility
+                         (or caps starintel-api--capabilities-cache))))))
+
+(defun starintel-api-resolve-endpoint (canonical-id &optional legacy-id caps)
+  "Resolve the advertised endpoint to use for one operation.
+Prefer the non-legacy endpoint CANONICAL-ID.  When it is missing (or
+itself legacy-marked), fall back to LEGACY-ID (or CANONICAL-ID) only
+if the server advertises compatibility.legacy_routes.  Returns the
+endpoint alist or nil when the operation is unavailable."
+  (let* ((caps (or caps starintel-api--capabilities-cache))
+         (endpoint (starintel-api-endpoint-by-id canonical-id caps)))
+    (cond
+     ((and endpoint (not (starintel-api--endpoint-legacy-p endpoint)))
+      endpoint)
+     ((starintel-api-legacy-compatible-p caps)
+      (or (and legacy-id (starintel-api-endpoint-by-id legacy-id caps))
+          endpoint))
+     (t nil))))
+
+(defun starintel-api--unavailable-error (feature canonical-id)
+  "Build an (:error ...) result for an unadvertised FEATURE."
+  (starintel-api--error-result
+   'starintel-api-unavailable-capability
+   (format "%s is not advertised by %s: no versioned `%s' endpoint and legacy-route compatibility is not advertised"
+           feature (starintel-api--base-url) canonical-id)
+   :capability feature))
+
+(defun starintel-api--with-capabilities (on-error ready)
+  "Call READY with capabilities, discovering them first when cold.
+Discovery failures follow the async error protocol via ON-ERROR."
+  (if starintel-api--capabilities-cache
+      (funcall ready starintel-api--capabilities-cache)
+    (starintel-api-capabilities
+     :on-success ready
+     :on-error on-error)))
+
+;;;; Contract operations
+
+(cl-defun starintel-api-health (&key on-success on-error)
+  "Check process health via the contracted GET /health route.
+Async when ON-SUCCESS is given (called with the result plist);
+otherwise blocks and returns the result plist
+(:status :headers :body :data :correlation-id)."
+  (starintel-api--request "GET" "/health"
+                          :on-success on-success :on-error on-error))
+
+(cl-defun starintel-api-server-info (&key on-success on-error)
+  "Fetch server metadata via the contracted GET / route.
+Async when ON-SUCCESS is given (called with the result plist);
+otherwise blocks and returns the result plist whose :data holds
+server, version and document spec information."
+  (starintel-api--request "GET" "/"
+                          :on-success on-success :on-error on-error))
+
+(defconst starintel-api--search-canonical-id "public_search"
+  "Capability id of the versioned search endpoint.")
+(defconst starintel-api--search-legacy-id "search"
+  "Capability id of the legacy search endpoint.")
+
+(defun starintel-api-search-available-p ()
+  "Return non-nil when the connected server advertises search.
+Blocking convenience around capability discovery."
+  (and (starintel-api-capabilities)
+       (starintel-api-resolve-endpoint
+        starintel-api--search-canonical-id
+        starintel-api--search-legacy-id)))
+
+(defun starintel-api--search-async (query limit bookmark on-success on-error)
+  "Async search core: resolve the endpoint, then fetch results."
+  (starintel-api--with-capabilities
+   on-error
+   (lambda (_caps)
+     (let ((endpoint (starintel-api-resolve-endpoint
+                      starintel-api--search-canonical-id
+                      starintel-api--search-legacy-id)))
+       (if (null endpoint)
+           (starintel-api--deliver-error
+            on-error
+            (plist-get (starintel-api--unavailable-error
+                        "search" starintel-api--search-canonical-id)
+                       :error)
+            (nth 2 (starintel-api--unavailable-error
+                    "search" starintel-api--search-canonical-id)))
+         (let ((params `((q . ,query)
+                         (limit . ,(or limit 25)))))
+           (when bookmark
+             (setq params (append params `((bookmark . ,bookmark)))))
+           (starintel-api--request
+            "GET"
+            (starintel-api--expand-path (cdr (assq 'path endpoint)) nil)
+            :query params
+            :on-success (lambda (result)
+                          (funcall on-success (plist-get result :data)))
+            :on-error on-error)))))))
+
+(cl-defun starintel-api-search (query &key limit bookmark on-success on-error)
+  "Search documents for QUERY over the capability-resolved endpoint.
+LIMIT defaults to 25; BOOKMARK continues a previous result page.
+
+Async when ON-SUCCESS is given (called with the decoded search
+document); otherwise blocks and returns it, signaling typed errors."
+  (if on-success
+      (starintel-api--search-async query limit bookmark on-success on-error)
+    (starintel-api--sync starintel-api-timeout-ms
+      (lambda (on-ok on-err)
+        (starintel-api--search-async query limit bookmark on-ok on-err)))))
+
+(defconst starintel-api--document-read-id "document_read"
+  "Capability id of the document lookup endpoint.")
+
+(defun starintel-api-document-lookup-available-p ()
+  "Return non-nil when the connected server advertises document lookup.
+Blocking convenience around capability discovery."
+  (and (starintel-api-capabilities)
+       (starintel-api-resolve-endpoint starintel-api--document-read-id)))
+
+(defun starintel-api--document-async (id on-success on-error)
+  "Async document lookup core: resolve the endpoint, then fetch."
+  (starintel-api--with-capabilities
+   on-error
+   (lambda (_caps)
+     (let ((endpoint (starintel-api-resolve-endpoint
+                      starintel-api--document-read-id)))
+       (if (null endpoint)
+           (let ((result (starintel-api--unavailable-error
+                          "document lookup" starintel-api--document-read-id)))
+             (starintel-api--deliver-error
+              on-error
+              (plist-get result :error)
+              (nth 2 result)))
+         (starintel-api--request
+          "GET"
+          (starintel-api--expand-path
+           (cdr (assq 'path endpoint)) `(("id" . ,id)))
+          :on-success (lambda (result)
+                        (funcall on-success (plist-get result :data)))
+          :on-error on-error))))))
+
+(cl-defun starintel-api-get-document (id &key on-success on-error)
+  "Fetch the document with ID over the capability-resolved endpoint.
+Async when ON-SUCCESS is given (called with the decoded document
+alist); otherwise blocks and returns it, signaling typed errors."
+  (if on-success
+      (starintel-api--document-async id on-success on-error)
+    (starintel-api--sync starintel-api-timeout-ms
+      (lambda (on-ok on-err)
+        (starintel-api--document-async id on-ok on-err)))))
+
+;;; ------------------------------------------------------------------
+;;; Legacy utility functions (compatibility)
+;;; ------------------------------------------------------------------
 
 ;;; Internal Variables
 
@@ -118,6 +913,8 @@ PARAMS is an alist of query parameters.
 DATA is the request body (will be JSON encoded).
 SUCCESS is callback for successful response.
 ERROR is callback for error response."
+  (unless (fboundp 'request)
+    (error "Legacy StarIntel functions require the third-party `request' package; the modern starintel-api layer works without it"))
   (let ((url (concat (starintel--make-url path)
                      (starintel--encode-params params))))
     (request url
@@ -183,8 +980,8 @@ If CALLBACK is provided, call it with the result."
    (lambda (err)
      (message "Failed to get document %s: %s" id err))))
 
-(defun starintel-search (query &optional limit bookmark callback)
-  "Search documents with QUERY string.
+(defun starintel-search-legacy (query &optional limit bookmark callback)
+  "Search documents with QUERY string using the legacy routes.
 LIMIT is max results (default 25).
 BOOKMARK is pagination token.
 CALLBACK is called with search results."
@@ -544,6 +1341,8 @@ DELAY is scan delay in seconds.
 RECURRING if non-nil makes this a recurring target.
 TRANSIENT if non-nil marks as transient (not persisted).
 DATASET is the dataset name (default: 'default')."
+  (unless (fboundp 'starintel-doc-to-json)
+    (error "starintel-make-target requires the `starintel-doc' package"))
   (let ((target-obj (target
                      :dtype "target"
                      :dataset (or dataset "default")
@@ -575,7 +1374,234 @@ DATASET is the dataset name (default: 'default')."
   (let ((transient (alist-get 'transient doc)))
     (and transient (not (eq transient :json-false)))))
 
-;;; Interactive Commands
+;;; ------------------------------------------------------------------
+;;; Presentation layer
+;;; ------------------------------------------------------------------
+
+(defgroup starintel-ui nil
+  "Presentation of StarIntel results in Emacs buffers."
+  :group 'starintel
+  :prefix "starintel-ui-")
+
+(defcustom starintel-ui-buffer-name "*StarIntel*"
+  "Name of the buffer used to present StarIntel results."
+  :type 'string
+  :group 'starintel-ui)
+
+(defface starintel-ui-heading-face
+  '((t :inherit font-lock-keyword-face :weight bold))
+  "Face for StarIntel result headings."
+  :group 'starintel-ui)
+
+(defun starintel-ui--report-error (condition plist)
+  "Report an async StarIntel failure to the operator.
+When the exchange completed synchronously (fake transports, cached
+capabilities) this signals a `user-error'; in a real async callback
+Emacs displays the error message from the sentinel instead."
+  (user-error "StarIntel: %s"
+              (starintel-api-error-message (cons condition (list plist)))))
+
+(defun starintel-ui--buffer ()
+  "Return a clean presentation buffer named by `starintel-ui-buffer-name'."
+  (let ((buffer (get-buffer-create starintel-ui-buffer-name)))
+    (with-current-buffer buffer
+      (special-mode)
+      (let ((inhibit-read-only t))
+        (erase-buffer)))
+    buffer))
+
+(defun starintel-ui--insert-heading (title)
+  "Insert TITLE as a section heading."
+  (insert (propertize title 'face 'starintel-ui-heading-face) "\n")
+  (insert (make-string (min 72 (max (length title) 8)) ?-) "\n\n"))
+
+(defun starintel-ui--insert-field (label value)
+  "Insert LABEL/VALUE pair on one line."
+  (insert (format "%-22s %s\n" label (or value "?"))))
+
+(defun starintel-ui--feature-summary (caps)
+  "Return a plain description of advertised features in CAPS."
+  (mapconcat
+   (lambda (feature)
+     (format "%s:%s" (car feature)
+             (if (eq t (cdr feature)) "on" "off")))
+   (cdr (assq 'features caps)) "  "))
+
+(defun starintel-ui--render-status (info health caps)
+  "Render server INFO, HEALTH and CAPS in the StarIntel buffer."
+  (let ((info-data (plist-get info :data))
+        (health-data (plist-get health :data))
+        (search-endpoint (starintel-api-resolve-endpoint
+                          starintel-api--search-canonical-id
+                          starintel-api--search-legacy-id caps))
+        (document-endpoint (starintel-api-resolve-endpoint
+                            starintel-api--document-read-id nil caps)))
+    (with-current-buffer (starintel-ui--buffer)
+      (let ((inhibit-read-only t))
+        (starintel-ui--insert-heading
+         (format "StarIntel server %s" (starintel-api--base-url)))
+        (starintel-ui--insert-field
+         "server"
+         (cdr (assq 'server info-data)))
+        (starintel-ui--insert-field
+         "server version"
+         (cdr (assq 'version info-data)))
+        (starintel-ui--insert-field
+         "document spec"
+         (cdr (assq 'doc_spec_version info-data)))
+        (starintel-ui--insert-field
+         "api revision"
+         (cdr (assq 'api (assq 'schema_revisions caps))))
+        (starintel-ui--insert-field
+         "health"
+         (if (equal "ok" (cdr (assq 'status health-data)))
+             (or (cdr (assq 'msg health-data)) "ok")
+           (cdr (assq 'msg health-data))))
+        (starintel-ui--insert-field
+         "auth modes"
+         (mapconcat #'identity
+                    (cdr (assq 'modes (assq 'authentication caps))) ", "))
+        (insert "\n")
+        (starintel-ui--insert-heading "Advertised endpoints in use")
+        (starintel-ui--insert-field
+         "search"
+         (if search-endpoint
+             (format "%s%s"
+                     (cdr (assq 'path search-endpoint))
+                     (if (starintel-api--endpoint-legacy-p search-endpoint)
+                         " (legacy compatibility)" ""))
+           "not advertised"))
+        (starintel-ui--insert-field
+         "document lookup"
+         (if document-endpoint
+             (format "%s%s"
+                     (cdr (assq 'path document-endpoint))
+                     (if (starintel-api--endpoint-legacy-p document-endpoint)
+                         " (legacy compatibility)" ""))
+           "not advertised"))
+        (starintel-ui--insert-field
+         "legacy routes"
+         (if (starintel-api-legacy-compatible-p caps)
+             "advertised" "not advertised"))
+        (insert "\n")
+        (starintel-ui--insert-heading "Features")
+        (insert (starintel-ui--feature-summary caps) "\n")
+        (goto-char (point-min)))
+      (pop-to-buffer (current-buffer)))))
+
+(defun starintel-ui--render-search (query data)
+  "Render search results DATA for QUERY in the StarIntel buffer."
+  (let ((rows (cdr (assq 'rows data)))
+        (bookmark (cdr (assq 'bookmark data))))
+    (with-current-buffer (starintel-ui--buffer)
+      (let ((inhibit-read-only t))
+        (starintel-ui--insert-heading (format "Search: %s" query))
+        (insert (format "%d result(s)%s\n\n"
+                        (length rows)
+                        (if bookmark
+                            (format "  [bookmark: %s]" bookmark)
+                          "")))
+        (dolist (row rows)
+          (let ((doc (cdr (assq 'doc row))))
+            (insert
+             (format "[%s] %s\n"
+                     (or (cdr (assq 'dtype doc)) "?")
+                     (or (cdr (assq '_id doc)) (cdr (assq 'id row)) "?")))
+            (when doc
+              (starintel-ui--insert-field
+               "dataset" (cdr (assq 'dataset doc)))
+              (insert "\n"))))
+        (goto-char (point-min)))
+      (pop-to-buffer (current-buffer)))))
+
+(defun starintel-ui--render-document (id data)
+  "Render document DATA for ID in the StarIntel buffer."
+  (with-current-buffer (starintel-ui--buffer)
+    (let ((inhibit-read-only t))
+      (starintel-ui--insert-heading (format "Document: %s" id))
+      (insert (json-encode data))
+      (ignore-errors (json-pretty-print (point-min) (point-max)))
+      (goto-char (point-min)))
+    (pop-to-buffer (current-buffer))))
+
+;;; ------------------------------------------------------------------
+;;; Interactive commands
+;;; ------------------------------------------------------------------
+
+(defun starintel-connect (base-url token)
+  "Connect to the StarIntel server at BASE-URL with bearer TOKEN.
+TOKEN may be empty for public/anonymous servers.  The token lives
+only in the Emacs session: it is sent as an Authorization header and
+is never written into URLs, results, or persisted customization.
+Performs capability discovery and a health check, then shows the
+status buffer."
+  (interactive
+   (let* ((default (or starintel-api-base-url (starintel--base-url)))
+          (url (read-string "StarIntel server URL: " default))
+          (token (read-passwd "API token (empty for public/anonymous): ")))
+     (list url token)))
+  (setq starintel-api-base-url base-url)
+  (setq starintel-api-token (and token (not (string= token "")) token))
+  (starintel-api-clear-capabilities)
+  (starintel-status))
+
+(defun starintel-status ()
+  "Show server metadata, health and capability summary.
+Renders into the buffer named by `starintel-ui-buffer-name'.  The
+exchange is fully asynchronous: the buffer is rendered when the
+server answers."
+  (interactive)
+  (message "StarIntel: contacting %s..." (starintel-api--base-url))
+  (starintel-api-server-info
+   :on-success
+   (lambda (info)
+     (starintel-api-health
+      :on-success
+      (lambda (health)
+        (starintel-api-capabilities
+         :refresh t
+         :on-success
+         (lambda (caps)
+           (message nil)
+           (starintel-ui--render-status info health caps))
+         :on-error #'starintel-ui--report-error))
+      :on-error #'starintel-ui--report-error))
+   :on-error #'starintel-ui--report-error))
+
+(defun starintel-search (query &optional limit bookmark callback)
+  "Search StarIntel documents for QUERY and render the results.
+Uses the capability-resolved search endpoint: the versioned route
+when advertised, the legacy route only when the server explicitly
+advertises legacy-route compatibility.  LIMIT bounds the result page.
+The exchange is fully asynchronous; results render when the server
+answers.  When CALLBACK is non-nil, the legacy asynchronous behavior
+is preserved and CALLBACK is invoked with the raw response instead."
+  (interactive "sStarIntel search: ")
+  (if callback
+      (starintel-search-legacy query limit bookmark callback)
+    (message "StarIntel: searching for %s..." query)
+    (starintel-api-search
+     query :limit (or limit 25) :bookmark bookmark
+     :on-success (lambda (data)
+                   (message nil)
+                   (starintel-ui--render-search query data))
+     :on-error #'starintel-ui--report-error)))
+
+(defun starintel-document (id)
+  "Fetch and render the StarIntel document with ID.
+Uses the capability-resolved document endpoint and fails with a
+clear message when the server does not advertise document lookup.
+The exchange is fully asynchronous."
+  (interactive "sStarIntel document ID: ")
+  (message "StarIntel: fetching document %s..." id)
+  (starintel-api-get-document
+   id
+   :on-success (lambda (doc)
+                 (message nil)
+                 (starintel-ui--render-document id doc))
+   :on-error #'starintel-ui--report-error))
+
+;;; Legacy Interactive Commands
 
 (defun starintel-test-connection ()
   "Test connection to StarIntel server."
@@ -588,7 +1614,7 @@ DATASET is the dataset name (default: 'default')."
 (defun starintel-quick-search (query)
   "Perform quick search with QUERY and display results in minibuffer."
   (interactive "sSearch query: ")
-  (starintel-search
+  (starintel-search-legacy
    query 10 nil
    (lambda (data)
      (let ((docs (alist-get 'rows data)))


### PR DESCRIPTION
## Summary
- Rewrites `client.el` (v1 -> v2) as a fully asynchronous contract layer over the StarIntel public HTTP contract: capability discovery (`GET /api/v1/capabilities`), bearer-token auth via headers only, explicit request deadlines, correlation IDs, and secret-safe typed errors.
- Adds a UI layer (`starintel-ui-*`) rendering into the `*StarIntel*` buffer; interactive commands fail fast when capabilities are unsupported.
- Versioned endpoints preferred; legacy routes only used when `compatibility.legacy_routes` is advertised. Legacy callback API preserved (soft `request`/`starintel-doc` deps).
- Adds `client-test.el`: 42 hermetic ERT tests against a fake HTTP transport (no live server).
- Makefile: new `test-emacs` target.

## Verification
`make test-emacs` -> Ran 42 tests, 42 passed, 0 unexpected.

Author: nsaspy