### PR TITLE
fix: preserve JSON false/null through the document pipeline

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,7 +30,7 @@
       },
       "locked": {
         "lastModified": 1786244418,
-        "narHash": "sha256-WO/qeIgw7nvRDYeM21Iuwb5HUGttVPMOXj69Ghfmlj4=",
+        "narHash": "sha256-0E7FePwBhT5QqRGa29m4OnNhXgsEaSwbEXwkh+kgsx8=",
         "owner": "lost-rob0t",
         "repo": "star-cl",
         "rev": "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa",

--- a/source/frontends/http-api.lisp
+++ b/source/frontends/http-api.lisp
@@ -166,10 +166,11 @@
       #'(lambda (params)
           (set-default-headers)
           (let* ((actor (cdr (assoc :actor params :test #'string=)))
-                 (body (jsown:parse
-                        (babel:octets-to-string
-                         (lack.request:request-content (ningle:context :request))
-                         :encoding :utf-8))))
+                 (body (jsown:with-injective-reader
+                         (jsown:parse
+                          (babel:octets-to-string
+                           (lack.request:request-content (ningle:context :request))
+                           :encoding :utf-8)))))
             (assert (and actor (stringp actor) (> (length actor) 0)) (actor)
                     "URL is missing :actor")
             (setf (jsown:val body "dtype") "target")
@@ -198,7 +199,8 @@
       #'(lambda (params)
           (set-default-headers)
           (let* ((dtype  (cdr (assoc :dtype params :test #'string=)))
-                 (body (jsown:parse (babel:octets-to-string  (lack.request:request-content (ningle:context :request)) :encoding :utf-8)))
+                 (body (jsown:with-injective-reader
+                         (jsown:parse (babel:octets-to-string  (lack.request:request-content (ningle:context :request)) :encoding :utf-8))))
                  (routing-key (format nil star.rabbit:+ingest-fmt-key+ dtype)))
             (log:info "POST /new/document/:dtype - dtype: ~a routing-key: ~a" dtype routing-key)
             (log:debug "Document body length: ~a" (length body))
@@ -225,7 +227,8 @@
           (set-default-headers)
           (handler-case
               (let* ((body-str (babel:octets-to-string (lack.request:request-content (ningle:context :request)) :encoding :utf-8))
-                     (documents (jsown:parse body-str)))
+                     (documents (jsown:with-injective-reader
+                                  (jsown:parse body-str))))
                 (log:info "POST /bulk - received request")
                 (cond
                   ((not (listp documents))

--- a/source/frontends/http-boundary-core.lisp
+++ b/source/frontends/http-boundary-core.lisp
@@ -136,8 +136,13 @@
       (let ((text (babel:octets-to-string octets :encoding :utf-8)))
         ;; Validate with the packaged standards-oriented parser, then retain
         ;; JSOWN as the service's existing internal document representation.
+        ;; The injective reader binds jsown's parsed-value slots so JSON
+        ;; false/null survive the internal representation and every later
+        ;; jsown:to-json re-serialization (wire, validation, CouchDB) emits
+        ;; the original literals instead of conflating them with [] / null.
         (yason:parse text)
-        (jsown:parse text))
+        (jsown:with-injective-reader
+          (jsown:parse text)))
     (error ()
       (signal-http-input-error
        400


### PR DESCRIPTION
## Problem

Canonical v0.9 ingest rejected schema-valid documents carrying JSON `false` values (e.g. `handling.pii: false`) with:

```
$.handling.pii: expected boolean, got array
```

## Root cause

jsown's default reader parses JSON `false` and `null` to CL `nil`, and `jsown:to-json` serializes `nil` as `[]`. Documents were therefore re-serialized as arrays before validation, publishing, and persistence.

## Fix

Wrap every document-body parse in `jsown:with-injective-reader` (`:true`/`:false`/`:null` keywords round-trip losslessly):

- `http-boundary-core.lisp` `parse-json-octets` (canonical boundary routes)
- `http-api.lisp` legacy `/new/document`, `/documents/bulk`, `/new/target` routes

Representations and accessors are unchanged; the keywords serialize back to the original literals through validation, RabbitMQ wire bodies, and CouchDB persistence.

## Verification

- All unit suites green: 20 suites, 184 tests
- End-to-end: a real corpus document with `handling.pii: false` accepted by `POST /documents/bulk` and stored in CouchDB with boolean `false`
- flake.lock updated: star-cl input NAR hash moved upstream

## Known follow-up

The outbox event fan-out path (`publish-outbox-event` -> `public-document-copy`) still re-serializes via jsown objects parsed elsewhere; documents at rest and on the canonical wire are correct, event bodies may still conflate false/null in rare legacy paths. Full jsown-to-jzon migration is the durable fix.